### PR TITLE
feat: Book · Favorite 기능 추가 및 통합 테스트 통과

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 
 	// SWAGGER
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kw/readwith/domain/Book.java
+++ b/src/main/java/com/kw/readwith/domain/Book.java
@@ -3,6 +3,7 @@ package com.kw.readwith.domain;
 import com.kw.readwith.domain.common.BaseEntity;
 import com.kw.readwith.domain.mapping.ChapterRelationshipEdge;
 import com.kw.readwith.domain.mapping.UserReadState;
+import com.kw.readwith.domain.mapping.Favorite;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -52,4 +53,7 @@ public class Book extends BaseEntity {
 
     @OneToMany(mappedBy = "book", cascade = CascadeType.ALL)
     private List<UserReadState> readStates = new ArrayList<>();
+
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL)
+    private List<Favorite> favorites = new ArrayList<>();
 }

--- a/src/main/java/com/kw/readwith/domain/User.java
+++ b/src/main/java/com/kw/readwith/domain/User.java
@@ -3,6 +3,7 @@ package com.kw.readwith.domain;
 import com.kw.readwith.domain.common.BaseEntity;
 import com.kw.readwith.domain.enums.Provider;
 import com.kw.readwith.domain.mapping.UserReadState;
+import com.kw.readwith.domain.mapping.Favorite;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -46,4 +47,7 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserReadState> readStates = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Favorite> favorites = new ArrayList<>();
 }

--- a/src/main/java/com/kw/readwith/domain/mapping/Favorite.java
+++ b/src/main/java/com/kw/readwith/domain/mapping/Favorite.java
@@ -1,0 +1,29 @@
+package com.kw.readwith.domain.mapping;
+
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.User;
+import com.kw.readwith.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+/* ─────────────── Favorite (즐겨찾기) ────────────────────────── */
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"user_id","book_id"}))
+public class Favorite extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Book book;
+} 

--- a/src/main/java/com/kw/readwith/dto/book/BookDetailDTO.java
+++ b/src/main/java/com/kw/readwith/dto/book/BookDetailDTO.java
@@ -1,0 +1,17 @@
+package com.kw.readwith.dto.book;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BookDetailDTO {
+    private Long id;
+    private String title;
+    private String author;
+    private String language;
+    private boolean isDefault;
+    private String coverImgUrl;
+    private String epubPath;
+    private boolean isFavorite;
+} 

--- a/src/main/java/com/kw/readwith/dto/book/BookSummaryDTO.java
+++ b/src/main/java/com/kw/readwith/dto/book/BookSummaryDTO.java
@@ -1,0 +1,18 @@
+package com.kw.readwith.dto.book;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class BookSummaryDTO {
+    private Long id;
+    private String title;
+    private String author;
+    private String coverImgUrl;
+    private boolean isFavorite;
+    private boolean isDefault;
+    private LocalDateTime updatedAt;
+} 

--- a/src/main/java/com/kw/readwith/repository/FavoriteRepository.java
+++ b/src/main/java/com/kw/readwith/repository/FavoriteRepository.java
@@ -1,0 +1,12 @@
+package com.kw.readwith.repository;
+
+import com.kw.readwith.domain.mapping.Favorite;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+    // 필요시 커스텀 쿼리 메소드 추가
+    List<Favorite> findByUserId(Long userId);
+    Favorite findByUserIdAndBookId(Long userId, Long bookId);
+} 

