### PR TITLE
feat: 관계 정보 업로드 api 구현

### DIFF
--- a/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
@@ -44,7 +44,10 @@ public enum ErrorStatus implements BaseErrorCode {
     JSON_PARSING_ERROR(HttpStatus.BAD_REQUEST, "ADMIN4005", "JSON 파일 파싱에 실패했습니다."),
     BOOK_CHARACTER_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN4006", "해당 책에 등록된 인물이 아닙니다."),
     CHAPTER_NOT_BELONG_TO_BOOK(HttpStatus.BAD_REQUEST, "ADMIN4007", "해당 책에 속한 챕터가 아닙니다."),
-    EVENT_DATA_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ADMIN4008", "해당 챕터의 이벤트 데이터가 이미 존재합니다."); // [추가]
+    EVENT_DATA_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ADMIN4008", "해당 챕터의 이벤트 데이터가 이미 존재합니다."),
+    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN4009", "해당 이벤트를 찾을 수 없습니다."),
+    RELATIONSHIP_DATA_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ADMIN4010", "해당 이벤트의 관계 데이터가 이미 존재합니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/kw/readwith/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/kw/readwith/apiPayload/exception/GeneralException.java
@@ -2,21 +2,45 @@ package com.kw.readwith.apiPayload.exception;
 
 import com.kw.readwith.apiPayload.code.BaseErrorCode;
 import com.kw.readwith.apiPayload.code.ErrorReasonDTO;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class GeneralException extends RuntimeException {
 
-    private BaseErrorCode code;
+    private final BaseErrorCode code;
+    private final String overrideMessage;
+
+    public GeneralException(BaseErrorCode code) {
+        this.code = code;
+        this.overrideMessage = null;
+    }
+
+    public GeneralException(BaseErrorCode code, String overrideMessage) {
+        this.code = code;
+        this.overrideMessage = overrideMessage;
+    }
 
     public ErrorReasonDTO getErrorReason() {
-        return this.code.getReason();
+        if (overrideMessage == null) {
+            return this.code.getReason();
+        }
+        return ErrorReasonDTO.builder()
+                .message(this.overrideMessage)
+                .code(this.code.getReason().getCode())
+                .isSuccess(false)
+                .build();
     }
 
     public ErrorReasonDTO getErrorReasonHttpStatus(){
-        return this.code.getReasonHttpStatus();
+        if (overrideMessage == null) {
+            return this.code.getReasonHttpStatus();
+        }
+        return ErrorReasonDTO.builder()
+                .message(this.overrideMessage)
+                .code(this.code.getReasonHttpStatus().getCode())
+                .isSuccess(false)
+                .httpStatus(this.code.getReasonHttpStatus().getHttpStatus())
+                .build();
     }
 
     public BaseErrorCode getErrorCode() {

--- a/src/main/java/com/kw/readwith/domain/mapping/EventRelationshipEdge.java
+++ b/src/main/java/com/kw/readwith/domain/mapping/EventRelationshipEdge.java
@@ -6,47 +6,45 @@ import com.kw.readwith.domain.common.BaseEntity;
 import com.kw.readwith.domain.enums.SentimentLabel;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
-/* ─────────────── EventRelationshipEdge ────────────────────────── */
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
-@Table(indexes = {
-        @Index(columnList = "event_id, from_char_id, to_char_id", unique = true)
-})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class EventRelationshipEdge extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(nullable = false)
-    private Event event;
-
-    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "from_char_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_char_id")
     private Character fromCharacter;
 
-    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "to_char_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_char_id")
     private Character toCharacter;
 
-    private int interactionCount;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private Event event;
 
-    @Enumerated(EnumType.STRING) @Column(length = 3)
-    private SentimentLabel sentimentLabel;
-
-    private float sentimentScore;
-
-    @JdbcTypeCode(SqlTypes.JSON)             // Hibernate 6
-    @Column(columnDefinition = "json")
-    private String relationTags;
-
-    @Lob @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT")
     private String explanation;
 
-    @Column(length = 7)
+    @Column(columnDefinition = "JSON")
+    private String relationTags;
+
+    private Integer interactionCount;
+
+    private Float sentimentScore;
+
+    @Enumerated(EnumType.STRING)
+    private SentimentLabel sentimentLabel;
+
     private String edgeColorHex;
 
-    private float edgeWidth;
+    @Column(name = "edge_weight")
+    private Float edgeWeight;
 }

