### PR TITLE
feat: manifest graph api 구현 및 세밀/거시 그래프 API 구현

### DIFF
--- a/src/main/java/com/kw/readwith/config/DataLoader.java
+++ b/src/main/java/com/kw/readwith/config/DataLoader.java
@@ -1,13 +1,20 @@
 package com.kw.readwith.config;
 
 import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Chapter;
+import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.Event;
 import com.kw.readwith.domain.User;
 import com.kw.readwith.domain.enums.Provider;
 import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import com.kw.readwith.repository.CharacterRepository;
+import com.kw.readwith.repository.EventRepository;
 import com.kw.readwith.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -15,15 +22,41 @@ public class DataLoader implements CommandLineRunner {
 
     private final UserRepository userRepository;
     private final BookRepository bookRepository;
+    private final ChapterRepository chapterRepository;
+    private final EventRepository eventRepository;
+    private final CharacterRepository characterRepository;
 
     @Override
     public void run(String... args) throws Exception {
         // 목업 데이터가 이미 존재하는지 확인
+        System.out.println("DataLoader running... User count: " + userRepository.count());
+        System.out.println("Book count: " + bookRepository.count());
+        
         if (userRepository.count() == 0) {
+            System.out.println("Creating mock data...");
             createMockData();
+        } else {
+            System.out.println("Mock data already exists, skipping creation.");
+            
+            // 기존 데이터에 챕터/캐릭터가 없다면 추가
+            if (chapterRepository.count() == 0 && characterRepository.count() == 0) {
+                System.out.println("Adding missing chapter and character data...");
+                Book book1 = bookRepository.findById(1L).orElse(null);
+                Book book2 = bookRepository.findById(2L).orElse(null);
+                
+                if (book1 != null) {
+                    System.out.println("Adding data for existing book: " + book1.getTitle());
+                    createHarryPotterData(book1);
+                }
+                if (book2 != null) {
+                    System.out.println("Adding data for existing book: " + book2.getTitle());
+                    createLordOfTheRingsData(book2);
+                }
+            }
         }
     }
 
+    @Transactional
     private void createMockData() {
         // 사용자 생성 (ID는 자동 생성)
         User user = User.builder()
@@ -41,9 +74,11 @@ public class DataLoader implements CommandLineRunner {
                 .author("J.K. 롤링")
                 .language("ko")
                 .isDefault(true)
+                .coverImgUrl("https://example.com/covers/harry_potter.jpg")
+                .epubPath("https://example.com/epubs/harry_potter.epub")
                 .uploadedBy(null)  // null = 서버 기본 제공
                 .build();
-        bookRepository.save(book1);
+        Book savedBook1 = bookRepository.save(book1);
 
         Book book2 = Book.builder()
                 .title("반지의 제왕")
@@ -51,9 +86,17 @@ public class DataLoader implements CommandLineRunner {
                 .author("J.R.R. 톨킨")
                 .language("ko")
                 .isDefault(true)
+                .coverImgUrl("https://example.com/covers/lotr.jpg")
+                .epubPath("https://example.com/epubs/lotr.epub")
                 .uploadedBy(null)  // null = 서버 기본 제공
                 .build();
-        bookRepository.save(book2);
+        Book savedBook2 = bookRepository.save(book2);
+        
+        // 첫 번째 책(해리포터)에 대한 상세 데이터 생성
+        createHarryPotterData(savedBook1);
+        
+        // 두 번째 책(반지의 제왕)에 대한 상세 데이터 생성
+        createLordOfTheRingsData(savedBook2);
 
         // 사용자별 책 생성 (해당 사용자만 접근 가능)
         Book book3 = Book.builder()
@@ -80,5 +123,226 @@ public class DataLoader implements CommandLineRunner {
         System.out.println("사용자 ID: " + savedUser.getId());
         System.out.println("기본 제공 책 ID: 1, 2 (모든 사용자 접근 가능)");
         System.out.println("사용자별 책 ID: 3, 4 (사용자 ID " + savedUser.getId() + "만 접근 가능)");
+        System.out.println("Manifest API 테스트 URL: GET /api/books/1/manifest");
+    }
+
+    /**
+     * 해리포터와 마법사의 돌 예제 데이터 생성
+     */
+    private void createHarryPotterData(Book book) {
+        // 인물 생성
+        Character harry = Character.builder()
+                .book(book)
+                .characterId(1L)
+                .name("해리 포터")
+                .names("해리, 포터, 살아남은 아이")
+                .isMainCharacter(true)
+                .firstChapterIdx(1)
+                .personalityText("용감하고 정의로운 마법사. 볼드모트를 물리칠 운명을 가진 소년.")
+                .profileText("검은 머리에 번개 모양 흉터가 있는 11세 소년. 둥근 안경을 쓰고 있다.")
+                .build();
+        characterRepository.save(harry);
+
+        Character hermione = Character.builder()
+                .book(book)
+                .characterId(2L)
+                .name("헤르미온느 그레인저")
+                .names("헤르미온느, 그레인저")
+                .isMainCharacter(true)
+                .firstChapterIdx(6)
+                .personalityText("매우 똑똑하고 성실한 마법사. 책을 좋아하고 규칙을 잘 지킨다.")
+                .profileText("곱슬한 갈색 머리에 앞니가 큰 똑똑한 소녀.")
+                .build();
+        characterRepository.save(hermione);
+
+        Character ron = Character.builder()
+                .book(book)
+                .characterId(3L)
+                .name("론 위즐리")
+                .names("론, 위즐리")
+                .isMainCharacter(true)
+                .firstChapterIdx(6)
+                .personalityText("충성스럽고 용감한 친구. 체스를 잘하고 유머 감각이 있다.")
+                .profileText("빨간 머리에 주근깨가 있는 키 큰 소년.")
+                .build();
+        characterRepository.save(ron);
+
+        Character hagrid = Character.builder()
+                .book(book)
+                .characterId(4L)
+                .name("루베우스 해그리드")
+                .names("해그리드")
+                .isMainCharacter(false)
+                .firstChapterIdx(4)
+                .personalityText("친근하고 따뜻한 거인. 마법 생물을 사랑한다.")
+                .profileText("매우 키가 크고 털이 많은 거인 혼혈. 분홍색 우산을 들고 다닌다.")
+                .build();
+        characterRepository.save(hagrid);
+
+        // 챕터 생성
+        Chapter chapter1 = Chapter.builder()
+                .book(book)
+                .idx(1)
+                .title("살아남은 아이")
+                .pageStart(1)
+                .pageEnd(20)
+                .startPos(0)
+                .endPos(5000)
+                .rawText("더즐리 가족은 프리벳 드라이브 4번지에 살고 있었고, 그들은 자신들이 매우 정상적이라고 자부했다...")
+                .summaryText("해리 포터가 더즐리 가족에게 맡겨지고, 마법사들이 볼드모트의 몰락을 축하한다.")
+                .povSummariesCached(true)
+                .build();
+        Chapter savedChapter1 = chapterRepository.save(chapter1);
+
+        Chapter chapter2 = Chapter.builder()
+                .book(book)
+                .idx(2)
+                .title("사라진 유리")
+                .pageStart(21)
+                .pageEnd(40)
+                .startPos(5001)
+                .endPos(10000)
+                .rawText("해리가 더즐리 가족과 함께 지낸 지 거의 10년이 되었다...")
+                .summaryText("해리의 11번째 생일이 다가오고, 동물원에서 뱀과 이야기하는 사건이 일어난다.")
+                .povSummariesCached(true)
+                .build();
+        chapterRepository.save(chapter2);
+
+        Chapter chapter3 = Chapter.builder()
+                .book(book)
+                .idx(3)
+                .title("편지들")
+                .pageStart(41)
+                .pageEnd(60)
+                .startPos(10001)
+                .endPos(15000)
+                .rawText("동물원 사건 이후, 더즐리 가족은 해리를 더욱 엄하게 다뤘다...")
+                .summaryText("호그와트에서 온 편지들이 계속 도착하고, 더즐리 가족은 이를 막으려 한다.")
+                .povSummariesCached(true)
+                .build();
+        chapterRepository.save(chapter3);
+
+        // 이벤트 생성 (첫 번째 챕터만)
+        Event event1 = Event.builder()
+                .book(book)
+                .chapter(savedChapter1)
+                .idx(1)
+                .startPos(0)
+                .endPos(1000)
+                .rawText("더즐리 씨는 그루닝스 드릴 회사의 중역이었다. 그는 뚱뚱하고 목이 거의 없는 남자였으며...")
+                .build();
+        eventRepository.save(event1);
+
+        Event event2 = Event.builder()
+                .book(book)
+                .chapter(savedChapter1)
+                .idx(2)
+                .startPos(1001)
+                .endPos(2500)
+                .rawText("그날 밤 늦게, 맥고나걸 교수가 고양이 모습에서 사람으로 변했다...")
+                .build();
+        eventRepository.save(event2);
+
+        Event event3 = Event.builder()
+                .book(book)
+                .chapter(savedChapter1)
+                .idx(3)
+                .startPos(2501)
+                .endPos(5000)
+                .rawText("덤블도어가 나타나서 해그리드와 함께 아기 해리를 더즐리 가족에게 맡겼다...")
+                .build();
+        eventRepository.save(event3);
+    }
+
+    /**
+     * 반지의 제왕 예제 데이터 생성
+     */
+    private void createLordOfTheRingsData(Book book) {
+        // 인물 생성
+        Character frodo = Character.builder()
+                .book(book)
+                .characterId(1L)
+                .name("프로도 배긴스")
+                .names("프로도, 배긴스")
+                .isMainCharacter(true)
+                .firstChapterIdx(1)
+                .personalityText("용감하고 희생정신이 강한 호빗. 반지를 파괴하는 임무를 맡는다.")
+                .profileText("작은 키의 호빗으로 곱슬한 갈색 머리를 가지고 있다.")
+                .build();
+        characterRepository.save(frodo);
+
+        Character gandalf = Character.builder()
+                .book(book)
+                .characterId(2L)
+                .name("간달프")
+                .names("간달프, 회색의 간달프, 미스란디르")
+                .isMainCharacter(true)
+                .firstChapterIdx(1)
+                .personalityText("지혜롭고 강력한 마법사. 프로도의 여행을 도와준다.")
+                .profileText("긴 회색 수염과 뾰족한 모자를 쓴 늙은 마법사.")
+                .build();
+        characterRepository.save(gandalf);
+
+        Character aragorn = Character.builder()
+                .book(book)
+                .characterId(3L)
+                .name("아라고른")
+                .names("아라고른, 스트라이더, 엘레사르")
+                .isMainCharacter(true)
+                .firstChapterIdx(10)
+                .personalityText("곤도르의 진정한 왕. 용감하고 고귀한 전사.")
+                .profileText("키가 크고 검은 머리를 가진 레인저. 날카로운 눈빛을 가지고 있다.")
+                .build();
+        characterRepository.save(aragorn);
+
+        // 챕터 생성
+        Chapter chapter1 = Chapter.builder()
+                .book(book)
+                .idx(1)
+                .title("오래 기다려온 파티")
+                .pageStart(1)
+                .pageEnd(25)
+                .startPos(0)
+                .endPos(6000)
+                .rawText("빌보 배긴스가 자신의 111번째 생일 파티를 준비하고 있었다...")
+                .summaryText("빌보의 생일 파티에서 그가 반지의 힘으로 사라지고, 간달프가 반지의 정체를 밝힌다.")
+                .povSummariesCached(true)
+                .build();
+        Chapter savedChapter1 = chapterRepository.save(chapter1);
+
+        Chapter chapter2 = Chapter.builder()
+                .book(book)
+                .idx(2)
+                .title("과거의 그림자")
+                .pageStart(26)
+                .pageEnd(50)
+                .startPos(6001)
+                .endPos(12000)
+                .rawText("간달프가 프로도에게 반지의 진실을 말해주었다...")
+                .summaryText("간달프가 반지가 사우론의 절대반지임을 밝히고, 프로도가 반지를 파괴해야 함을 알게 된다.")
+                .povSummariesCached(true)
+                .build();
+        chapterRepository.save(chapter2);
+
+        // 이벤트 생성
+        Event event1 = Event.builder()
+                .book(book)
+                .chapter(savedChapter1)
+                .idx(1)
+                .startPos(0)
+                .endPos(2000)
+                .rawText("빌보 배긴스는 백엔드에서 자신의 111번째 생일을 맞아 성대한 파티를 열었다...")
+                .build();
+        eventRepository.save(event1);
+
+        Event event2 = Event.builder()
+                .book(book)
+                .chapter(savedChapter1)
+                .idx(2)
+                .startPos(2001)
+                .endPos(4000)
+                .rawText("파티가 끝난 후, 빌보는 반지를 끼고 사라져버렸다...")
+                .build();
+        eventRepository.save(event2);
     }
 } 

--- a/src/main/java/com/kw/readwith/config/DataLoader.java
+++ b/src/main/java/com/kw/readwith/config/DataLoader.java
@@ -5,12 +5,16 @@ import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.Character;
 import com.kw.readwith.domain.Event;
 import com.kw.readwith.domain.User;
+import com.kw.readwith.domain.mapping.EventRelationshipEdge;
+import com.kw.readwith.domain.mapping.ChapterRelationshipEdge;
 import com.kw.readwith.domain.enums.Provider;
 import com.kw.readwith.repository.BookRepository;
 import com.kw.readwith.repository.ChapterRepository;
 import com.kw.readwith.repository.CharacterRepository;
 import com.kw.readwith.repository.EventRepository;
 import com.kw.readwith.repository.UserRepository;
+import com.kw.readwith.repository.EventRelationshipEdgeRepository;
+import com.kw.readwith.repository.ChapterRelationshipEdgeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
@@ -25,6 +29,8 @@ public class DataLoader implements CommandLineRunner {
     private final ChapterRepository chapterRepository;
     private final EventRepository eventRepository;
     private final CharacterRepository characterRepository;
+    private final EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
+    private final ChapterRelationshipEdgeRepository chapterRelationshipEdgeRepository;
 
     @Override
     public void run(String... args) throws Exception {
@@ -251,7 +257,10 @@ public class DataLoader implements CommandLineRunner {
                 .endPos(5000)
                 .rawText("덤블도어가 나타나서 해그리드와 함께 아기 해리를 더즐리 가족에게 맡겼다...")
                 .build();
-        eventRepository.save(event3);
+        Event savedEvent3 = eventRepository.save(event3);
+        
+        // EventRelationshipEdge 관계 데이터 추가 (Admin API 업로드 형태와 동일)
+        createHarryPotterRelationships(book, savedEvent3, harry, hermione, ron, hagrid);
     }
 
     /**
@@ -344,5 +353,116 @@ public class DataLoader implements CommandLineRunner {
                 .rawText("파티가 끝난 후, 빌보는 반지를 끼고 사라져버렸다...")
                 .build();
         eventRepository.save(event2);
+        
+        // 반지의 제왕 관계 데이터 추가
+        createLordOfTheRingsRelationships(book, event2, frodo, gandalf, aragorn);
+    }
+
+    /**
+     * 해리포터 관계 데이터 생성 (Admin API 업로드 형태와 동일)
+     */
+    private void createHarryPotterRelationships(Book book, Event event, Character harry, Character hermione, Character ron, Character hagrid) {
+        // 해리 - 해그리드 관계 (긍정적)
+        EventRelationshipEdge harryHagrid = EventRelationshipEdge.builder()
+                .fromCharacter(harry)
+                .toCharacter(hagrid)
+                .event(event)
+                .edgeWeight(3.5f)  // Admin API의 weight 필드
+                .sentimentScore(0.8f)  // Admin API의 positivity 필드
+                .interactionCount(2)  // Admin API의 count 필드
+                .relationTags("[\"care\", \"protection\"]")  // Admin API의 relation 필드 (JSON 문자열)
+                .build();
+        eventRelationshipEdgeRepository.save(harryHagrid);
+
+        // 해그리드 - 해리 관계 (상호)
+        EventRelationshipEdge hagridHarry = EventRelationshipEdge.builder()
+                .fromCharacter(hagrid)
+                .toCharacter(harry)
+                .event(event)
+                .edgeWeight(3.5f)
+                .sentimentScore(0.7f)
+                .interactionCount(2)
+                .relationTags("[\"mentorship\", \"guidance\"]")
+                .build();
+        eventRelationshipEdgeRepository.save(hagridHarry);
+
+        // ChapterRelationshipEdge 누적 데이터 생성 (챕터 1 기준)
+        ChapterRelationshipEdge chapterEdge1 = ChapterRelationshipEdge.builder()
+                .book(book)
+                .chapterIdx(1)
+                .fromCharacter(harry)
+                .toCharacter(hagrid)
+                .cumulativeInteraction(2)
+                .sentimentWeightedSum(1.6f)  // 0.8 * 2
+                .edgeColorHex("#4CAF50")  // 긍정적 관계 - 녹색
+                .edgeWidth(2.5f)
+                .build();
+        chapterRelationshipEdgeRepository.save(chapterEdge1);
+
+        ChapterRelationshipEdge chapterEdge2 = ChapterRelationshipEdge.builder()
+                .book(book)
+                .chapterIdx(1)
+                .fromCharacter(hagrid)
+                .toCharacter(harry)
+                .cumulativeInteraction(2)
+                .sentimentWeightedSum(1.4f)  // 0.7 * 2
+                .edgeColorHex("#4CAF50")
+                .edgeWidth(2.5f)
+                .build();
+        chapterRelationshipEdgeRepository.save(chapterEdge2);
+    }
+
+    /**
+     * 반지의 제왕 관계 데이터 생성
+     */
+    private void createLordOfTheRingsRelationships(Book book, Event event, Character frodo, Character gandalf, Character aragorn) {
+        // 프로도 - 간달프 관계 (신뢰)
+        EventRelationshipEdge frodoGandalf = EventRelationshipEdge.builder()
+                .fromCharacter(frodo)
+                .toCharacter(gandalf)
+                .event(event)
+                .edgeWeight(4.0f)
+                .sentimentScore(0.9f)
+                .interactionCount(3)
+                .relationTags("[\"trust\", \"guidance\", \"friendship\"]")
+                .build();
+        eventRelationshipEdgeRepository.save(frodoGandalf);
+
+        // 간달프 - 프로도 관계 (보호)
+        EventRelationshipEdge gandalfFrodo = EventRelationshipEdge.builder()
+                .fromCharacter(gandalf)
+                .toCharacter(frodo)
+                .event(event)
+                .edgeWeight(4.2f)
+                .sentimentScore(0.85f)
+                .interactionCount(3)
+                .relationTags("[\"protection\", \"mentorship\"]")
+                .build();
+        eventRelationshipEdgeRepository.save(gandalfFrodo);
+
+        // ChapterRelationshipEdge 누적 데이터
+        ChapterRelationshipEdge chapterEdge1 = ChapterRelationshipEdge.builder()
+                .book(book)
+                .chapterIdx(1)
+                .fromCharacter(frodo)
+                .toCharacter(gandalf)
+                .cumulativeInteraction(3)
+                .sentimentWeightedSum(2.7f)  // 0.9 * 3
+                .edgeColorHex("#2196F3")  // 신뢰 관계 - 파란색
+                .edgeWidth(3.0f)
+                .build();
+        chapterRelationshipEdgeRepository.save(chapterEdge1);
+
+        ChapterRelationshipEdge chapterEdge2 = ChapterRelationshipEdge.builder()
+                .book(book)
+                .chapterIdx(1)
+                .fromCharacter(gandalf)
+                .toCharacter(frodo)
+                .cumulativeInteraction(3)
+                .sentimentWeightedSum(2.55f)  // 0.85 * 3
+                .edgeColorHex("#2196F3")
+                .edgeWidth(3.0f)
+                .build();
+        chapterRelationshipEdgeRepository.save(chapterEdge2);
     }
 } 

--- a/src/main/java/com/kw/readwith/config/WebConfig.java
+++ b/src/main/java/com/kw/readwith/config/WebConfig.java
@@ -1,0 +1,33 @@
+package com.kw.readwith.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
+
+@Configuration
+public class WebConfig {
+
+    /**
+     * Spring의 자동 ETag 지원을 위한 ShallowEtagHeaderFilter 설정
+     * 
+     * 동작 원리:
+     * 1. 응답 본문의 MD5 해시값으로 ETag 자동 생성
+     * 2. 클라이언트의 If-None-Match 헤더와 비교
+     * 3. 동일하면 304 Not Modified 응답 (본문 없음)
+     * 4. 다르면 200 OK 응답 (본문 포함)
+     */
+    @Bean
+    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
+        FilterRegistrationBean<ShallowEtagHeaderFilter> filterRegistrationBean = 
+            new FilterRegistrationBean<>(new ShallowEtagHeaderFilter());
+        
+        // Manifest API에만 ETag 적용
+        filterRegistrationBean.addUrlPatterns("/api/books/*/manifest");
+        
+        // 필터 순서 설정 (낮을수록 먼저 실행)
+        filterRegistrationBean.setOrder(1);
+        
+        return filterRegistrationBean;
+    }
+}

--- a/src/main/java/com/kw/readwith/domain/Event.java
+++ b/src/main/java/com/kw/readwith/domain/Event.java
@@ -4,7 +4,8 @@ import com.kw.readwith.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-@Entity(name = "book_event")
+@Entity
+@Table(name = "book_event")
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/kw/readwith/dto/graph/EventInfoDTO.java
+++ b/src/main/java/com/kw/readwith/dto/graph/EventInfoDTO.java
@@ -1,0 +1,12 @@
+package com.kw.readwith.dto.graph;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EventInfoDTO {
+    private Integer chapterIdx;
+    private Integer eventIdx;
+    private String eventText;
+}

--- a/src/main/java/com/kw/readwith/dto/graph/FineGraphEdgeDTO.java
+++ b/src/main/java/com/kw/readwith/dto/graph/FineGraphEdgeDTO.java
@@ -1,0 +1,17 @@
+package com.kw.readwith.dto.graph;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class FineGraphEdgeDTO {
+    private Long from;
+    private Long to;
+    private Double weight;
+    private Double sentimentScore;
+    private Integer interactionCount;
+    private List<String> relationTags;
+}

--- a/src/main/java/com/kw/readwith/dto/graph/FineGraphResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/graph/FineGraphResponseDTO.java
@@ -1,0 +1,14 @@
+package com.kw.readwith.dto.graph;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class FineGraphResponseDTO {
+    private List<GraphNodeDTO> nodes;
+    private List<FineGraphEdgeDTO> edges;
+    private EventInfoDTO eventInfo;
+}

--- a/src/main/java/com/kw/readwith/dto/graph/GraphNodeDTO.java
+++ b/src/main/java/com/kw/readwith/dto/graph/GraphNodeDTO.java
@@ -1,0 +1,16 @@
+package com.kw.readwith.dto.graph;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GraphNodeDTO {
+    private Long id;
+    private String label;
+    private Boolean isMainCharacter;
+    private String profileImage;
+    private String description;
+    private String portraitPrompt;
+    private String names;
+}

--- a/src/main/java/com/kw/readwith/dto/graph/MacroGraphEdgeDTO.java
+++ b/src/main/java/com/kw/readwith/dto/graph/MacroGraphEdgeDTO.java
@@ -1,0 +1,15 @@
+package com.kw.readwith.dto.graph;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MacroGraphEdgeDTO {
+    private Long from;
+    private Long to;
+    private Integer cumulativeInteraction;
+    private Double cumulativeSentiment;
+    private Double sentimentWeightedSum;
+    private Integer chapterIdx;
+}

--- a/src/main/java/com/kw/readwith/dto/graph/MacroGraphResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/graph/MacroGraphResponseDTO.java
@@ -1,0 +1,14 @@
+package com.kw.readwith.dto.graph;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MacroGraphResponseDTO {
+    private List<GraphNodeDTO> nodes;
+    private List<MacroGraphEdgeDTO> edges;
+    private MacroGraphSummaryDTO summary;
+}

--- a/src/main/java/com/kw/readwith/dto/graph/MacroGraphSummaryDTO.java
+++ b/src/main/java/com/kw/readwith/dto/graph/MacroGraphSummaryDTO.java
@@ -1,0 +1,12 @@
+package com.kw.readwith.dto.graph;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MacroGraphSummaryDTO {
+    private Integer uptoChapter;
+    private Integer totalCharacters;
+    private Integer totalRelationships;
+}

--- a/src/main/java/com/kw/readwith/dto/manifest/BookManifestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/manifest/BookManifestDTO.java
@@ -1,0 +1,54 @@
+package com.kw.readwith.dto.manifest;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BookManifestDTO {
+    
+    /**
+     * 책 ID
+     */
+    private Long id;
+    
+    /**
+     * 제목
+     */
+    private String title;
+    
+    /**
+     * 저자
+     */
+    private String author;
+    
+    /**
+     * 언어 (ISO-639 코드)
+     */
+    private String language;
+    
+    /**
+     * 기본 제공 책 여부
+     */
+    private Boolean isDefault;
+    
+    /**
+     * 요약 완료 여부
+     */
+    private Boolean summary;
+    
+    /**
+     * 커버 이미지 URL
+     */
+    private String coverImgUrl;
+    
+    /**
+     * 요약 파일 URL
+     */
+    private String summaryUrl;
+    
+    /**
+     * EPUB 파일 경로
+     */
+    private String epubPath;
+}

--- a/src/main/java/com/kw/readwith/dto/manifest/ChapterManifestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/manifest/ChapterManifestDTO.java
@@ -1,0 +1,56 @@
+package com.kw.readwith.dto.manifest;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ChapterManifestDTO {
+    
+    /**
+     * 챕터 인덱스 (1-based)
+     */
+    private Integer idx;
+    
+    /**
+     * 챕터 제목
+     */
+    private String title;
+    
+    /**
+     * 시작 위치
+     */
+    private Integer startPos;
+    
+    /**
+     * 종료 위치
+     */
+    private Integer endPos;
+    
+    /**
+     * 원본 텍스트 (일부)
+     */
+    private String rawText;
+    
+    /**
+     * 챕터 요약
+     */
+    private String summaryText;
+    
+    /**
+     * 요약 업로드 URL
+     */
+    private String summaryUploadUrl;
+    
+    /**
+     * POV 요약 캐시 여부
+     */
+    private Boolean povSummariesCached;
+    
+    /**
+     * 이벤트 목록
+     */
+    private List<EventManifestDTO> events;
+}

--- a/src/main/java/com/kw/readwith/dto/manifest/CharacterManifestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/manifest/CharacterManifestDTO.java
@@ -1,0 +1,49 @@
+package com.kw.readwith.dto.manifest;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CharacterManifestDTO {
+    
+    /**
+     * 인물 ID (책 내 고유 ID)
+     */
+    private Long id;
+    
+    /**
+     * 인물 이름
+     */
+    private String name;
+    
+    /**
+     * 인물이 불리는 다른 이름들
+     */
+    private String names;
+    
+    /**
+     * 프로필 이미지 URL
+     */
+    private String profileImage;
+    
+    /**
+     * 주요 인물 여부
+     */
+    private Boolean isMainCharacter;
+    
+    /**
+     * 첫 등장 챕터
+     */
+    private Integer firstChapterIdx;
+    
+    /**
+     * 성격/인물 설명
+     */
+    private String personalityText;
+    
+    /**
+     * 프로필 묘사
+     */
+    private String profileText;
+}

--- a/src/main/java/com/kw/readwith/dto/manifest/EventManifestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/manifest/EventManifestDTO.java
@@ -1,0 +1,29 @@
+package com.kw.readwith.dto.manifest;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EventManifestDTO {
+    
+    /**
+     * 이벤트 인덱스 (챕터 내)
+     */
+    private Integer idx;
+    
+    /**
+     * 시작 위치
+     */
+    private Integer startPos;
+    
+    /**
+     * 종료 위치
+     */
+    private Integer endPos;
+    
+    /**
+     * 원본 텍스트
+     */
+    private String rawText;
+}

--- a/src/main/java/com/kw/readwith/dto/manifest/ManifestResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/manifest/ManifestResponseDTO.java
@@ -1,0 +1,26 @@
+package com.kw.readwith.dto.manifest;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ManifestResponseDTO {
+    
+    /**
+     * 책 기본 정보
+     */
+    private BookManifestDTO book;
+    
+    /**
+     * 챕터 목록 (이벤트 포함)
+     */
+    private List<ChapterManifestDTO> chapters;
+    
+    /**
+     * 인물 목록
+     */
+    private List<CharacterManifestDTO> characters;
+}

--- a/src/main/java/com/kw/readwith/repository/ChapterRelationshipEdgeRepository.java
+++ b/src/main/java/com/kw/readwith/repository/ChapterRelationshipEdgeRepository.java
@@ -1,0 +1,34 @@
+package com.kw.readwith.repository;
+
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.mapping.ChapterRelationshipEdge;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChapterRelationshipEdgeRepository extends JpaRepository<ChapterRelationshipEdge, Long> {
+    
+    /**
+     * 특정 책의 특정 챕터까지의 모든 관계 엣지 조회 (거시 그래프용)
+     */
+    @Query("SELECT c FROM ChapterRelationshipEdge c " +
+           "WHERE c.book = :book AND c.chapterIdx <= :uptoChapter " +
+           "ORDER BY c.chapterIdx ASC")
+    List<ChapterRelationshipEdge> findByBookAndChapterIdxLessThanEqual(
+            @Param("book") Book book, 
+            @Param("uptoChapter") Integer uptoChapter);
+
+    /**
+     * 특정 책의 모든 관계 엣지 조회 (챕터 순서대로)
+     */
+    List<ChapterRelationshipEdge> findByBookOrderByChapterIdxAsc(Book book);
+
+    /**
+     * 특정 책의 특정 챕터의 관계 엣지 조회
+     */
+    List<ChapterRelationshipEdge> findByBookAndChapterIdx(Book book, Integer chapterIdx);
+}

--- a/src/main/java/com/kw/readwith/repository/CharacterRepository.java
+++ b/src/main/java/com/kw/readwith/repository/CharacterRepository.java
@@ -3,8 +3,11 @@ package com.kw.readwith.repository;
 import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Character;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,4 +18,12 @@ public interface CharacterRepository extends JpaRepository<Character, Long> {
 
     // Book과 name으로 Character를 찾는 메소드
     Optional<Character> findByBookAndName(Book book, String name);
+    
+    /**
+     * 특정 책의 모든 인물을 주요 인물 우선, 이름 순으로 조회
+     */
+    @Query("SELECT c FROM Character c " +
+           "WHERE c.book = :book " +
+           "ORDER BY c.isMainCharacter DESC, c.name ASC")
+    List<Character> findByBookOrderByIsMainCharacterDescNameAsc(@Param("book") Book book);
 }

--- a/src/main/java/com/kw/readwith/repository/EventRelationshipEdgeRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventRelationshipEdgeRepository.java
@@ -4,6 +4,13 @@ import com.kw.readwith.domain.Event;
 import com.kw.readwith.domain.mapping.EventRelationshipEdge;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface EventRelationshipEdgeRepository extends JpaRepository<EventRelationshipEdge, Long> {
     boolean existsByEvent(Event event);
+    
+    /**
+     * 특정 이벤트의 모든 관계 엣지 조회 (세밀 그래프용)
+     */
+    List<EventRelationshipEdge> findByEvent(Event event);
 }

--- a/src/main/java/com/kw/readwith/repository/EventRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventRepository.java
@@ -4,7 +4,10 @@ import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
@@ -14,4 +17,17 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     // Event를 찾는 메소드
     Optional<Event> findByBookAndChapterAndIdx(Book book, Chapter chapter, Integer idx);
+    
+    /**
+     * 특정 챕터의 모든 이벤트를 인덱스 순으로 조회
+     */
+    List<Event> findByChapterOrderByIdx(Chapter chapter);
+    
+    /**
+     * 특정 책의 모든 이벤트를 챕터, 이벤트 순으로 조회
+     */
+    @Query("SELECT e FROM Event e JOIN e.chapter c " +
+           "WHERE e.book = :book " +
+           "ORDER BY c.idx ASC, e.idx ASC")
+    List<Event> findByBookOrderByChapterIdxAscIdxAsc(@Param("book") Book book);
 }

--- a/src/main/java/com/kw/readwith/service/FineGraphService.java
+++ b/src/main/java/com/kw/readwith/service/FineGraphService.java
@@ -1,0 +1,130 @@
+package com.kw.readwith.service;
+
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.Chapter;
+import com.kw.readwith.domain.Event;
+import com.kw.readwith.domain.mapping.EventRelationshipEdge;
+import com.kw.readwith.dto.graph.*;
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FineGraphService {
+
+    private final BookRepository bookRepository;
+    private final ChapterRepository chapterRepository;
+    private final EventRepository eventRepository;
+    private final CharacterRepository characterRepository;
+    private final EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
+
+    /**
+     * 세밀(이벤트) 그래프 조회 - 특정 이벤트에서의 관계
+     */
+    public FineGraphResponseDTO getFineGraph(Long bookId, Integer chapterIdx, Integer eventIdx, Long userId) {
+        // TODO: 사용자 인증 구현 후 접근 권한 검증 로직 추가
+        
+        // 책 존재 확인
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+
+        // 챕터 존재 확인
+        Chapter chapter = chapterRepository.findByBookIdAndIdx(book.getId(), chapterIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+
+        // 이벤트 존재 확인
+        Event event = eventRepository.findByChapterAndIdx(chapter, eventIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND));
+
+        // 해당 이벤트의 모든 관계 엣지 조회
+        List<EventRelationshipEdge> edges = eventRelationshipEdgeRepository.findByEvent(event);
+
+        // 관련된 인물들 추출
+        Set<Long> characterIds = edges.stream()
+                .flatMap(edge -> List.of(edge.getFromCharacter().getId(), edge.getToCharacter().getId()).stream())
+                .collect(Collectors.toSet());
+
+        List<Character> characters = characterRepository.findAllById(characterIds);
+
+        // DTO 변환
+        List<GraphNodeDTO> nodes = characters.stream()
+                .map(this::convertToGraphNodeDTO)
+                .collect(Collectors.toList());
+
+        List<FineGraphEdgeDTO> edgeDTOs = edges.stream()
+                .map(this::convertToFineGraphEdgeDTO)
+                .collect(Collectors.toList());
+
+        EventInfoDTO eventInfo = EventInfoDTO.builder()
+                .chapterIdx(chapterIdx)
+                .eventIdx(eventIdx)
+                .eventText(truncateText(event.getRawText(), 100))
+                .build();
+
+        return FineGraphResponseDTO.builder()
+                .nodes(nodes)
+                .edges(edgeDTOs)
+                .eventInfo(eventInfo)
+                .build();
+    }
+
+    /**
+     * Character를 GraphNodeDTO로 변환
+     */
+    private GraphNodeDTO convertToGraphNodeDTO(Character character) {
+        return GraphNodeDTO.builder()
+                .id(character.getId())
+                .label(character.getName())
+                .isMainCharacter(character.isMainCharacter())
+                .profileImage(character.getProfileImage())
+                .description(truncateText(character.getProfileText(), 200))
+                .portraitPrompt(character.getPersonalityText())
+                .names(character.getNames())
+                .build();
+    }
+
+    /**
+     * EventRelationshipEdge를 FineGraphEdgeDTO로 변환
+     */
+    private FineGraphEdgeDTO convertToFineGraphEdgeDTO(EventRelationshipEdge edge) {
+        List<String> relationTags = edge.getRelationTags() != null ? 
+                Arrays.asList(edge.getRelationTags().split(",")) : 
+                new ArrayList<>();
+
+        return FineGraphEdgeDTO.builder()
+                .from(edge.getFromCharacter().getId())
+                .to(edge.getToCharacter().getId())
+                .weight(edge.getEdgeWeight() != null ? edge.getEdgeWeight().doubleValue() : 0.0)
+                .sentimentScore(edge.getSentimentScore() != null ? edge.getSentimentScore().doubleValue() : 0.0)
+                .interactionCount(edge.getInteractionCount())
+                .relationTags(relationTags)
+                .build();
+    }
+
+    /**
+     * 텍스트를 지정된 길이로 자르기
+     */
+    private String truncateText(String text, int maxLength) {
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+        
+        // 개행 문자 제거 및 공백 정리
+        String cleanText = text.replaceAll("\\s+", " ").trim();
+        
+        if (cleanText.length() <= maxLength) {
+            return cleanText;
+        }
+        
+        return cleanText.substring(0, maxLength - 3) + "...";
+    }
+}

--- a/src/main/java/com/kw/readwith/service/MacroGraphService.java
+++ b/src/main/java/com/kw/readwith/service/MacroGraphService.java
@@ -1,0 +1,116 @@
+package com.kw.readwith.service;
+
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.mapping.ChapterRelationshipEdge;
+import com.kw.readwith.dto.graph.*;
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MacroGraphService {
+
+    private final BookRepository bookRepository;
+    private final CharacterRepository characterRepository;
+    private final ChapterRelationshipEdgeRepository chapterRelationshipEdgeRepository;
+
+    /**
+     * 거시(챕터 누적) 그래프 조회
+     */
+    public MacroGraphResponseDTO getMacroGraph(Long bookId, Integer uptoChapter, Long userId) {
+        // TODO: 사용자 인증 구현 후 접근 권한 검증 로직 추가
+        
+        // 책 존재 확인
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+
+        // 해당 챕터까지의 모든 관계 엣지 조회
+        List<ChapterRelationshipEdge> edges = chapterRelationshipEdgeRepository
+                .findByBookAndChapterIdxLessThanEqual(book, uptoChapter);
+
+        // 관련된 인물들 추출
+        Set<Long> characterIds = edges.stream()
+                .flatMap(edge -> List.of(edge.getFromCharacter().getId(), edge.getToCharacter().getId()).stream())
+                .collect(Collectors.toSet());
+
+        List<Character> characters = characterRepository.findAllById(characterIds);
+
+        // DTO 변환
+        List<GraphNodeDTO> nodes = characters.stream()
+                .map(this::convertToGraphNodeDTO)
+                .collect(Collectors.toList());
+
+        List<MacroGraphEdgeDTO> edgeDTOs = edges.stream()
+                .map(this::convertToMacroGraphEdgeDTO)
+                .collect(Collectors.toList());
+
+        MacroGraphSummaryDTO summary = MacroGraphSummaryDTO.builder()
+                .uptoChapter(uptoChapter)
+                .totalCharacters(characters.size())
+                .totalRelationships(edges.size())
+                .build();
+
+        return MacroGraphResponseDTO.builder()
+                .nodes(nodes)
+                .edges(edgeDTOs)
+                .summary(summary)
+                .build();
+    }
+
+    /**
+     * Character를 GraphNodeDTO로 변환
+     */
+    private GraphNodeDTO convertToGraphNodeDTO(Character character) {
+        return GraphNodeDTO.builder()
+                .id(character.getId())
+                .label(character.getName())
+                .isMainCharacter(character.isMainCharacter())
+                .profileImage(character.getProfileImage())
+                .description(truncateText(character.getProfileText(), 200))
+                .portraitPrompt(character.getPersonalityText())
+                .names(character.getNames())
+                .build();
+    }
+
+    /**
+     * ChapterRelationshipEdge를 MacroGraphEdgeDTO로 변환
+     */
+    private MacroGraphEdgeDTO convertToMacroGraphEdgeDTO(ChapterRelationshipEdge edge) {
+        return MacroGraphEdgeDTO.builder()
+                .from(edge.getFromCharacter().getId())
+                .to(edge.getToCharacter().getId())
+                .cumulativeInteraction(edge.getCumulativeInteraction())
+                .cumulativeSentiment(edge.getCumulativeInteraction() > 0 ? 
+                    edge.getSentimentWeightedSum() / edge.getCumulativeInteraction() : 0.0)
+                .sentimentWeightedSum((double) edge.getSentimentWeightedSum())
+                .chapterIdx(edge.getChapterIdx())
+                .build();
+    }
+
+    /**
+     * 텍스트를 지정된 길이로 자르기
+     */
+    private String truncateText(String text, int maxLength) {
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+        
+        // 개행 문자 제거 및 공백 정리
+        String cleanText = text.replaceAll("\\s+", " ").trim();
+        
+        if (cleanText.length() <= maxLength) {
+            return cleanText;
+        }
+        
+        return cleanText.substring(0, maxLength - 3) + "...";
+    }
+}

--- a/src/main/java/com/kw/readwith/service/ManifestService.java
+++ b/src/main/java/com/kw/readwith/service/ManifestService.java
@@ -1,0 +1,167 @@
+package com.kw.readwith.service;
+
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Chapter;
+import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.Event;
+import com.kw.readwith.dto.manifest.*;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import com.kw.readwith.repository.CharacterRepository;
+import com.kw.readwith.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ManifestService {
+
+    private final BookRepository bookRepository;
+    private final ChapterRepository chapterRepository;
+    private final CharacterRepository characterRepository;
+    private final EventRepository eventRepository;
+
+    /**
+     * 책 구조/캐시 패키지 조회
+     * 책 메타데이터 + 챕터/이벤트 + 인물 정보를 한 번에 제공
+     */
+    public ManifestResponseDTO getBookManifest(Long bookId, Long userId) {
+        // 1. 책 접근 권한 확인 및 조회
+        Book book = validateAndGetBook(bookId, userId);
+        
+        // 2. 챕터 목록 조회
+        List<Chapter> chapters = chapterRepository.findByBookId(bookId);
+        
+        // 3. 인물 목록 조회 (주요 인물 우선, 이름순)
+        List<Character> characters = characterRepository.findByBookOrderByIsMainCharacterDescNameAsc(book);
+        
+        // 4. 모든 이벤트 조회 후 챕터별로 그룹화
+        List<Event> events = eventRepository.findByBookOrderByChapterIdxAscIdxAsc(book);
+        Map<Long, List<Event>> eventsByChapter = events.stream()
+                .collect(Collectors.groupingBy(event -> event.getChapter().getId()));
+        
+        // 5. DTO 변환
+        return ManifestResponseDTO.builder()
+                .book(convertToBookManifestDTO(book))
+                .chapters(convertToChapterManifestDTOs(chapters, eventsByChapter))
+                .characters(convertToCharacterManifestDTOs(characters))
+                .build();
+    }
+
+    /**
+     * 책 접근 권한 확인 및 조회
+     */
+    private Book validateAndGetBook(Long bookId, Long userId) {
+        Book book;
+        if (userId == null) {
+            // 비로그인 사용자: 기본 제공 + 요약 완료만
+            book = bookRepository.findByIdAndSummaryTrueAndIsDefaultTrue(bookId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+        } else {
+            // 로그인 사용자: 기본 제공 + 본인 업로드 + 요약 완료만
+            book = bookRepository.findAccessibleBook(bookId, userId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+        }
+        return book;
+    }
+
+    /**
+     * Book -> BookManifestDTO 변환
+     */
+    private BookManifestDTO convertToBookManifestDTO(Book book) {
+        return BookManifestDTO.builder()
+                .id(book.getId())
+                .title(book.getTitle())
+                .author(book.getAuthor())
+                .language(book.getLanguage())
+                .isDefault(book.isDefault())
+                .summary(book.isSummary())
+                .coverImgUrl(book.getCoverImgUrl())
+                .summaryUrl(book.getSummaryUrl())
+                .epubPath(book.getEpubPath())
+                .build();
+    }
+
+    /**
+     * Chapter 목록 -> ChapterManifestDTO 목록 변환
+     */
+    private List<ChapterManifestDTO> convertToChapterManifestDTOs(
+            List<Chapter> chapters, 
+            Map<Long, List<Event>> eventsByChapter) {
+        
+        return chapters.stream()
+                .map(chapter -> {
+                    List<Event> chapterEvents = eventsByChapter.getOrDefault(chapter.getId(), List.of());
+                    return ChapterManifestDTO.builder()
+                            .idx(chapter.getIdx())
+                            .title(chapter.getTitle())
+                            .startPos(chapter.getStartPos())
+                            .endPos(chapter.getEndPos())
+                            .rawText(truncateText(chapter.getRawText(), 200)) // 원본 텍스트 일부만
+                            .summaryText(chapter.getSummaryText())
+                            .summaryUploadUrl(chapter.getSummaryUploadUrl())
+                            .povSummariesCached(chapter.isPovSummariesCached())
+                            .events(convertToEventManifestDTOs(chapterEvents))
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Event 목록 -> EventManifestDTO 목록 변환
+     */
+    private List<EventManifestDTO> convertToEventManifestDTOs(List<Event> events) {
+        return events.stream()
+                .map(event -> EventManifestDTO.builder()
+                        .idx(event.getIdx())
+                        .startPos(event.getStartPos())
+                        .endPos(event.getEndPos())
+                        .rawText(truncateText(event.getRawText(), 300)) // 원본 텍스트 일부
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Character 목록 -> CharacterManifestDTO 목록 변환
+     */
+    private List<CharacterManifestDTO> convertToCharacterManifestDTOs(List<Character> characters) {
+        return characters.stream()
+                .map(character -> CharacterManifestDTO.builder()
+                        .id(character.getCharacterId()) // 책 내 고유 ID 사용
+                        .name(character.getName())
+                        .names(character.getNames())
+                        .profileImage(character.getProfileImage())
+                        .isMainCharacter(character.isMainCharacter())
+                        .firstChapterIdx(character.getFirstChapterIdx())
+                        .personalityText(character.getPersonalityText())
+                        .profileText(character.getProfileText())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 텍스트를 지정된 길이로 자르기
+     */
+    private String truncateText(String text, int maxLength) {
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+        
+        // 개행 문자 제거 및 공백 정리
+        String cleanText = text.replaceAll("\\s+", " ").trim();
+        
+        if (cleanText.length() <= maxLength) {
+            return cleanText;
+        }
+        
+        return cleanText.substring(0, maxLength - 3) + "...";
+    }
+}

--- a/src/main/java/com/kw/readwith/web/controller/GraphController.java
+++ b/src/main/java/com/kw/readwith/web/controller/GraphController.java
@@ -1,0 +1,62 @@
+package com.kw.readwith.web.controller;
+
+import com.kw.readwith.apiPayload.ApiResponse;
+import com.kw.readwith.dto.graph.FineGraphResponseDTO;
+import com.kw.readwith.dto.graph.MacroGraphResponseDTO;
+import com.kw.readwith.service.FineGraphService;
+import com.kw.readwith.service.MacroGraphService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/graph")
+@RequiredArgsConstructor
+@Tag(name = "Graph", description = "인물 관계 그래프 API")
+public class GraphController {
+
+    private final FineGraphService fineGraphService;
+    private final MacroGraphService macroGraphService;
+
+    /**
+     * 세밀(이벤트) 그래프 조회
+     */
+    @GetMapping("/fine")
+    @Operation(
+            summary = "세밀(이벤트) 그래프 조회",
+            description = "특정 이벤트에서의 인물 관계 그래프를 조회합니다. 해당 이벤트에 존재하는 EventRelationshipEdge를 기반으로 관계 데이터를 반환합니다."
+    )
+    public ApiResponse<FineGraphResponseDTO> getFineGraph(
+            @Parameter(description = "책 ID", required = true, example = "1")
+            @RequestParam Long bookId,
+            @Parameter(description = "챕터 인덱스", required = true, example = "1")
+            @RequestParam Integer chapterIdx,
+            @Parameter(description = "이벤트 인덱스", required = true, example = "3")
+            @RequestParam Integer eventIdx) {
+
+        Long userId = 1L; // TODO: 실제 인증된 사용자 ID로 교체
+        FineGraphResponseDTO response = fineGraphService.getFineGraph(bookId, chapterIdx, eventIdx, userId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    /**
+     * 거시(챕터 누적) 그래프 조회
+     */
+    @GetMapping("/macro")
+    @Operation(
+            summary = "거시(챕터 누적) 그래프 조회",
+            description = "특정 챕터까지의 누적 인물 관계 그래프를 조회합니다. ChapterRelationshipEdge 기반으로 챕터별 누적 관계를 반환합니다."
+    )
+    public ApiResponse<MacroGraphResponseDTO> getMacroGraph(
+            @Parameter(description = "책 ID", required = true, example = "1")
+            @RequestParam Long bookId,
+            @Parameter(description = "조회할 마지막 챕터 인덱스", required = true, example = "3")
+            @RequestParam Integer uptoChapter) {
+
+        Long userId = 1L; // TODO: 실제 인증된 사용자 ID로 교체
+        MacroGraphResponseDTO response = macroGraphService.getMacroGraph(bookId, uptoChapter, userId);
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/kw/readwith/web/controller/ManifestController.java
+++ b/src/main/java/com/kw/readwith/web/controller/ManifestController.java
@@ -1,0 +1,62 @@
+package com.kw.readwith.web.controller;
+
+import com.kw.readwith.apiPayload.ApiResponse;
+import com.kw.readwith.dto.manifest.ManifestResponseDTO;
+import com.kw.readwith.service.ManifestService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/books")
+@RequiredArgsConstructor
+@Tag(name = "Manifest", description = "책 구조 패키지 API")
+public class ManifestController {
+
+    private final ManifestService manifestService;
+
+    /**
+     * 책 구조/캐시 패키지 조회
+     * 책 메타데이터 + 챕터/이벤트 + 인물 정보를 한 번에 제공하여 뷰어 초기화를 돕습니다.
+     * 개인화 데이터(진도, 즐겨찾기, 북마크)는 별도 API에서 조회해야 합니다.
+     */
+    @GetMapping("/{bookId}/manifest")
+    @Operation(
+        summary = "책 구조 패키지 조회",
+        description = "책 메타데이터, 챕터/이벤트 구조, 인물 정보를 한 번에 제공합니다. " +
+                     "뷰어 초기화에 필요한 공용 데이터를 포함하며, " +
+                     "개인화 데이터(진도, 즐겨찾기 등)는 별도 API에서 조회해야 합니다."
+    )
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", 
+            description = "책 구조 패키지 조회 성공"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404", 
+            description = "책을 찾을 수 없거나 접근 권한이 없음"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400", 
+            description = "잘못된 요청 파라미터"
+        )
+    })
+    public ApiResponse<ManifestResponseDTO> getBookManifest(
+            @Parameter(
+                description = "책 ID", 
+                required = true,
+                example = "42"
+            )
+            @PathVariable Long bookId) {
+        
+        // TODO: 실제 인증된 사용자 ID 가져오기
+        // 현재는 임시로 하드코딩된 값 사용
+        Long userId = 1L; // JWT에서 추출해야 함
+        
+        ManifestResponseDTO response = manifestService.getBookManifest(bookId, userId);
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: update
+          auto: create
         default_batch_fetch_size: 1000
   servlet:
     multipart:


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
Manifest API 및 Graph API 구현 + 테스트 데이터 추가
책 메타데이터 조회와 인물 관계 그래프 시각화를 위한 API 구현 및 완전한 테스트 환경 구축

✨ 추가된 API
- GET /api/books/{id}/manifest - 책 구조 패키지 (메타데이터, 챕터, 이벤트, 인물)
- GET /api/graph/fine - 특정 이벤트의 인물 관계 그래프
- GET /api/graph/macro - 챕터별 누적 인물 관계 그래프

## 📋 변경 사항
Manifest API
- ManifestController, ManifestService - 책 구조 데이터 제공
- Manifest DTO 패키지 (BookManifestDTO, ChapterManifestDTO, EventManifestDTO, CharacterManifestDTO)
- WebConfig - ETag 캐싱 지원 (ShallowEtagHeaderFilter)

Graph API
- GraphController - 통합 그래프 API 엔드포인트
- FineGraphService, MacroGraphService - 세밀/거시 그래프 비즈니스 로직
- ChapterRelationshipEdgeRepository - 챕터별 누적 관계 조회
- Graph DTO 패키지 (GraphNodeDTO, FineGraphEdgeDTO, MacroGraphEdgeDTO 등)

테스트 데이터
- DataLoader 대폭 확장 - 완전한 테스트 시나리오 구축
- 해리포터, 반지의 제왕 샘플 데이터 (챕터, 이벤트, 인물, 관계) - 실제 데이터 x 출력 확인용.
- 관계 그래프 샘플 데이터 (EventRelationshipEdge, ChapterRelationshipEdge)

수정사항
- Event 엔티티 JPA 매핑 수정 (@Entity(name) → @Entity @Table(name))
- Repository 쿼리 메서드 추가 (정렬, 필터링)

## 🔍 Code Review
- 에러 처리 및 Swagger 문서화
- ETag 캐싱으로 성능 최적화
- 트랜잭션 적용 및 데이터 무결성 보장

## 📸 ScreenShot
