### PR TITLE
feat: 도서 업로드 API의 S3 업로드 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### API SPEC ###
+API_SPEC_READWITH.txt

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ dependencies {
 	// SWAGGER
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	testImplementation 'com.h2database:h2'
+
+	// S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.681'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kw/readwith/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/kw/readwith/aws/s3/AmazonS3Manager.java
@@ -1,0 +1,91 @@
+package com.kw.readwith.aws.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.kw.readwith.config.AmazonConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AmazonS3Manager{
+
+    private final AmazonS3 amazonS3;
+
+    private final AmazonConfig amazonConfig;
+
+    public String uploadFile(String keyName, MultipartFile file){
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+        try {
+            amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata)
+                    );
+        }catch (IOException e){
+            log.error("error at AmazonS3Manager uploadFile : {}", (Object) e.getStackTrace());
+        }
+
+        return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+    }
+
+    public String uploadFileFromBase64(String keyName, String base64Data, String contentType){
+        // 디코딩 전 모든 공백 문자 제거
+        base64Data = base64Data.replaceAll("\\s+", "");
+        // Base64 디코딩
+        byte[] fileContent = Base64.getDecoder().decode(base64Data);
+
+        // Base64를 MultipartFile 객체로 변환
+        // contentType("image/png") 등 실제 타입에 맞춰서 설정
+        MultipartFile multipartFile =
+                new Base64ToMultipartFile(fileContent, keyName, contentType);
+
+        // uploadFile() 호출
+        return uploadFile(keyName, multipartFile);
+    }
+
+    public String uploadOriginal(String title, MultipartFile file){
+        String slug = slugify(title);
+        String ext = getExtension(file.getOriginalFilename());
+        String keyName = amazonConfig.getOriginal()+"/"+slug+ext;
+        return uploadFile(keyName, file);
+    }
+
+    public String uploadMetadata(String title, MultipartFile file){
+        String slug = slugify(title);
+        String uniqueName = generateUniqueFileName(file.getOriginalFilename());
+        String keyName = amazonConfig.getMetadata()+"/"+slug+"/"+uniqueName;
+        return uploadFile(keyName, file);
+    }
+
+    private String slugify(String input){
+        String slug = input.toLowerCase()
+                .replaceAll("[^a-z0-9]+", "-")
+                .replaceAll("^-|-$", "");
+        return slug.length() > 0 ? slug : UUID.randomUUID().toString();
+    }
+
+    private String getExtension(String filename){
+        int idx = filename.lastIndexOf('.');
+        if(idx > -1){
+            return filename.substring(idx);
+        }
+        return "";
+    }
+
+    private String generateUniqueFileName(String originalFilename){
+        String ext = "";
+        int idx = originalFilename.lastIndexOf('.');
+        if(idx > -1){
+            ext = originalFilename.substring(idx);
+        }
+        return UUID.randomUUID().toString()+ext;
+    }
+}

--- a/src/main/java/com/kw/readwith/aws/s3/Base64ToMultipartFile.java
+++ b/src/main/java/com/kw/readwith/aws/s3/Base64ToMultipartFile.java
@@ -1,0 +1,63 @@
+package com.kw.readwith.aws.s3;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class Base64ToMultipartFile implements MultipartFile {
+
+    private final byte[] fileContent;
+    private final String originalFilename;
+    private final String contentType;
+
+    public Base64ToMultipartFile(byte[] fileContent,
+                                 String originalFilename,
+                                 String contentType) {
+        this.fileContent = fileContent;
+        this.originalFilename = originalFilename;
+        this.contentType = contentType;
+    }
+
+    @Override
+    public String getName() {
+        // 업로드 시 필드명
+        return originalFilename;
+    }
+
+    @Override
+    public String getOriginalFilename() {
+        return this.originalFilename;
+    }
+
+    @Override
+    public String getContentType() {
+        return this.contentType;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return fileContent == null || fileContent.length == 0;
+    }
+
+    @Override
+    public long getSize() {
+        return fileContent.length;
+    }
+
+    @Override
+    public byte[] getBytes() throws IOException {
+        return fileContent;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return new ByteArrayInputStream(fileContent);
+    }
+
+    @Override
+    public void transferTo(java.io.File dest) throws IOException, IllegalStateException {
+        throw new UnsupportedOperationException("지원하지 않음. 서버 문의");
+    }
+}