--- a/src/main/java/com/kw/readwith/dto/admin/CharacterPovSummaryDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/CharacterPovSummaryDTO.java
@@ -1,4 +1,4 @@
-package com.kw.readwith.dto;
+package com.kw.readwith.dto.admin;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/kw/readwith/dto/admin/RelationshipDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/RelationshipDTO.java
@@ -1,0 +1,17 @@
+package com.kw.readwith.dto.admin;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class RelationshipDTO {
+    private List<String> relation;
+    private Double id1;
+    private Double id2;
+    private Double positivity;
+    private Double weight;
+    private Integer count;
+}

--- a/src/main/java/com/kw/readwith/dto/admin/RelationshipUploadDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/RelationshipUploadDTO.java
@@ -1,0 +1,12 @@
+package com.kw.readwith.dto.admin;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class RelationshipUploadDTO {
+    private List<RelationshipDTO> relations;
+}

--- a/src/main/java/com/kw/readwith/repository/EventRelationshipEdgeRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventRelationshipEdgeRepository.java
@@ -1,0 +1,9 @@
+package com.kw.readwith.repository;
+
+import com.kw.readwith.domain.Event;
+import com.kw.readwith.domain.mapping.EventRelationshipEdge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRelationshipEdgeRepository extends JpaRepository<EventRelationshipEdge, Long> {
+    boolean existsByEvent(Event event);
+}

--- a/src/main/java/com/kw/readwith/repository/EventRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventRepository.java
@@ -5,8 +5,13 @@ import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface EventRepository extends JpaRepository<Event, Long> {
 
-    // Book과 Chapter를 기준으로 데이터 존재 여부를 확인.
     boolean existsByBookAndChapter(Book book, Chapter chapter);
+    Optional<Event> findByChapterAndIdx(Chapter chapter, Integer idx);
+
+    // [FIX] Book, Chapter, idx를 모두 사용하여 Event를 찾는 필수 메소드
+    Optional<Event> findByBookAndChapterAndIdx(Book book, Chapter chapter, Integer idx);
 }

--- a/src/main/java/com/kw/readwith/repository/EventRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventRepository.java
@@ -12,6 +12,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     boolean existsByBookAndChapter(Book book, Chapter chapter);
     Optional<Event> findByChapterAndIdx(Chapter chapter, Integer idx);
 
-    // [FIX] Book, Chapter, idx를 모두 사용하여 Event를 찾는 필수 메소드
+    // Event를 찾는 메소드
     Optional<Event> findByBookAndChapterAndIdx(Book book, Chapter chapter, Integer idx);
 }

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -9,7 +9,6 @@ import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.Event;
 import com.kw.readwith.domain.Character;
-import com.kw.readwith.domain.enums.SentimentLabel;
 import com.kw.readwith.domain.mapping.EventRelationshipEdge;
 import com.kw.readwith.dto.admin.CharacterDTO;
 import com.kw.readwith.dto.admin.EventDTO;
