### PR TITLE
feat: 인물/이벤트/POV 요약/관계 정보 삭제 api 구현

### DIFF
--- a/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
@@ -48,6 +48,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN4009", "해당 이벤트를 찾을 수 없습니다."),
     RELATIONSHIP_DATA_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ADMIN4010", "해당 이벤트의 관계 데이터가 이미 존재합니다."),
     NO_CHARACTERS_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4011", "삭제할 인물 데이터가 존재하지 않습니다."),
+    NO_EVENTS_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4012", "삭제할 이벤트 데이터가 존재하지 않습니다."),
 
     // Bookmark
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOKMARK4001", "해당 북마크를 찾을 수 없습니다."),

--- a/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
@@ -50,6 +50,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NO_CHARACTERS_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4011", "삭제할 인물 데이터가 존재하지 않습니다."),
     NO_EVENTS_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4012", "삭제할 이벤트 데이터가 존재하지 않습니다."),
     NO_SUMMARY_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4013", "삭제할 POV 요약본이 존재하지 않습니다."),
+    NO_RELATIONSHIPS_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4015", "삭제할 관계 정보가 존재하지 않습니다."),
 
     // Bookmark
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOKMARK4001", "해당 북마크를 찾을 수 없습니다."),

--- a/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
@@ -47,6 +47,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EVENT_DATA_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ADMIN4008", "해당 챕터의 이벤트 데이터가 이미 존재합니다."),
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN4009", "해당 이벤트를 찾을 수 없습니다."),
     RELATIONSHIP_DATA_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ADMIN4010", "해당 이벤트의 관계 데이터가 이미 존재합니다."),
+    NO_CHARACTERS_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4011", "삭제할 인물 데이터가 존재하지 않습니다."),
 
     // Bookmark
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOKMARK4001", "해당 북마크를 찾을 수 없습니다."),

--- a/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
@@ -49,6 +49,7 @@ public enum ErrorStatus implements BaseErrorCode {
     RELATIONSHIP_DATA_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ADMIN4010", "해당 이벤트의 관계 데이터가 이미 존재합니다."),
     NO_CHARACTERS_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4011", "삭제할 인물 데이터가 존재하지 않습니다."),
     NO_EVENTS_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4012", "삭제할 이벤트 데이터가 존재하지 않습니다."),
+    NO_SUMMARY_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4013", "삭제할 POV 요약본이 존재하지 않습니다."),
 
     // Bookmark
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOKMARK4001", "해당 북마크를 찾을 수 없습니다."),

--- a/src/main/java/com/kw/readwith/domain/Chapter.java
+++ b/src/main/java/com/kw/readwith/domain/Chapter.java
@@ -68,4 +68,13 @@ public class Chapter extends BaseEntity {
     public void setSummaryText(String summaryText) {
         this.summaryText = summaryText;
     }
+
+    public void deleteSummary() {
+        this.summaryText = null;
+        this.summaryUploadUrl = null;
+    }
+
+    public void markPovSummariesAsUncached() {
+        this.povSummariesCached = false;
+    }
 }

--- a/src/main/java/com/kw/readwith/repository/CharacterRepository.java
+++ b/src/main/java/com/kw/readwith/repository/CharacterRepository.java
@@ -3,6 +3,7 @@ package com.kw.readwith.repository;
 import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Character;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -15,4 +16,9 @@ public interface CharacterRepository extends JpaRepository<Character, Long> {
 
     // Book과 name으로 Character를 찾는 메소드
     Optional<Character> findByBookAndName(Book book, String name);
+
+    boolean existsByBook(Book book);
+
+    @Modifying
+    void deleteByBook(Book book);
 }

--- a/src/main/java/com/kw/readwith/repository/EventRelationshipEdgeRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventRelationshipEdgeRepository.java
@@ -3,7 +3,11 @@ package com.kw.readwith.repository;
 import com.kw.readwith.domain.Event;
 import com.kw.readwith.domain.mapping.EventRelationshipEdge;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface EventRelationshipEdgeRepository extends JpaRepository<EventRelationshipEdge, Long> {
     boolean existsByEvent(Event event);
+
+    void deleteByEvent(Event event);
 }

--- a/src/main/java/com/kw/readwith/repository/EventRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventRepository.java
@@ -4,6 +4,7 @@ import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 
 import java.util.Optional;
 
@@ -14,4 +15,9 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     // Event를 찾는 메소드
     Optional<Event> findByBookAndChapterAndIdx(Book book, Chapter chapter, Integer idx);
+
+    boolean existsByChapter(Chapter chapter);
+
+    @Modifying
+    void deleteByChapter(Chapter chapter);
 }