--- a/src/main/java/com/kw/readwith/service/BookService.java
+++ b/src/main/java/com/kw/readwith/service/BookService.java
@@ -1,0 +1,144 @@
+package com.kw.readwith.service;
+
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.dto.book.BookDetailDTO;
+import com.kw.readwith.dto.book.BookSummaryDTO;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.FavoriteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BookService {
+
+    private final BookRepository bookRepository;
+    private final FavoriteRepository favoriteRepository;
+
+    /**
+     * 도서 목록 조회 (검색/필터/정렬/즐겨찾기)
+     */
+    public List<BookSummaryDTO> getBooks(String keyword,
+                                         String language,
+                                         Boolean favoriteOnly,
+                                         String sortBy,
+                                         Long userId) {
+        List<Book> books = bookRepository.findAll();
+
+        // 검색
+        if (keyword != null && !keyword.isBlank()) {
+            String lower = keyword.toLowerCase();
+            books = books.stream()
+                    .filter(b -> b.getTitle().toLowerCase().contains(lower) || b.getAuthor().toLowerCase().contains(lower))
+                    .collect(Collectors.toList());
+        }
+
+        // 언어 필터
+        if (language != null && !language.isBlank()) {
+            books = books.stream()
+                    .filter(b -> language.equalsIgnoreCase(b.getLanguage()))
+                    .collect(Collectors.toList());
+        }
+
+        // 즐겨찾기 필터
+        final Set<Long> favoriteBookIds;
+        if (userId != null) {
+            favoriteBookIds = favoriteRepository.findByUserId(userId).stream()
+                    .map(fav -> fav.getBook().getId())
+                    .collect(Collectors.toSet());
+        } else {
+            favoriteBookIds = Set.of();
+        }
+
+        if (favoriteOnly != null && favoriteOnly) {
+            books = books.stream()
+                    .filter(b -> favoriteBookIds.contains(b.getId()))
+                    .collect(Collectors.toList());
+        }
+
+        // 정렬 (updatedAt, title)
+        books.sort((a, b) -> {
+            if ("title".equalsIgnoreCase(sortBy)) {
+                return a.getTitle().compareToIgnoreCase(b.getTitle());
+            }
+            // default updatedAt desc
+            return b.getUpdatedAt().compareTo(a.getUpdatedAt());
+        });
+
+        return books.stream()
+                .map(book -> BookSummaryDTO.builder()
+                        .id(book.getId())
+                        .title(book.getTitle())
+                        .author(book.getAuthor())
+                        .coverImgUrl(book.getCoverImgUrl())
+                        .isDefault(book.isDefault())
+                        .isFavorite(favoriteBookIds.contains(book.getId()))
+                        .updatedAt(book.getUpdatedAt())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 단일 도서 조회
+     */
+    public BookDetailDTO getBook(Long bookId, Long userId) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+
+        boolean isFavorite = false;
+        if (userId != null) {
+            isFavorite = favoriteRepository.findByUserId(userId).stream()
+                    .anyMatch(fav -> fav.getBook().getId().equals(bookId));
+        }
+        return convertToDetailDTO(book, isFavorite);
+    }
+
+    /**
+     * 도서 업로드 (EPUB 파일 S3 업로드 후 Book 레코드 저장)
+     * 실제 S3 업로드 로직은 구현되어 있지 않고, 파일명을 그대로 epubPath 로 저장합니다.
+     */
+    @Transactional
+    public BookDetailDTO uploadBook(Long uploaderUserId,
+                                    MultipartFile epubFile,
+                                    String title,
+                                    String author,
+                                    String language) {
+        // TODO: S3 업로드 구현. 현재는 파일명만 저장.
+        String epubPath = epubFile != null ? epubFile.getOriginalFilename() : null;
+
+        Book book = Book.builder()
+                .title(title)
+                .author(author)
+                .language(language)
+                .isDefault(false)
+                .coverImgUrl(null)
+                .epubPath(epubPath)
+                .uploadedBy(null) // TODO: uploaderUserId 로 사용자 매핑
+                .build();
+
+        Book saved = bookRepository.save(book);
+        return convertToDetailDTO(saved, false);
+    }
+
+    private BookDetailDTO convertToDetailDTO(Book book, boolean isFavorite) {
+        return BookDetailDTO.builder()
+                .id(book.getId())
+                .title(book.getTitle())
+                .author(book.getAuthor())
+                .language(book.getLanguage())
+                .isDefault(book.isDefault())
+                .coverImgUrl(book.getCoverImgUrl())
+                .epubPath(book.getEpubPath())
+                .isFavorite(isFavorite)
+                .build();
+    }
+} 

--- a/src/main/java/com/kw/readwith/service/FavoriteService.java
+++ b/src/main/java/com/kw/readwith/service/FavoriteService.java
@@ -1,0 +1,71 @@
+package com.kw.readwith.service;
+
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.User;
+import com.kw.readwith.domain.mapping.Favorite;
+import com.kw.readwith.dto.book.BookSummaryDTO;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.FavoriteRepository;
+import com.kw.readwith.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final UserRepository userRepository;
+    private final BookRepository bookRepository;
+
+    // 즐겨찾기 추가
+    @Transactional
+    public void addFavorite(Long userId, Long bookId) {
+        Favorite existing = favoriteRepository.findByUserIdAndBookId(userId, bookId);
+        if (existing != null) return; // 이미 존재
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+
+        Favorite favorite = Favorite.builder()
+                .user(user)
+                .book(book)
+                .build();
+        favoriteRepository.save(favorite);
+    }
+
+    // 즐겨찾기 삭제
+    @Transactional
+    public void removeFavorite(Long userId, Long bookId) {
+        Favorite favorite = favoriteRepository.findByUserIdAndBookId(userId, bookId);
+        if (favorite != null) {
+            favoriteRepository.delete(favorite);
+        }
+    }
+
+    // 즐겨찾기 목록 조회
+    public List<BookSummaryDTO> getFavoriteBooks(Long userId) {
+        List<Favorite> favorites = favoriteRepository.findByUserId(userId);
+        return favorites.stream()
+                .map(Favorite::getBook)
+                .map(book -> BookSummaryDTO.builder()
+                        .id(book.getId())
+                        .title(book.getTitle())
+                        .author(book.getAuthor())
+                        .coverImgUrl(book.getCoverImgUrl())
+                        .isDefault(book.isDefault())
+                        .isFavorite(true)
+                        .updatedAt(book.getUpdatedAt())
+                        .build())
+                .collect(Collectors.toList());
+    }
+} 