--- a/src/main/java/com/kw/readwith/config/AmazonConfig.java
+++ b/src/main/java/com/kw/readwith/config/AmazonConfig.java
@@ -1,0 +1,58 @@
+package com.kw.readwith.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class AmazonConfig {
+
+
+    private AWSCredentials awsCredentials;
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.path.original}")
+    private String original;
+
+    @Value("${cloud.aws.path.metadata}")
+    private String metadata;
+
+    @PostConstruct
+    public void init() {
+        this.awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+    }
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+
+    @Bean
+    public AWSCredentialsProvider awsCredentialsProvider() {
+        return new AWSStaticCredentialsProvider(awsCredentials);
+    }
+}

--- a/src/main/java/com/kw/readwith/config/DataLoader.java
+++ b/src/main/java/com/kw/readwith/config/DataLoader.java
@@ -37,6 +37,7 @@ public class DataLoader implements CommandLineRunner {
         // 기본 제공 책들 생성 (모든 사용자가 접근 가능)
         Book book1 = Book.builder()
                 .title("해리포터와 마법사의 돌")
+                .infoUploaded(true)
                 .author("J.K. 롤링")
                 .language("ko")
                 .isDefault(true)
@@ -46,6 +47,7 @@ public class DataLoader implements CommandLineRunner {
 
         Book book2 = Book.builder()
                 .title("반지의 제왕")
+                .infoUploaded(true)
                 .author("J.R.R. 톨킨")
                 .language("ko")
                 .isDefault(true)
@@ -56,6 +58,7 @@ public class DataLoader implements CommandLineRunner {
         // 사용자별 책 생성 (해당 사용자만 접근 가능)
         Book book3 = Book.builder()
                 .title("개인 도서관 - 1984")
+                .infoUploaded(false)
                 .author("조지 오웰")
                 .language("ko")
                 .isDefault(false)
@@ -65,6 +68,7 @@ public class DataLoader implements CommandLineRunner {
 
         Book book4 = Book.builder()
                 .title("개인 도서관 - 동물농장")
+                .infoUploaded(false)
                 .author("조지 오웰")
                 .language("ko")
                 .isDefault(false)

--- a/src/main/java/com/kw/readwith/domain/Book.java
+++ b/src/main/java/com/kw/readwith/domain/Book.java
@@ -25,8 +25,8 @@ public class Book extends BaseEntity {
     @Column(length = 120, nullable = false)
     private String author;
 
-    @Column(length = 2, nullable = false)
-    private String language;   // ISO-639-1
+    @Column(length = 10, nullable = false)
+    private String language;   // ISO-639 code (e.g., "ko", "en", "en-US")
 
     @Column(nullable = false)
     private boolean isDefault;
@@ -36,6 +36,11 @@ public class Book extends BaseEntity {
 
     @Column(name = "epub_path", length = 255)
     private String epubPath;
+
+    // 분석 정보(관계정보·통계 등)가 업로드되었는지 여부
+    @Column(name = "info_uploaded", nullable = false)
+    @Builder.Default
+    private boolean infoUploaded = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "uploaded_by_user_id")

--- a/src/main/java/com/kw/readwith/repository/BookRepository.java
+++ b/src/main/java/com/kw/readwith/repository/BookRepository.java
@@ -2,8 +2,10 @@ package com.kw.readwith.repository;
 
 import com.kw.readwith.domain.Book;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
+    List<Book> findByInfoUploadedTrue();
 } 

--- a/src/main/java/com/kw/readwith/service/BookService.java
+++ b/src/main/java/com/kw/readwith/service/BookService.java
@@ -7,6 +7,9 @@ import com.kw.readwith.dto.book.BookDetailDTO;
 import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.repository.BookRepository;
 import com.kw.readwith.repository.FavoriteRepository;
+import com.kw.readwith.repository.UserRepository;
+import com.kw.readwith.domain.User;
+import com.kw.readwith.aws.s3.AmazonS3Manager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +26,8 @@ public class BookService {
 
     private final BookRepository bookRepository;
     private final FavoriteRepository favoriteRepository;
+    private final UserRepository userRepository;
+    private final AmazonS3Manager amazonS3Manager;
 
     /**
      * 도서 목록 조회 (검색/필터/정렬/즐겨찾기)
@@ -32,7 +37,9 @@ public class BookService {
                                          Boolean favoriteOnly,
                                          String sortBy,
                                          Long userId) {
-        List<Book> books = bookRepository.findAll();
+        List<Book> books = bookRepository.findAll().stream()
+                .filter(b -> b.isInfoUploaded() || b.isDefault())
+                .collect(Collectors.toList());
 
         // 검색
         if (keyword != null && !keyword.isBlank()) {
@@ -92,6 +99,7 @@ public class BookService {
      */
     public BookDetailDTO getBook(Long bookId, Long userId) {
         Book book = bookRepository.findById(bookId)
+                .filter(b -> b.isInfoUploaded() || b.isDefault())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
         boolean isFavorite = false;
@@ -104,16 +112,21 @@ public class BookService {
 
     /**
      * 도서 업로드 (EPUB 파일 S3 업로드 후 Book 레코드 저장)
-     * 실제 S3 업로드 로직은 구현되어 있지 않고, 파일명을 그대로 epubPath 로 저장합니다.
      */
     @Transactional
-    public BookDetailDTO uploadBook(Long uploaderUserId,
+    public BookDetailDTO uploadBook(Long userId,
                                     MultipartFile epubFile,
                                     String title,
                                     String author,
                                     String language) {
-        // TODO: S3 업로드 구현. 현재는 파일명만 저장.
-        String epubPath = epubFile != null ? epubFile.getOriginalFilename() : null;
+        if(epubFile == null || epubFile.isEmpty()){
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+        // 업로더 유저 조회
+        User uploader = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        // S3 original 폴더에 EPUB 업로드
+        String epubUrl = amazonS3Manager.uploadOriginal(title, epubFile);
 
         Book book = Book.builder()
                 .title(title)
@@ -121,8 +134,9 @@ public class BookService {
                 .language(language)
                 .isDefault(false)
                 .coverImgUrl(null)
-                .epubPath(epubPath)
-                .uploadedBy(null) // TODO: uploaderUserId 로 사용자 매핑
+                .epubPath(epubUrl)
+                .infoUploaded(false)
+                .uploadedBy(uploader)
                 .build();
 
         Book saved = bookRepository.save(book);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,3 +27,17 @@ spring:
     multipart:
       max-file-size: 20MB
       max-request-size: 20MB
+cloud:
+  aws:
+    s3:
+      bucket: readwith-s3-bucket
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    credentials:
+      accessKey: ${AWS_ACCESS_KEY_ID}
+      secretKey: ${AWS_SECRET_ACCESS_KEY}
+    path:
+      original: original
+      metadata: metadata


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
백엔드 서버가 직접 S3 original/{slug}.epub 경로로 업로드한다.
프론트엔드는 해당 url을 통해, original epub.js 파일에 대한 다운로드가 가능하도록 한다.

## 📋 변경 사항
- S3 관련 의존성 추가
- AmazonConfig, AmazonS3Manager 구현(업로드전 전처리 및 설정 전담)
- Book Domain에 infoUploaded 필드 추가(책만 업로드되고, 분석 정보는 업데이트 되지 않음을 추적하기 위함)
- 도서 목록 조회에서 ALL이 아닌, 분석이 완료된 (사용자가 업로드 or 서버 업로드) 도서만 조회하도록 수정.
- AWS_ACCESS_KEY_ID와 AWS_SECRET_ACCESS_KEY를 환경변수로 application.yml에서 주입
- S3 버킷 정책 수정 (Action: s3:PutObject 퍼블릭 허용 제거, GetObject 만 퍼블릭 허용(기존 다운로드 URL 계속 사용 가능))

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