--- a/src/main/java/com/kw/readwith/service/BookService.java
+++ b/src/main/java/com/kw/readwith/service/BookService.java
@@ -299,4 +299,22 @@ public class BookService {
 
         eventRepository.deleteByChapter(chapter);
     }
+
+    @Transactional
+    public void deleteChapterSummary(Long bookId, Integer chapterIdx) {
+        // 1. 챕터가 존재하는지 확인
+        Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+
+        // 2. POV 요약본이 존재하는지 확인
+        if (!characterPovSummaryRepository.existsByChapter(chapter)) {
+            throw new GeneralException(ErrorStatus.NO_SUMMARY_TO_DELETE);
+        }
+
+        // 3. 해당 챕터의 모든 챕터 요약본을 삭제
+        characterPovSummaryRepository.deleteByChapter(chapter);
+
+        // 4. 해당 챕터의 요약 상태를 업데이트
+        chapter.markPovSummariesAsUncached();
+    }
 }

--- a/src/main/java/com/kw/readwith/service/BookService.java
+++ b/src/main/java/com/kw/readwith/service/BookService.java
@@ -8,6 +8,7 @@ import com.kw.readwith.aws.s3.AmazonS3Manager;
 import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.Event;
 import com.kw.readwith.domain.User;
 import com.kw.readwith.domain.mapping.CharacterPovSummary;
 import com.kw.readwith.dto.admin.UnsummarizedItemDTO;
@@ -20,6 +21,7 @@ import com.kw.readwith.repository.CharacterRepository;
 import com.kw.readwith.repository.EventRepository;
 import com.kw.readwith.repository.FavoriteRepository;
 import com.kw.readwith.repository.UserRepository;