--- a/src/main/java/com/kw/readwith/web/controller/BookController.java
+++ b/src/main/java/com/kw/readwith/web/controller/BookController.java
@@ -1,0 +1,58 @@
+package com.kw.readwith.web.controller;
+
+import com.kw.readwith.dto.book.BookDetailDTO;
+import com.kw.readwith.dto.book.BookSummaryDTO;
+import com.kw.readwith.service.BookService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/api/books")
+@RequiredArgsConstructor
+@Tag(name = "Books", description = "도서 관련 API")
+public class BookController {
+
+    private final BookService bookService;
+
+    // 도서 목록 조회
+    @GetMapping
+    @Operation(summary = "도서 목록 조회", description = "검색/필터/정렬 파라미터를 이용해 도서 목록을 반환합니다.")
+    public ResponseEntity<List<BookSummaryDTO>> getBooks(
+            @RequestParam(required = false) String q,
+            @RequestParam(required = false) String language,
+            @RequestParam(defaultValue = "updatedAt") String sort,
+            @RequestParam(required = false) Boolean favorite
+    ) {
+        Long userId = 1L; // TODO 인증된 사용자
+        List<BookSummaryDTO> response = bookService.getBooks(q, language, favorite, sort, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 단일 도서 조회
+    @GetMapping("/{bookId}")
+    @Operation(summary = "단일 도서 조회", description = "도서 ID로 단일 도서를 조회합니다.")
+    public ResponseEntity<BookDetailDTO> getBook(@PathVariable Long bookId) {
+        Long userId = 1L; // TODO 인증된 사용자
+        BookDetailDTO response = bookService.getBook(bookId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 도서 업로드
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "도서 업로드", description = "EPUB 파일을 업로드하여 도서를 등록합니다.")
+    public ResponseEntity<BookDetailDTO> uploadBook(@RequestPart("file") MultipartFile file,
+                                                    @RequestPart("title") String title,
+                                                    @RequestPart("author") String author,
+                                                    @RequestPart("language") String language) {
+        Long userId = 1L; // TODO 인증된 사용자
+        BookDetailDTO response = bookService.uploadBook(userId, file, title, author, language);
+        return ResponseEntity.ok(response);
+    }
+} 

--- a/src/main/java/com/kw/readwith/web/controller/FavoriteController.java
+++ b/src/main/java/com/kw/readwith/web/controller/FavoriteController.java
@@ -1,0 +1,47 @@
+package com.kw.readwith.web.controller;
+
+import com.kw.readwith.dto.book.BookSummaryDTO;
+import com.kw.readwith.service.FavoriteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/api/favorites")
+@RequiredArgsConstructor
+@Tag(name = "Favorites", description = "즐겨찾기 관련 API")
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    // 즐겨찾기 추가
+    @PostMapping("/{bookId}")
+    @Operation(summary = "즐겨찾기 추가", description = "도서를 즐겨찾기 목록에 추가합니다.")
+    public ResponseEntity<Void> addFavorite(@PathVariable Long bookId) {
+        Long userId = 1L; // TODO 인증된 사용자
+        favoriteService.addFavorite(userId, bookId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 즐겨찾기 삭제
+    @DeleteMapping("/{bookId}")
+    @Operation(summary = "즐겨찾기 삭제", description = "즐겨찾기 목록에서 도서를 제거합니다.")
+    public ResponseEntity<Void> removeFavorite(@PathVariable Long bookId) {
+        Long userId = 1L; // TODO 인증된 사용자
+        favoriteService.removeFavorite(userId, bookId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 즐겨찾기 목록 조회
+    @GetMapping
+    @Operation(summary = "즐겨찾기 목록 조회", description = "사용자의 즐겨찾기 도서 목록을 조회합니다.")
+    public ResponseEntity<List<BookSummaryDTO>> getFavorites() {
+        Long userId = 1L; // TODO 인증된 사용자
+        List<BookSummaryDTO> response = favoriteService.getFavoriteBooks(userId);
+        return ResponseEntity.ok(response);
+    }
+} 

--- a/src/test/java/com/kw/readwith/controller/BookControllerTest.java
+++ b/src/test/java/com/kw/readwith/controller/BookControllerTest.java
@@ -1,0 +1,72 @@
+package com.kw.readwith.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kw.readwith.dto.book.BookDetailDTO;
+import com.kw.readwith.dto.book.BookSummaryDTO;
+import com.kw.readwith.repository.BookRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class BookControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    private Long existingBookId;
+
+    @BeforeEach
+    void setUp() {
+        existingBookId = bookRepository.findAll().get(0).getId();
+    }
+
+    @Test
+    @DisplayName("도서 목록 조회 API가 200과 결과 리스트를 반환한다")
+    void getBooks_returnsList() throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/books")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String responseJson = result.getResponse().getContentAsString();
+        List<BookSummaryDTO> list = objectMapper.readValue(responseJson, new TypeReference<>() {});
+        assertThat(list).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("단일 도서 조회 API가 200과 상세 정보를 반환한다")
+    void getBook_returnsDetail() throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/books/" + existingBookId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String responseJson = result.getResponse().getContentAsString();
+        BookDetailDTO dto = objectMapper.readValue(responseJson, BookDetailDTO.class);
+        assertThat(dto.getId()).isEqualTo(existingBookId);
+        assertThat(dto.getTitle()).isNotBlank();
+    }
+} 

--- a/src/test/java/com/kw/readwith/controller/FavoriteControllerTest.java
+++ b/src/test/java/com/kw/readwith/controller/FavoriteControllerTest.java
@@ -1,0 +1,72 @@
+package com.kw.readwith.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kw.readwith.dto.book.BookSummaryDTO;
+import com.kw.readwith.repository.BookRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class FavoriteControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    private Long existingBookId;
+
+    @BeforeEach
+    void setUp() {
+        existingBookId = bookRepository.findAll().get(0).getId();
+    }
+
+    @Test
+    @DisplayName("즐겨찾기 추가/조회/삭제 플로우가 정상 동작한다")
+    void favorite_flow() throws Exception {
+        // 1. 즐겨찾기 추가
+        mockMvc.perform(post("/api/favorites/" + existingBookId))
+                .andExpect(status().isOk());
+
+        // 2. 즐겨찾기 목록 조회 – 추가된 책 포함
+        MvcResult listResult = mockMvc.perform(get("/api/favorites")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        List<BookSummaryDTO> list = objectMapper.readValue(listResult.getResponse().getContentAsString(), new TypeReference<>() {});
+        assertThat(list).extracting(BookSummaryDTO::getId).contains(existingBookId);
+
+        // 3. 즐겨찾기 삭제
+        mockMvc.perform(delete("/api/favorites/" + existingBookId))
+                .andExpect(status().isNoContent());
+
+        // 4. 목록 조회 시 비어 있음
+        MvcResult listResult2 = mockMvc.perform(get("/api/favorites")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        List<BookSummaryDTO> list2 = objectMapper.readValue(listResult2.getResponse().getContentAsString(), new TypeReference<>() {});
+        assertThat(list2).extracting(BookSummaryDTO::getId).doesNotContain(existingBookId);
+    }
+} 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MYSQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  sql:
+    init:
+      mode: never 


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- 도서(Book) API – 목록 조회, 단일 조회, EPUB 업로드 기능 구현
- 즐겨찾기(Favorite) API – 즐겨찾기 추가·삭제·목록 조회 기능 구현
- Swagger 문서 주석 추가(Books, Favorites)
- 통합 테스트(도서·즐겨찾기) 작성, H2 인메모리 DB로 모든 테스트 Green
- Gradle·테스트 환경 설정(H2 의존성, application-test.yml)

## 📋 변경 사항
- Favorite 엔티티 및 Repository 생성, User·Book 엔티티에 연관관계 필드 추가
- DTO 두 종(BookSummaryDTO, BookDetailDTO) 생성
- BookService, FavoriteService 비즈니스 로직 추가
- BookController, FavoriteController REST 엔드포인트 구현
- Swagger 주석(@Tag, @Operation) 반영
- 통합 테스트 클래스 두 종 추가(MockMvc)
- build.gradle: H2 의존성, test profile 설정

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

- Code Review 확인 사항
- 트랜잭션 범위(@Transactional) 적절성
- Favorite 중복 삽입 방지(Unique 제약 + 중복 체크)
- BookService in-memory 필터 로직 → 향후 QueryDSL 적용 여부
- 테스트 환경(H2)과 운영 DB(MySQL) 스키마 호환성
- 남은 TODO: S3 업로드 로직, 인증(userId 하드코딩) 제거


## 📸 ScreenShot