@@ -54,6 +53,7 @@ public class AdminService {
 
             List<Character> newCharacters = new ArrayList<>();
             for (CharacterDTO dto : characterListDTO.getCharacters()) {
+                // snake_case 필드에 맞는 getter 호출
                 Optional<Character> existingCharacter = characterRepository.findByBookAndName(book, dto.getCommon_name());
 
                 if (existingCharacter.isEmpty()) {
@@ -70,6 +70,7 @@ public class AdminService {
                 }
             }
 
+            // 데이터베이스에 저장
             if (!newCharacters.isEmpty()) {
                 characterRepository.saveAll(newCharacters);
             }
@@ -84,20 +85,25 @@ public class AdminService {
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
+        // Repository의 기존 메소드에 맞게 book.getId()와 chapterIdx를 전달
         Chapter chapter = chapterRepository.findByBookIdAndIdx(book.getId(), chapterIdx)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
 
+        // 해당 책에 속한 챕터가 맞는지 확인
         if (!chapter.getBook().getId().equals(book.getId())) {
             throw new GeneralException(ErrorStatus.CHAPTER_NOT_BELONG_TO_BOOK);
         }
 
+        // Book과 Chapter를 함께 사용하여 데이터가 이미 존재하는지 확인
         if (eventRepository.existsByBookAndChapter(book, chapter)) {
             throw new GeneralException(ErrorStatus.EVENT_DATA_ALREADY_EXISTS);
         }
 
         try {
+            // JSON 파일을 DTO 리스트로 파싱
             List<EventDTO> eventDTOs = objectMapper.readValue(file.getInputStream(), new TypeReference<List<EventDTO>>() {});
 
+            // DTO를 Entity로 변환
             List<Event> newEvents = eventDTOs.stream()
                     .map(dto -> Event.builder()
                             .startPos(dto.getStart())
@@ -109,6 +115,7 @@ public class AdminService {
                             .build())
                     .collect(Collectors.toList());
 
+            // 데이터베이스에 저장
             if (!newEvents.isEmpty()) {
                 eventRepository.saveAllAndFlush(newEvents);
             }
@@ -129,12 +136,14 @@ public class AdminService {
         Event event = eventRepository.findByBookAndChapterAndIdx(book, chapter, eventIdx)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND));
 
+        // 데이터가 이미 존재하는지 확인
         if (eventRelationshipEdgeRepository.existsByEvent(event)) {
             throw new GeneralException(ErrorStatus.RELATIONSHIP_DATA_ALREADY_EXISTS);
         }
 
         RelationshipUploadDTO uploadDTO;
         try {
+            // JSON 파일을 DTO로 파싱
             uploadDTO = objectMapper.readValue(file.getInputStream(), RelationshipUploadDTO.class);
         } catch (IOException e) {
             throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
@@ -142,12 +151,14 @@ public class AdminService {
 
         List<EventRelationshipEdge> newEdges = new ArrayList<>();
         for (RelationshipDTO dto : uploadDTO.getRelations()) {
+            // DTO에서 Character 찾아오기
             Character fromChar = characterRepository.findByBookAndCharacterId(book, dto.getId1().longValue())
                     .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "From Character not found with jsonId: " + dto.getId1()));
             Character toChar = characterRepository.findByBookAndCharacterId(book, dto.getId2().longValue())
                     .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "To Character not found with jsonId: " + dto.getId2()));
 
             try {
+                // DTO를 Entity로 변환
                 EventRelationshipEdge edge = EventRelationshipEdge.builder()
                         .fromCharacter(fromChar)
                         .toCharacter(toChar)
@@ -156,7 +167,6 @@ public class AdminService {
                         .sentimentScore(dto.getPositivity().floatValue())
                         .interactionCount(dto.getCount())
                         .relationTags(objectMapper.writeValueAsString(dto.getRelation()))
-                        .sentimentLabel(determineSentimentLabel(dto.getPositivity().floatValue()))
                         .build();
                 newEdges.add(edge);
             } catch (JsonProcessingException e) {
@@ -164,18 +174,9 @@ public class AdminService {
             }
         }
 
+        // 데이터베이스에 저장
         if (!newEdges.isEmpty()) {
             eventRelationshipEdgeRepository.saveAll(newEdges);
-        }
-    }
-
-    private SentimentLabel determineSentimentLabel(float score) {
-        if (score > 0.3) {
-            return SentimentLabel.POS;
-        } else if (score < -0.3) {
-            return SentimentLabel.NEG;
-        } else {
-            return SentimentLabel.NEU;
         }
     }
 }

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -1,21 +1,27 @@
 package com.kw.readwith.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Chapter;
-import com.kw.readwith.domain.Character;
 import com.kw.readwith.domain.Event;
+import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.enums.SentimentLabel;
+import com.kw.readwith.domain.mapping.EventRelationshipEdge;
 import com.kw.readwith.dto.admin.CharacterDTO;
 import com.kw.readwith.dto.admin.EventDTO;
-import com.kw.readwith.repository.BookRepository;
-import com.kw.readwith.repository.ChapterRepository;
-import com.kw.readwith.repository.CharacterRepository;
-import com.kw.readwith.repository.EventRepository;
+import com.kw.readwith.dto.admin.RelationshipDTO;
+import com.kw.readwith.dto.admin.RelationshipUploadDTO;
+import com.kw.readwith.repository.*;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -27,15 +33,18 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class AdminService {
+
+    private static final Logger log = LoggerFactory.getLogger(AdminService.class);
 
     private final BookRepository bookRepository;
     private final CharacterRepository characterRepository;
     private final ChapterRepository chapterRepository;
     private final EventRepository eventRepository;
+    private final EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
     private final ObjectMapper objectMapper;
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void uploadCharacters(Long bookId, MultipartFile file) {
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
@@ -45,7 +54,6 @@ public class AdminService {
 
             List<Character> newCharacters = new ArrayList<>();
             for (CharacterDTO dto : characterListDTO.getCharacters()) {
-                // snake_case 필드에 맞는 getter 호출
                 Optional<Character> existingCharacter = characterRepository.findByBookAndName(book, dto.getCommon_name());
 
                 if (existingCharacter.isEmpty()) {
@@ -71,29 +79,25 @@ public class AdminService {
         }
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void uploadEvents(Long bookId, Integer chapterIdx, MultipartFile file) {
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
-        // Repository의 기존 메소드에 맞게 book.getId()와 chapterIdx를 전달
         Chapter chapter = chapterRepository.findByBookIdAndIdx(book.getId(), chapterIdx)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
 
-        // 해당 책에 속한 챕터가 맞는지 확인
         if (!chapter.getBook().getId().equals(book.getId())) {
             throw new GeneralException(ErrorStatus.CHAPTER_NOT_BELONG_TO_BOOK);
         }
 
-        // Book과 Chapter를 함께 사용하여 데이터가 이미 존재하는지 확인
         if (eventRepository.existsByBookAndChapter(book, chapter)) {
             throw new GeneralException(ErrorStatus.EVENT_DATA_ALREADY_EXISTS);
         }
 
         try {
-            // JSON 파일을 DTO 리스트로 파싱
             List<EventDTO> eventDTOs = objectMapper.readValue(file.getInputStream(), new TypeReference<List<EventDTO>>() {});
 
-            // DTO를 Entity로 변환
             List<Event> newEvents = eventDTOs.stream()
                     .map(dto -> Event.builder()
                             .startPos(dto.getStart())
@@ -105,13 +109,73 @@ public class AdminService {
                             .build())
                     .collect(Collectors.toList());
 
-            // 데이터베이스에 저장
             if (!newEvents.isEmpty()) {
-                eventRepository.saveAll(newEvents);
+                eventRepository.saveAllAndFlush(newEvents);
             }
 
         } catch (IOException e) {
             throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.READ_COMMITTED)
+    public void uploadRelationships(Long bookId, Integer chapterIdx, Integer eventIdx, MultipartFile file) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+
+        Chapter chapter = chapterRepository.findByBookIdAndIdx(book.getId(), chapterIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+
+        Event event = eventRepository.findByBookAndChapterAndIdx(book, chapter, eventIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND));
+
+        if (eventRelationshipEdgeRepository.existsByEvent(event)) {
+            throw new GeneralException(ErrorStatus.RELATIONSHIP_DATA_ALREADY_EXISTS);
+        }
+
+        RelationshipUploadDTO uploadDTO;
+        try {
+            uploadDTO = objectMapper.readValue(file.getInputStream(), RelationshipUploadDTO.class);
+        } catch (IOException e) {
+            throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
+        }
+
+        List<EventRelationshipEdge> newEdges = new ArrayList<>();
+        for (RelationshipDTO dto : uploadDTO.getRelations()) {
+            Character fromChar = characterRepository.findByBookAndCharacterId(book, dto.getId1().longValue())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "From Character not found with jsonId: " + dto.getId1()));
+            Character toChar = characterRepository.findByBookAndCharacterId(book, dto.getId2().longValue())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "To Character not found with jsonId: " + dto.getId2()));
+
+            try {
+                EventRelationshipEdge edge = EventRelationshipEdge.builder()
+                        .fromCharacter(fromChar)
+                        .toCharacter(toChar)
+                        .event(event)
+                        .edgeWeight(dto.getWeight().floatValue())
+                        .sentimentScore(dto.getPositivity().floatValue())
+                        .interactionCount(dto.getCount())
+                        .relationTags(objectMapper.writeValueAsString(dto.getRelation()))
+                        .sentimentLabel(determineSentimentLabel(dto.getPositivity().floatValue()))
+                        .build();
+                newEdges.add(edge);
+            } catch (JsonProcessingException e) {
+                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "Failed to process relation tags for characters " + dto.getId1() + " and " + dto.getId2());
+            }
+        }
+
+        if (!newEdges.isEmpty()) {
+            eventRelationshipEdgeRepository.saveAll(newEdges);
+        }
+    }
+
+    private SentimentLabel determineSentimentLabel(float score) {
+        if (score > 0.3) {
+            return SentimentLabel.POS;
+        } else if (score < -0.3) {
+            return SentimentLabel.NEG;
+        } else {
+            return SentimentLabel.NEU;
         }
     }
 }

--- a/src/main/java/com/kw/readwith/service/BookService.java
+++ b/src/main/java/com/kw/readwith/service/BookService.java
@@ -215,8 +215,8 @@ public class BookService {
     }
 
     @Transactional
-    public void uploadChapterSummary(Long bookId, Integer idx, MultipartFile summaryFile) {
-        Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, idx).orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+    public void uploadChapterSummary(Long bookId, Integer chapterIdx, MultipartFile summaryFile) {
+        Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx).orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
         if (chapter.isPovSummariesCached()) {
             throw new GeneralException(ErrorStatus.CHAPTER_ALREADY_SUMMARIZED);
         }

--- a/src/main/java/com/kw/readwith/service/CharacterPovSummaryService.java
+++ b/src/main/java/com/kw/readwith/service/CharacterPovSummaryService.java
@@ -6,7 +6,7 @@ import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.Character;
 import com.kw.readwith.domain.mapping.CharacterPovSummary;
-import com.kw.readwith.dto.CharacterPovSummaryDTO;
+import com.kw.readwith.dto.admin.CharacterPovSummaryDTO;
 import com.kw.readwith.repository.ChapterRepository;
 import com.kw.readwith.repository.CharacterPovSummaryRepository;
 import com.kw.readwith.repository.CharacterRepository;

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -37,13 +37,13 @@ public class AdminController {
     }
 
     @Operation(summary = "챕터 요약본 업로드 API", description = "특정 챕터에 대한 인물별 요약 정보가 담긴 JSON 파일을 업로드합니다.")
-    @PostMapping(value = "/books/{bookId}/chapters/{idx}/summary", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/books/{bookId}/chapters/{chapterIdx}/summary", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadChapterSummary(
             @Parameter(description = "요약본을 추가할 책의 ID") @PathVariable Long bookId,
-            @Parameter(description = "요약본을 추가할 챕터의 순서(index)") @PathVariable Integer idx,
+            @Parameter(description = "요약본을 추가할 챕터의 순서(index)") @PathVariable Integer chapterIdx,
             @Parameter(description = "인물별 요약 정보가 담긴 JSON 파일") @RequestParam("file") MultipartFile file) {
 
-        bookService.uploadChapterSummary(bookId, idx, file);
+        bookService.uploadChapterSummary(bookId, chapterIdx, file);
         return ApiResponse.onSuccess("Chapter summary has been successfully uploaded.");
     }
 

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -66,4 +66,15 @@ public class AdminController {
         adminService.uploadEvents(bookId, chapterIdx, file);
         return ApiResponse.onSuccess("Events uploaded successfully.");
     }
+
+    @Operation(summary = "관계 정보 업로드 API", description = "특정 이벤트에 대한 인물 관계 정보(JSON)를 업로드합니다.")
+    @PostMapping(value = "/books/{bookId}/chapters/{chapterIdx}/events/{eventIdx}/relationships", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<String> uploadRelationships(
+            @Parameter(description = "책 ID") @PathVariable Long bookId,
+            @Parameter(description = "챕터 순서(index)") @PathVariable Integer chapterIdx,
+            @Parameter(description = "이벤트 순서(index)") @PathVariable Integer eventIdx,
+            @Parameter(description = "관계 정보가 담긴 JSON 파일") @RequestParam("file") MultipartFile file) {
+        adminService.uploadRelationships(bookId, chapterIdx, eventIdx, file);
+        return ApiResponse.onSuccess("Relationships uploaded successfully.");
+    }
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
특정 event에 대한 인물 간의 관계 정보를 JSON 파일로 업로드하는 관리자 api를 추가했습니다.

관리자가 특정 책의 챕터 내 사건별로, 인물 간의 관계 정보(관계 점수, 관계 태그 등)를 등록할 수 있는 기능을 제공.

## 📋 변경 사항

🛠️ 신규 API 엔드포인트 추가
- POST /api/admin/books/{bookId}/chapters/{chapterIdx}/events/{eventIdx}/relationships

✨ AdminService 로직
- uploadRelationships 메소드를 구현.
- JSON 파일을 파싱하여 각 관계 데이터를 EventRelationshipEdge 엔티티로 변환.
- sentiment_score는 JSON의 positivity 값을 기반으로 저장하며, sentiment_label은 현재 저장하지 않음.
- 데이터 업로드 전, Book, Chapter, Event의 존재 여부 및 관계 데이터의 중복 여부를 확인하는 유효성 검사 로직을 추가.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