+import com.kw.readwith.repository.EventRelationshipEdgeRepository;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.NoArgsConstructor;
@@ -47,6 +49,7 @@ public class BookService {
     private final CharacterRepository characterRepository;
     private final CharacterPovSummaryRepository characterPovSummaryRepository;
     private final EventRepository eventRepository;
+    private final EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
     private final ObjectMapper objectMapper;
 
     /**
@@ -316,5 +319,20 @@ public class BookService {
 
         // 4. 해당 챕터의 요약 상태를 업데이트
         chapter.markPovSummariesAsUncached();
+    }
+
+    @Transactional
+    public void deleteRelationships(Long bookId, Integer chapterIdx, Integer eventIdx) {
+        Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+
+        Event event = eventRepository.findByChapterAndIdx(chapter, eventIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND));
+
+        if (!eventRelationshipEdgeRepository.existsByEvent(event)) {
+            throw new GeneralException(ErrorStatus.NO_RELATIONSHIPS_TO_DELETE);
+        }
+
+        eventRelationshipEdgeRepository.deleteByEvent(event);
     }
 }

--- a/src/main/java/com/kw/readwith/service/BookService.java
+++ b/src/main/java/com/kw/readwith/service/BookService.java
@@ -271,4 +271,17 @@ public class BookService {
         List<Book> books = bookRepository.findBySummaryIsFalse();
         return books.stream().map(book -> BookSummaryDTO.builder().id(book.getId()).title(book.getTitle()).author(book.getAuthor()).coverImgUrl(book.getCoverImgUrl()).isDefault(book.isDefault()).isFavorite(false).updatedAt(book.getUpdatedAt()).build()).collect(Collectors.toList());
     }
+
+    @Transactional
+    public void deleteCharacters(Long bookId) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+
+        // 삭제할 데이터가 존재하는지 먼저 확인
+        if (!characterRepository.existsByBook(book)) {
+            throw new GeneralException(ErrorStatus.NO_CHARACTERS_TO_DELETE);
+        }
+
+        characterRepository.deleteByBook(book);
+    }
 }

--- a/src/main/java/com/kw/readwith/service/BookService.java
+++ b/src/main/java/com/kw/readwith/service/BookService.java
@@ -17,6 +17,7 @@ import com.kw.readwith.repository.BookRepository;
 import com.kw.readwith.repository.ChapterRepository;
 import com.kw.readwith.repository.CharacterPovSummaryRepository;
 import com.kw.readwith.repository.CharacterRepository;
+import com.kw.readwith.repository.EventRepository;
 import com.kw.readwith.repository.FavoriteRepository;
 import com.kw.readwith.repository.UserRepository;
 import lombok.Getter;
@@ -45,6 +46,7 @@ public class BookService {
     private final ChapterRepository chapterRepository;
     private final CharacterRepository characterRepository;
     private final CharacterPovSummaryRepository characterPovSummaryRepository;
+    private final EventRepository eventRepository;
     private final ObjectMapper objectMapper;
 
     /**
@@ -283,5 +285,18 @@ public class BookService {
         }
 
         characterRepository.deleteByBook(book);
+    }
+
+    @Transactional
+    public void deleteEvents(Long bookId, Integer chapterIdx) {
+        Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+
+        // 삭제할 데이터가 존재하는지 먼저 확인
+        if (!eventRepository.existsByChapter(chapter)) {
+            throw new GeneralException(ErrorStatus.NO_EVENTS_TO_DELETE);
+        }
+
+        eventRepository.deleteByChapter(chapter);
     }
 }

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -75,6 +75,15 @@ public class AdminController {
         return ApiResponse.onSuccess("Events uploaded successfully.");
     }
 
+    @Operation(summary = "이벤트 정보 삭제 API", description = "특정 챕터에 대한 모든 이벤트 정보를 삭제합니다. 이벤트 정보 업로드 실패 시 사용합니다.")
+    @DeleteMapping("/books/{bookId}/chapters/{chapterIdx}/events")
+    public ApiResponse<String> deleteEvents(
+            @Parameter(description = "이벤트 정보를 삭제할 책의 ID") @PathVariable Long bookId,
+            @Parameter(description = "이벤트 정보를 삭제할 챕터의 순서(index)") @PathVariable Integer chapterIdx) {
+        bookService.deleteEvents(bookId, chapterIdx);
+        return ApiResponse.onSuccess("Events for the chapter have been successfully deleted.");
+    }
+
     @Operation(summary = "관계 정보 업로드 API", description = "특정 이벤트에 대한 인물 관계 정보(JSON)를 업로드합니다.")
     @PostMapping(value = "/books/{bookId}/chapters/{chapterIdx}/events/{eventIdx}/relationships", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadRelationships(

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -47,6 +47,15 @@ public class AdminController {
         return ApiResponse.onSuccess("Chapter summary has been successfully uploaded.");
     }
 
+    @Operation(summary = "챕터 요약본 삭제 API", description = "특정 챕터에 대한 요약본 정보를 삭제합니다. 요약본 업로드 실패 시 사용합니다.")
+    @DeleteMapping("/books/{bookId}/chapters/{chapterIdx}/summary")
+    public ApiResponse<String> deleteChapterSummary(
+            @Parameter(description = "요약본을 삭제할 책의 ID") @PathVariable Long bookId,
+            @Parameter(description = "요약본을 삭제할 챕터의 순서(index)") @PathVariable Integer chapterIdx) {
+        bookService.deleteChapterSummary(bookId, chapterIdx);
+        return ApiResponse.onSuccess("Chapter summary has been successfully deleted.");
+    }
+
     @Operation(summary = "인물 정보 업로드 API", description = "특정 책에 대한 인물 정보가 담긴 JSON 파일을 업로드합니다.")
     @PostMapping(value = "/books/{bookId}/characters", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadCharacters(

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -96,11 +96,21 @@ public class AdminController {
     @Operation(summary = "관계 정보 업로드 API", description = "특정 이벤트에 대한 인물 관계 정보(JSON)를 업로드합니다.")
     @PostMapping(value = "/books/{bookId}/chapters/{chapterIdx}/events/{eventIdx}/relationships", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadRelationships(
-            @Parameter(description = "책 ID") @PathVariable Long bookId,
-            @Parameter(description = "챕터 순서(index)") @PathVariable Integer chapterIdx,
-            @Parameter(description = "이벤트 순서(index)") @PathVariable Integer eventIdx,
+            @Parameter(description = "관계 정보를 추가할 책의 ID") @PathVariable Long bookId,
+            @Parameter(description = "관계 정보를 추가할 챕터의 순서(index)") @PathVariable Integer chapterIdx,
+            @Parameter(description = "관계 정보를 추가할 이벤트의 순서(index)") @PathVariable Integer eventIdx,
             @Parameter(description = "관계 정보가 담긴 JSON 파일") @RequestParam("file") MultipartFile file) {
         adminService.uploadRelationships(bookId, chapterIdx, eventIdx, file);
         return ApiResponse.onSuccess("Relationships uploaded successfully.");
+    }
+
+    @Operation(summary = "관계 정보 삭제 API", description = "특정 이벤트에 대한 모든 관계 정보(엣지)를 삭제합니다. 관계 정보 업로드 실패 시 사용합니다.")
+    @DeleteMapping("/books/{bookId}/chapters/{chapterIdx}/events/{eventIdx}/relationships")
+    public ApiResponse<String> deleteRelationships(
+            @Parameter(description = "관계 정보를 삭제할 책의 ID") @PathVariable Long bookId,
+            @Parameter(description = "관계 정보를 삭제할 챕터의 순서(index)") @PathVariable Integer chapterIdx,
+            @Parameter(description = "관계 정보를 삭제할 이벤트의 순서(index)") @PathVariable Integer eventIdx) {
+        bookService.deleteRelationships(bookId, chapterIdx, eventIdx);
+        return ApiResponse.onSuccess("Relationships have been successfully deleted.");
     }
 }

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -57,6 +57,14 @@ public class AdminController {
         return ApiResponse.onSuccess("Characters have been successfully uploaded.");
     }
 
+    @Operation(summary = "인물 정보 삭제 API", description = "특정 책에 대한 모든 인물 정보를 삭제합니다. 인물 정보 업로드 실패 시 사용합니다.")
+    @DeleteMapping("/books/{bookId}/characters")
+    public ApiResponse<String> deleteCharacters(
+            @Parameter(description = "인물 정보를 삭제할 책의 ID") @PathVariable Long bookId) {
+        bookService.deleteCharacters(bookId);
+        return ApiResponse.onSuccess("Characters for the book have been successfully deleted.");
+    }
+
     @Operation(summary = "이벤트 정보 업로드 API", description = "책의 특정 챕터에 대한 이벤트 정보(JSON)를 업로드합니다.")
     @PostMapping(value = "/books/{bookId}/chapters/{chapterIdx}/events", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadEvents(


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
인물, 이벤트, POV 요약, 관계 정보를 삭제하는 api를 구현했습니다.

관리자가 데이터 업로드 실패 시, 재시도를 용이하게 할 수 있도록, 인물, 이벤트, POV 요약, 관계 정보를 일괄 삭제하는 기능을 제공함.

## 📋 변경 사항
🛠️ 신규 DELETE API 엔드포인트 추가
- 인물 정보 삭제: DELETE /api/admin/books/{bookId}/characters
- 이벤트 정보 삭제: DELETE /api/admin/books/{bookId}/chapters/{chapterIdx}/events
- POV 요약 삭제: DELETE /api/admin/books/{bookId}/chapters/{chapterIdx}/summary
- 관계 정보 삭제: DELETE /api/admin/books/{bookId}/chapters/{chapterIdx}/events/{eventIdx}/relationships

✨ 기능별 역할
- 인물 정보: 특정 책에 속한 모든 인물 데이터를 삭제
- 이벤트 정보: 특정 챕터에 속한 모든 이벤트 데이터를 삭제
- POV 요약 정보: 특정 챕터에 대한 모든 POV 요약 데이터를 삭제하고, 챕터의 요약 상태를 초기화
- 관계 정보: 특정 이벤트의 모든 관계(엣지) 데이터를 삭제

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
