### PR TITLE
refactor: POV 요약 업로드 api, 캐릭터 조회 버그 수정 및 데이터 처리 정책 변경 (덮어쓰기 → 중복 생성 방지)

### DIFF
--- a/src/main/java/com/kw/readwith/repository/CharacterPovSummaryRepository.java
+++ b/src/main/java/com/kw/readwith/repository/CharacterPovSummaryRepository.java
@@ -1,13 +1,18 @@
 package com.kw.readwith.repository;
 
+import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.mapping.CharacterPovSummary;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List; // 추가
+import java.util.List;
 
 @Repository
 public interface CharacterPovSummaryRepository extends JpaRepository<CharacterPovSummary, Long> {
 
     List<CharacterPovSummary> findByChapterId(Long chapterId);
+
+    boolean existsByChapter(Chapter chapter);
+
+    void deleteByChapter(Chapter chapter);
 }

--- a/src/main/java/com/kw/readwith/service/BookService.java
+++ b/src/main/java/com/kw/readwith/service/BookService.java
@@ -216,30 +216,41 @@ public class BookService {
 
     @Transactional
     public void uploadChapterSummary(Long bookId, Integer chapterIdx, MultipartFile summaryFile) {
-        Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx).orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
-        if (chapter.isPovSummariesCached()) {
+        Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+
+        // 데이터가 이미 존재하는지 먼저 확인
+        if (characterPovSummaryRepository.existsByChapter(chapter)) {
             throw new GeneralException(ErrorStatus.CHAPTER_ALREADY_SUMMARIZED);
         }
+
         Map<String, PovSummaryData> summaries;
         try {
             summaries = objectMapper.readValue(summaryFile.getInputStream(), new TypeReference<>() {});
         } catch (IOException e) {
             throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
         }
-        for (Map.Entry<String, PovSummaryData> entry : summaries.entrySet()) {
+
+        List<CharacterPovSummary> newSummaries = summaries.entrySet().stream().map(entry -> {
             Long characterId = Long.parseLong(entry.getKey());
             PovSummaryData summaryData = entry.getValue();
-            Character character = characterRepository.findById(characterId).orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND));
+            // JSON의 characterId는 book_character 테이블의 character_id 컬럼 값이므로, book과 함께 조회해야 함
+            Character character = characterRepository.findByBookAndCharacterId(chapter.getBook(), characterId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "Character not found with jsonId: " + characterId));
 
-            CharacterPovSummary povSummary = CharacterPovSummary.builder()
+            return CharacterPovSummary.builder()
                     .book(chapter.getBook())
                     .chapter(chapter)
                     .character(character)
                     // summaryData.getSummary()를 호출하여 'summary' 값을 가져옴
                     .summaryText(summaryData.getSummary())
                     .build();
-            characterPovSummaryRepository.save(povSummary);
+        }).collect(Collectors.toList());
+
+        if (!newSummaries.isEmpty()) {
+            characterPovSummaryRepository.saveAll(newSummaries);
         }
+
         chapter.markAsSummarized();
         checkAndUpdateBookSummaryStatus(chapter.getBook());
     }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
관리자 기능 중 POV 요약본 업로드 API (POST /api/admin/books/{bookId}/chapters/{chapterIdx}/summary)의 내부 로직을 개선하고 데이터 처리 정책을 변경함.

## 📋 변경 사항
1. 캐릭터 조회 로직 수정
- 기존 코드에서는 JSON 파일의 character_id(책별 고유 ID)를 book_character 테이블의 PK(id)로 잘못 조회하는 오류가 있었음.
- characterRepository.findByBookAndCharacterId() 메소드를 사용하도록 수정하여, book 정보와 character_id(책별 고유 ID)를 함께 사용해 정확한 인물을 조회하도록 변경함.

2. 데이터 처리 정책 변경 (덮어쓰기 → 중복 방지)
- 기존에는 새로운 요약본 업로드 시, 해당 챕터의 모든 기존 데이터를 먼저 삭제하고 새로운 데이터로 덮어쓰는 방식
- existsByChapter()를 통해 데이터 존재 여부를 먼저 확인하고, 데이터가 이미 존재할 경우 CHAPTER_ALREADY_SUMMARIZED 에러를 발생시켜 중복 생성을 방지하도록 변경함.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
