### PR TITLE
feat: 다중 파일 업로드 기능 구현 및 관리자 기능 서비스 분리

### DIFF
--- a/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
@@ -51,6 +51,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NO_EVENTS_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4012", "삭제할 이벤트 데이터가 존재하지 않습니다."),
     NO_SUMMARY_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4013", "삭제할 POV 요약본이 존재하지 않습니다."),
     NO_RELATIONSHIPS_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4015", "삭제할 관계 정보가 존재하지 않습니다."),
+    INVALID_FILE_NAME_FORMAT(HttpStatus.BAD_REQUEST, "ADMIN4016", "잘못된 형식의 파일 이름입니다. 'chapter<숫자>_perspective_summaries.json' 형식을 따라야 합니다."),
 
     // Bookmark
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOKMARK4001", "해당 북마크를 찾을 수 없습니다."),

--- a/src/main/java/com/kw/readwith/repository/ChapterRepository.java
+++ b/src/main/java/com/kw/readwith/repository/ChapterRepository.java
@@ -12,7 +12,8 @@ import java.util.Optional;
 @Repository
 public interface ChapterRepository extends JpaRepository<Chapter, Long> {
 
-    @Query("SELECT c FROM Chapter c WHERE c.povSummariesCached = false AND c.summaryUploadUrl IS NOT NULL")
+    // POV 요약이 완료되지 않은 모든 챕터를 조회
+    @Query("SELECT c FROM Chapter c WHERE c.povSummariesCached = false")
     List<Chapter> findUnsummarizedChapters();
 
     // bookId와 chapterIdx로 확인

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -29,6 +29,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -80,48 +82,68 @@ public class AdminService {
         }
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void uploadEvents(Long bookId, Integer chapterIdx, MultipartFile file) {
+    /**
+     * 여러 챕터의 이벤트 JSON 파일들을 한번에 업로드합니다.
+     * 파일 이름(chapter<번호>_events.json)에서 챕터 번호를 자동으로 인식하여 처리하며,
+     * 트랜잭션으로 동작하여 하나라도 실패 시 모든 작업이 롤백됩니다.
+     * @param bookId 이벤트를 추가할 책의 ID
+     * @param eventFiles 'chapter<번호>_events.json' 형식의 파일 목록
+     */
+    @Transactional
+    public void uploadEvents(Long bookId, List<MultipartFile> eventFiles) {
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
-        // Repository의 기존 메소드에 맞게 book.getId()와 chapterIdx를 전달
-        Chapter chapter = chapterRepository.findByBookIdAndIdx(book.getId(), chapterIdx)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+        // DB에 한번에 저장하기 위해 모든 이벤트를 담을 리스트
+        List<Event> allNewEvents = new ArrayList<>();
+        // 파일명에서 챕터 번호를 추출하기 위한 정규표현식
+        Pattern pattern = Pattern.compile("chapter(\\d+)_events\\.json");
 
-        // 해당 책에 속한 챕터가 맞는지 확인
-        if (!chapter.getBook().getId().equals(book.getId())) {
-            throw new GeneralException(ErrorStatus.CHAPTER_NOT_BELONG_TO_BOOK);
-        }
+        for (MultipartFile eventFile : eventFiles) {
+            String filename = eventFile.getOriginalFilename();
+            Matcher matcher = pattern.matcher(filename);
 
-        // Book과 Chapter를 함께 사용하여 데이터가 이미 존재하는지 확인
-        if (eventRepository.existsByBookAndChapter(book, chapter)) {
-            throw new GeneralException(ErrorStatus.EVENT_DATA_ALREADY_EXISTS);
-        }
-
-        try {
-            // JSON 파일을 DTO 리스트로 파싱
-            List<EventDTO> eventDTOs = objectMapper.readValue(file.getInputStream(), new TypeReference<List<EventDTO>>() {});
-
-            // DTO를 Entity로 변환
-            List<Event> newEvents = eventDTOs.stream()
-                    .map(dto -> Event.builder()
-                            .startPos(dto.getStart())
-                            .endPos(dto.getEnd())
-                            .rawText(dto.getText())
-                            .idx(dto.getEventId())
-                            .chapter(chapter)
-                            .book(book)
-                            .build())
-                    .collect(Collectors.toList());
-
-            // 데이터베이스에 저장
-            if (!newEvents.isEmpty()) {
-                eventRepository.saveAllAndFlush(newEvents);
+            if (!matcher.matches()) {
+                throw new GeneralException(ErrorStatus.INVALID_FILE_NAME_FORMAT, "파일명: " + filename);
             }
 
-        } catch (IOException e) {
-            throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
+            // 파일명에서 챕터 번호 추출 및 해당 챕터 조회
+            Integer chapterIdx = Integer.parseInt(matcher.group(1));
+            Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND, "챕터 인덱스 " + chapterIdx + "를 찾을 수 없습니다."));
+
+            // 이미 이벤트가 있는 챕터는 업로드 불가
+            if (eventRepository.existsByChapter(chapter)) {
+                throw new GeneralException(ErrorStatus.EVENT_DATA_ALREADY_EXISTS, "챕터 " + chapterIdx + "의 이벤트는 이미 존재합니다.");
+            }
+
+            try {
+                // JSON 파일을 DTO 리스트로 파싱
+                List<EventDTO> eventDTOs = objectMapper.readValue(eventFile.getInputStream(), new TypeReference<List<EventDTO>>() {});
+
+                // DTO 리스트를 Entity로 변환
+                List<Event> newEventsFromFile = eventDTOs.stream()
+                        .map(dto -> Event.builder()
+                                .book(book)
+                                .chapter(chapter)
+                                .idx(dto.getEventId())
+                                .startPos(dto.getStart())
+                                .endPos(dto.getEnd())
+                                .rawText(dto.getText())
+                                .build())
+                        .collect(Collectors.toList());
+
+                allNewEvents.addAll(newEventsFromFile);
+
+            } catch (IOException e) {
+                // 파일 입출력 또는 JSON 형식 오류 시 예외 발생
+                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
+            }
+        }
+
+        // 모든 파일 처리가 성공하면, 수집된 모든 이벤트를 DB에 한번에 저장
+        if (!allNewEvents.isEmpty()) {
+            eventRepository.saveAll(allNewEvents);
         }
     }
 

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -7,15 +7,21 @@ import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Chapter;
-import com.kw.readwith.domain.Event;
 import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.Event;
+import com.kw.readwith.domain.mapping.CharacterPovSummary;
 import com.kw.readwith.domain.mapping.EventRelationshipEdge;
 import com.kw.readwith.dto.admin.CharacterDTO;
 import com.kw.readwith.dto.admin.EventDTO;
 import com.kw.readwith.dto.admin.RelationshipDTO;
 import com.kw.readwith.dto.admin.RelationshipUploadDTO;
+import com.kw.readwith.dto.admin.UnsummarizedItemDTO;
+import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.repository.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -27,24 +33,37 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true) // 기본적으로 읽기 전용 트랜잭션으로 설정
 public class AdminService {
 
     private static final Logger log = LoggerFactory.getLogger(AdminService.class);
 
+    // 모든 관리자 기능에 필요한 Repository 및 ObjectMapper 의존성 주입
     private final BookRepository bookRepository;
     private final CharacterRepository characterRepository;
     private final ChapterRepository chapterRepository;
     private final EventRepository eventRepository;
     private final EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
+    private final CharacterPovSummaryRepository characterPovSummaryRepository;
     private final ObjectMapper objectMapper;
 
+    /*
+     * =====================================================================================
+     * 1. 데이터 업로드
+     * =====================================================================================
+     */
+
+    /**
+     * 등장인물 정보가 담긴 JSON 파일을 업로드합니다.
+     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void uploadCharacters(Long bookId, MultipartFile file) {
         Book book = bookRepository.findById(bookId)
@@ -55,7 +74,7 @@ public class AdminService {
 
             List<Character> newCharacters = new ArrayList<>();
             for (CharacterDTO dto : characterListDTO.getCharacters()) {
-                // snake_case 필드에 맞는 getter 호출
+                // 중복 저장을 방지하기 위해, 해당 이름의 캐릭터가 없는 경우에만 추가
                 Optional<Character> existingCharacter = characterRepository.findByBookAndName(book, dto.getCommon_name());
 
                 if (existingCharacter.isEmpty()) {
@@ -72,7 +91,6 @@ public class AdminService {
                 }
             }
 
-            // 데이터베이스에 저장
             if (!newCharacters.isEmpty()) {
                 characterRepository.saveAll(newCharacters);
             }
@@ -84,17 +102,13 @@ public class AdminService {
 
     /**
      * 여러 챕터의 이벤트 JSON 파일들을 한번에 업로드합니다.
-     * 파일 이름(chapter<번호>_events.json)에서 챕터 번호를 자동으로 인식하여 처리하며,
-     * 트랜잭션으로 동작하여 하나라도 실패 시 모든 작업이 롤백됩니다.
-     * @param bookId 이벤트를 추가할 책의 ID
-     * @param eventFiles 'chapter<번호>_events.json' 형식의 파일 목록
+     * 파일 이름(chapter<번호>_events.json)에서 챕터 번호를 자동으로 인식합니다.
      */
     @Transactional
     public void uploadEvents(Long bookId, List<MultipartFile> eventFiles) {
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
-        // DB에 한번에 저장하기 위해 모든 이벤트를 담을 리스트
         List<Event> allNewEvents = new ArrayList<>();
         // 파일명에서 챕터 번호를 추출하기 위한 정규표현식
         Pattern pattern = Pattern.compile("chapter(\\d+)_events\\.json");
@@ -107,21 +121,17 @@ public class AdminService {
                 throw new GeneralException(ErrorStatus.INVALID_FILE_NAME_FORMAT, "파일명: " + filename);
             }
 
-            // 파일명에서 챕터 번호 추출 및 해당 챕터 조회
             Integer chapterIdx = Integer.parseInt(matcher.group(1));
             Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
                     .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND, "챕터 인덱스 " + chapterIdx + "를 찾을 수 없습니다."));
 
-            // 이미 이벤트가 있는 챕터는 업로드 불가
+            // 이미 데이터가 있는 챕터는 업로드 불가
             if (eventRepository.existsByChapter(chapter)) {
                 throw new GeneralException(ErrorStatus.EVENT_DATA_ALREADY_EXISTS, "챕터 " + chapterIdx + "의 이벤트는 이미 존재합니다.");
             }
 
             try {
-                // JSON 파일을 DTO 리스트로 파싱
                 List<EventDTO> eventDTOs = objectMapper.readValue(eventFile.getInputStream(), new TypeReference<List<EventDTO>>() {});
-
-                // DTO 리스트를 Entity로 변환
                 List<Event> newEventsFromFile = eventDTOs.stream()
                         .map(dto -> Event.builder()
                                 .book(book)
@@ -132,21 +142,82 @@ public class AdminService {
                                 .rawText(dto.getText())
                                 .build())
                         .collect(Collectors.toList());
-
                 allNewEvents.addAll(newEventsFromFile);
-
             } catch (IOException e) {
-                // 파일 입출력 또는 JSON 형식 오류 시 예외 발생
                 throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
             }
         }
 
-        // 모든 파일 처리가 성공하면, 수집된 모든 이벤트를 DB에 한번에 저장
+        // 모든 파일 유효성 검사가 끝난 후, DB에 한번에 저장
         if (!allNewEvents.isEmpty()) {
             eventRepository.saveAll(allNewEvents);
         }
     }
 
+    /**
+     * 여러 챕터의 POV 요약 JSON 파일들을 한번에 업로드합니다.
+     */
+    @Transactional
+    public void uploadChapterSummaries(Long bookId, List<MultipartFile> summaryFiles) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+
+        List<CharacterPovSummary> allNewSummaries = new ArrayList<>();
+        Pattern pattern = Pattern.compile("chapter(\\d+)_perspective_summaries\\.json");
+
+        for (MultipartFile summaryFile : summaryFiles) {
+            String filename = summaryFile.getOriginalFilename();
+            Matcher matcher = pattern.matcher(filename);
+
+            if (!matcher.matches()) {
+                throw new GeneralException(ErrorStatus.INVALID_FILE_NAME_FORMAT, "파일명: " + filename);
+            }
+
+            Integer chapterIdx = Integer.parseInt(matcher.group(1));
+            Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND, "챕터 인덱스 " + chapterIdx + "를 찾을 수 없습니다."));
+
+            if (characterPovSummaryRepository.existsByChapter(chapter)) {
+                throw new GeneralException(ErrorStatus.CHAPTER_ALREADY_SUMMARIZED, "챕터 " + chapterIdx + "의 요약본은 이미 존재합니다.");
+            }
+
+            Map<String, PovSummaryData> summaries;
+            try {
+                summaries = objectMapper.readValue(summaryFile.getInputStream(), new TypeReference<>() {});
+            } catch (IOException e) {
+                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
+            }
+
+            List<CharacterPovSummary> newSummariesFromFile = summaries.entrySet().stream().map(entry -> {
+                Long characterId = Long.parseLong(entry.getKey());
+                PovSummaryData summaryData = entry.getValue();
+                Character character = characterRepository.findByBookAndCharacterId(chapter.getBook(), characterId)
+                        .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "Character not found with jsonId: " + characterId));
+
+                return CharacterPovSummary.builder()
+                        .book(chapter.getBook())
+                        .chapter(chapter)
+                        .character(character)
+                        .summaryText(summaryData.getSummary())
+                        .build();
+            }).collect(Collectors.toList());
+
+            allNewSummaries.addAll(newSummariesFromFile);
+            // 해당 챕터의 요약이 완료되었음을 표시
+            chapter.markAsSummarized();
+        }
+
+        if (!allNewSummaries.isEmpty()) {
+            characterPovSummaryRepository.saveAll(allNewSummaries);
+        }
+
+        // 모든 챕터의 요약이 완료되었는지 확인 후, 책의 전체 요약 상태 업데이트
+        checkAndUpdateBookSummaryStatus(book);
+    }
+
+    /**
+     * 특정 이벤트의 관계 정보가 담긴 JSON 파일을 업로드합니다.
+     */
     @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.READ_COMMITTED)
     public void uploadRelationships(Long bookId, Integer chapterIdx, Integer eventIdx, MultipartFile file) {
         Book book = bookRepository.findById(bookId)
@@ -158,14 +229,12 @@ public class AdminService {
         Event event = eventRepository.findByBookAndChapterAndIdx(book, chapter, eventIdx)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND));
 
-        // 데이터가 이미 존재하는지 확인
         if (eventRelationshipEdgeRepository.existsByEvent(event)) {
             throw new GeneralException(ErrorStatus.RELATIONSHIP_DATA_ALREADY_EXISTS);
         }
 
         RelationshipUploadDTO uploadDTO;
         try {
-            // JSON 파일을 DTO로 파싱
             uploadDTO = objectMapper.readValue(file.getInputStream(), RelationshipUploadDTO.class);
         } catch (IOException e) {
             throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
@@ -173,14 +242,12 @@ public class AdminService {
 
         List<EventRelationshipEdge> newEdges = new ArrayList<>();
         for (RelationshipDTO dto : uploadDTO.getRelations()) {
-            // DTO에서 Character 찾아오기
             Character fromChar = characterRepository.findByBookAndCharacterId(book, dto.getId1().longValue())
                     .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "From Character not found with jsonId: " + dto.getId1()));
             Character toChar = characterRepository.findByBookAndCharacterId(book, dto.getId2().longValue())
                     .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "To Character not found with jsonId: " + dto.getId2()));
 
             try {
-                // DTO를 Entity로 변환
                 EventRelationshipEdge edge = EventRelationshipEdge.builder()
                         .fromCharacter(fromChar)
                         .toCharacter(toChar)
@@ -196,9 +263,140 @@ public class AdminService {
             }
         }
 
-        // 데이터베이스에 저장
         if (!newEdges.isEmpty()) {
             eventRelationshipEdgeRepository.saveAll(newEdges);
         }
+    }
+
+    /*
+     * =====================================================================================
+     * 2. 데이터 조회
+     * =====================================================================================
+     */
+
+    /**
+     * 전체 요약이 완료되지 않은 책 목록을 조회합니다.
+     */
+    public List<BookSummaryDTO> getUnsummarizedBooks() {
+        List<Book> books = bookRepository.findBySummaryIsFalse();
+        return books.stream()
+                .map(book -> BookSummaryDTO.builder()
+                        .id(book.getId())
+                        .title(book.getTitle())
+                        .author(book.getAuthor())
+                        .coverImgUrl(book.getCoverImgUrl())
+                        .isDefault(book.isDefault())
+                        .isFavorite(false) // 관리자 페이지에서는 즐겨찾기 정보가 불필요
+                        .updatedAt(book.getUpdatedAt())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * POV 요약본이 없는 챕터 목록을 조회합니다.
+     */
+    public List<UnsummarizedItemDTO> getUnsummarizedChapters() {
+        return chapterRepository.findUnsummarizedChapters().stream()
+                .map(UnsummarizedItemDTO::from)
+                .collect(Collectors.toList());
+    }
+
+    /*
+     * =====================================================================================
+     * 3. 데이터 삭제
+     * =====================================================================================
+     */
+
+    /**
+     * 특정 책에 속한 모든 등장인물을 삭제합니다.
+     */
+    @Transactional
+    public void deleteCharacters(Long bookId) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+
+        if (!characterRepository.existsByBook(book)) {
+            throw new GeneralException(ErrorStatus.NO_CHARACTERS_TO_DELETE);
+        }
+        characterRepository.deleteByBook(book);
+    }
+
+    /**
+     * 특정 챕터에 속한 모든 이벤트를 삭제합니다.
+     */
+    @Transactional
+    public void deleteEvents(Long bookId, Integer chapterIdx) {
+        Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+
+        if (!eventRepository.existsByChapter(chapter)) {
+            throw new GeneralException(ErrorStatus.NO_EVENTS_TO_DELETE);
+        }
+        eventRepository.deleteByChapter(chapter);
+    }
+
+    /**
+     * 특정 챕터의 모든 POV 요약본을 삭제합니다.
+     */
+    @Transactional
+    public void deleteChapterSummary(Long bookId, Integer chapterIdx) {
+        Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+
+        if (!characterPovSummaryRepository.existsByChapter(chapter)) {
+            throw new GeneralException(ErrorStatus.NO_SUMMARY_TO_DELETE);
+        }
+        characterPovSummaryRepository.deleteByChapter(chapter);
+        // 챕터의 요약 상태를 '미완료'로 되돌림
+        chapter.markPovSummariesAsUncached();
+    }
+
+    /**
+     * 특정 이벤트에 연결된 모든 관계 정보를 삭제합니다.
+     */
+    @Transactional
+    public void deleteRelationships(Long bookId, Integer chapterIdx, Integer eventIdx) {
+        Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+
+        Event event = eventRepository.findByChapterAndIdx(chapter, eventIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND));
+
+        if (!eventRelationshipEdgeRepository.existsByEvent(event)) {
+            throw new GeneralException(ErrorStatus.NO_RELATIONSHIPS_TO_DELETE);
+        }
+        eventRelationshipEdgeRepository.deleteByEvent(event);
+    }
+
+    /*
+     * =====================================================================================
+     * 4. 내부 헬퍼 메소드 및 클래스
+     * =====================================================================================
+     */
+
+    /**
+     * 책에 속한 모든 챕터의 요약이 완료되었는지 확인하고, 책의 전체 요약 상태를 업데이트합니다.
+     */
+    private void checkAndUpdateBookSummaryStatus(Book book) {
+        // 이미 완료된 책은 검사할 필요 없음
+        if (book.isSummary()) {
+            return;
+        }
+        List<Chapter> chapters = chapterRepository.findByBookId(book.getId());
+        boolean allChaptersSummarized = chapters.stream().allMatch(Chapter::isPovSummariesCached);
+        if (allChaptersSummarized) {
+            book.completeSummary();
+        }
+    }
+
+    /**
+     * POV 요약본 JSON 파일 파싱을 위한 내부 전용 클래스
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    private static class PovSummaryData {
+        private String character_name;
+        private String summary;
     }
 }

--- a/src/main/java/com/kw/readwith/service/BookService.java
+++ b/src/main/java/com/kw/readwith/service/BookService.java
@@ -35,6 +35,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -219,47 +222,81 @@ public class BookService {
         private String summary;
     }
 
+    /**
+     * 여러 챕터의 POV 요약 JSON 파일들을 한번에 업로드합니다.
+     * 파일 이름(chapter<번호>_...)에서 챕터 번호를 자동으로 인식하여 처리하며,
+     * 트랜잭션으로 동작하여 하나라도 실패 시 모든 작업이 롤백됩니다.
+     * @param bookId 요약본을 추가할 책의 ID
+     * @param summaryFiles 'chapter<번호>_perspective_summaries.json' 형식의 파일 목록
+     */
     @Transactional
-    public void uploadChapterSummary(Long bookId, Integer chapterIdx, MultipartFile summaryFile) {
-        Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+    public void uploadChapterSummaries(Long bookId, List<MultipartFile> summaryFiles) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
-        // 데이터가 이미 존재하는지 먼저 확인
-        if (characterPovSummaryRepository.existsByChapter(chapter)) {
-            throw new GeneralException(ErrorStatus.CHAPTER_ALREADY_SUMMARIZED);
+        // 처리된 모든 POV 요약을 모아 DB에 한번에 저장하기 위한 리스트
+        List<CharacterPovSummary> allNewSummaries = new ArrayList<>();
+        // 파일명에서 챕터 번호를 추출하기 위한 정규표현식
+        Pattern pattern = Pattern.compile("chapter(\\d+)_perspective_summaries\\.json");
+
+        for (MultipartFile summaryFile : summaryFiles) {
+            String filename = summaryFile.getOriginalFilename();
+            Matcher matcher = pattern.matcher(filename);
+
+            // 파일 이름 형식 검증
+            if (!matcher.matches()) {
+                throw new GeneralException(ErrorStatus.INVALID_FILE_NAME_FORMAT, "파일명: " + filename);
+            }
+
+            Integer chapterIdx = Integer.parseInt(matcher.group(1));
+
+            Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND, "챕터 인덱스 " + chapterIdx + "를 찾을 수 없습니다."));
+
+            // 이미 요약본이 있는 챕터는 업로드 불가
+            // 예외 발생 시 @Transactional에 의해 지금까지의 모든 작업이 롤백
+            if (characterPovSummaryRepository.existsByChapter(chapter)) {
+                throw new GeneralException(ErrorStatus.CHAPTER_ALREADY_SUMMARIZED, "챕터 " + chapterIdx + "의 요약본은 이미 존재합니다.");
+            }
+
+            Map<String, PovSummaryData> summaries;
+            try {
+                summaries = objectMapper.readValue(summaryFile.getInputStream(), new TypeReference<>() {});
+            } catch (IOException e) {
+                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
+            }
+
+            List<CharacterPovSummary> newSummariesFromFile = summaries.entrySet().stream().map(entry -> {
+                Long characterId = Long.parseLong(entry.getKey());
+                PovSummaryData summaryData = entry.getValue();
+                Character character = characterRepository.findByBookAndCharacterId(chapter.getBook(), characterId)
+                        .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "Character not found with jsonId: " + characterId));
+
+                return CharacterPovSummary.builder()
+                        .book(chapter.getBook())
+                        .chapter(chapter)
+                        .character(character)
+                        .summaryText(summaryData.getSummary())
+                        .build();
+            }).collect(Collectors.toList());
+
+            allNewSummaries.addAll(newSummariesFromFile);
+
+            chapter.markAsSummarized();
+        }
+        // 모든 파일 처리가 성공하면, 요약본들을 DB에 한번에 저장
+        if (!allNewSummaries.isEmpty()) {
+            characterPovSummaryRepository.saveAll(allNewSummaries);
         }
 
-        Map<String, PovSummaryData> summaries;
-        try {
-            summaries = objectMapper.readValue(summaryFile.getInputStream(), new TypeReference<>() {});
-        } catch (IOException e) {
-            throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
-        }
-
-        List<CharacterPovSummary> newSummaries = summaries.entrySet().stream().map(entry -> {
-            Long characterId = Long.parseLong(entry.getKey());
-            PovSummaryData summaryData = entry.getValue();
-            // JSON의 characterId는 book_character 테이블의 character_id 컬럼 값이므로, book과 함께 조회해야 함
-            Character character = characterRepository.findByBookAndCharacterId(chapter.getBook(), characterId)
-                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "Character not found with jsonId: " + characterId));
-
-            return CharacterPovSummary.builder()
-                    .book(chapter.getBook())
-                    .chapter(chapter)
-                    .character(character)
-                    // summaryData.getSummary()를 호출하여 'summary' 값을 가져옴
-                    .summaryText(summaryData.getSummary())
-                    .build();
-        }).collect(Collectors.toList());
-
-        if (!newSummaries.isEmpty()) {
-            characterPovSummaryRepository.saveAll(newSummaries);
-        }
-
-        chapter.markAsSummarized();
-        checkAndUpdateBookSummaryStatus(chapter.getBook());
+        // 책의 전체 요약 상태를 최종적으로 확인하고 업데이트
+        checkAndUpdateBookSummaryStatus(book);
     }
 
+    /**
+     * 책에 속한 모든 챕터의 요약이 완료되었는지 확인하고, 책의 요약 상태를 업데이트합니다.
+     * @param book 상태를 체크할 책 엔터티
+     */
     private void checkAndUpdateBookSummaryStatus(Book book) {
         if (book.isSummary()) {
             return;

--- a/src/main/java/com/kw/readwith/service/BookService.java
+++ b/src/main/java/com/kw/readwith/service/BookService.java
@@ -6,22 +6,12 @@ import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.aws.s3.AmazonS3Manager;
 import com.kw.readwith.domain.Book;
-import com.kw.readwith.domain.Chapter;
-import com.kw.readwith.domain.Character;
-import com.kw.readwith.domain.Event;
 import com.kw.readwith.domain.User;
-import com.kw.readwith.domain.mapping.CharacterPovSummary;
-import com.kw.readwith.dto.admin.UnsummarizedItemDTO;
 import com.kw.readwith.dto.book.BookDetailDTO;
 import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.repository.BookRepository;
-import com.kw.readwith.repository.ChapterRepository;
-import com.kw.readwith.repository.CharacterPovSummaryRepository;
-import com.kw.readwith.repository.CharacterRepository;
-import com.kw.readwith.repository.EventRepository;
 import com.kw.readwith.repository.FavoriteRepository;
 import com.kw.readwith.repository.UserRepository;
-import com.kw.readwith.repository.EventRelationshipEdgeRepository;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.NoArgsConstructor;
@@ -35,9 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.ArrayList;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -48,12 +35,6 @@ public class BookService {
     private final FavoriteRepository favoriteRepository;
     private final UserRepository userRepository;
     private final AmazonS3Manager amazonS3Manager;
-    private final ChapterRepository chapterRepository;
-    private final CharacterRepository characterRepository;
-    private final CharacterPovSummaryRepository characterPovSummaryRepository;
-    private final EventRepository eventRepository;
-    private final EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
-    private final ObjectMapper objectMapper;
 
     /**
      * 도서 목록 조회 (검색/필터/정렬/즐겨찾기)
@@ -197,179 +178,5 @@ public class BookService {
                 .isFavorite(isFavorite)
                 .summary(book.isSummary())
                 .build();
-    }
-    @Transactional
-    public BookDetailDTO uploadBookSummary(Long bookId, MultipartFile summaryFile) {
-        Book book = bookRepository.findById(bookId).orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
-        if (book.isSummary()) {
-            throw new GeneralException(ErrorStatus.BOOK_ALREADY_SUMMARIZED);
-        }
-        String summaryUrl = "https://s3-dummy-url.com/summaries/books/" + summaryFile.getOriginalFilename();
-        book.updateSummary(summaryUrl);
-        return convertToDetailDTO(book, false);
-    }
-
-    public List<UnsummarizedItemDTO> getUnsummarizedChapters() {
-        return chapterRepository.findUnsummarizedChapters().stream().map(UnsummarizedItemDTO::from).collect(Collectors.toList());
-    }
-
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    private static class PovSummaryData {
-        private String character_name;
-        // JSON의 'summary' 키와 정확히 일치시킴
-        private String summary;
-    }
-
-    /**
-     * 여러 챕터의 POV 요약 JSON 파일들을 한번에 업로드합니다.
-     * 파일 이름(chapter<번호>_...)에서 챕터 번호를 자동으로 인식하여 처리하며,
-     * 트랜잭션으로 동작하여 하나라도 실패 시 모든 작업이 롤백됩니다.
-     * @param bookId 요약본을 추가할 책의 ID
-     * @param summaryFiles 'chapter<번호>_perspective_summaries.json' 형식의 파일 목록
-     */
-    @Transactional
-    public void uploadChapterSummaries(Long bookId, List<MultipartFile> summaryFiles) {
-        Book book = bookRepository.findById(bookId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
-
-        // 처리된 모든 POV 요약을 모아 DB에 한번에 저장하기 위한 리스트
-        List<CharacterPovSummary> allNewSummaries = new ArrayList<>();
-        // 파일명에서 챕터 번호를 추출하기 위한 정규표현식
-        Pattern pattern = Pattern.compile("chapter(\\d+)_perspective_summaries\\.json");
-
-        for (MultipartFile summaryFile : summaryFiles) {
-            String filename = summaryFile.getOriginalFilename();
-            Matcher matcher = pattern.matcher(filename);
-
-            // 파일 이름 형식 검증
-            if (!matcher.matches()) {
-                throw new GeneralException(ErrorStatus.INVALID_FILE_NAME_FORMAT, "파일명: " + filename);
-            }
-
-            Integer chapterIdx = Integer.parseInt(matcher.group(1));
-
-            Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
-                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND, "챕터 인덱스 " + chapterIdx + "를 찾을 수 없습니다."));
-
-            // 이미 요약본이 있는 챕터는 업로드 불가
-            // 예외 발생 시 @Transactional에 의해 지금까지의 모든 작업이 롤백
-            if (characterPovSummaryRepository.existsByChapter(chapter)) {
-                throw new GeneralException(ErrorStatus.CHAPTER_ALREADY_SUMMARIZED, "챕터 " + chapterIdx + "의 요약본은 이미 존재합니다.");
-            }
-
-            Map<String, PovSummaryData> summaries;
-            try {
-                summaries = objectMapper.readValue(summaryFile.getInputStream(), new TypeReference<>() {});
-            } catch (IOException e) {
-                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
-            }
-
-            List<CharacterPovSummary> newSummariesFromFile = summaries.entrySet().stream().map(entry -> {
-                Long characterId = Long.parseLong(entry.getKey());
-                PovSummaryData summaryData = entry.getValue();
-                Character character = characterRepository.findByBookAndCharacterId(chapter.getBook(), characterId)
-                        .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "Character not found with jsonId: " + characterId));
-
-                return CharacterPovSummary.builder()
-                        .book(chapter.getBook())
-                        .chapter(chapter)
-                        .character(character)
-                        .summaryText(summaryData.getSummary())
-                        .build();
-            }).collect(Collectors.toList());
-
-            allNewSummaries.addAll(newSummariesFromFile);
-
-            chapter.markAsSummarized();
-        }
-        // 모든 파일 처리가 성공하면, 요약본들을 DB에 한번에 저장
-        if (!allNewSummaries.isEmpty()) {
-            characterPovSummaryRepository.saveAll(allNewSummaries);
-        }
-
-        // 책의 전체 요약 상태를 최종적으로 확인하고 업데이트
-        checkAndUpdateBookSummaryStatus(book);
-    }
-
-    /**
-     * 책에 속한 모든 챕터의 요약이 완료되었는지 확인하고, 책의 요약 상태를 업데이트합니다.
-     * @param book 상태를 체크할 책 엔터티
-     */
-    private void checkAndUpdateBookSummaryStatus(Book book) {
-        if (book.isSummary()) {
-            return;
-        }
-        List<Chapter> chapters = chapterRepository.findByBookId(book.getId());
-        boolean allChaptersSummarized = chapters.stream().allMatch(Chapter::isPovSummariesCached);
-        if (allChaptersSummarized) {
-            book.completeSummary();
-        }
-    }
-
-    @Transactional(readOnly = true)
-    public List<BookSummaryDTO> getUnsummarizedBooks() {
-        List<Book> books = bookRepository.findBySummaryIsFalse();
-        return books.stream().map(book -> BookSummaryDTO.builder().id(book.getId()).title(book.getTitle()).author(book.getAuthor()).coverImgUrl(book.getCoverImgUrl()).isDefault(book.isDefault()).isFavorite(false).updatedAt(book.getUpdatedAt()).build()).collect(Collectors.toList());
-    }
-
-    @Transactional
-    public void deleteCharacters(Long bookId) {
-        Book book = bookRepository.findById(bookId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
-
-        // 삭제할 데이터가 존재하는지 먼저 확인
-        if (!characterRepository.existsByBook(book)) {
-            throw new GeneralException(ErrorStatus.NO_CHARACTERS_TO_DELETE);
-        }
-
-        characterRepository.deleteByBook(book);
-    }
-
-    @Transactional
-    public void deleteEvents(Long bookId, Integer chapterIdx) {
-        Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
-
-        // 삭제할 데이터가 존재하는지 먼저 확인
-        if (!eventRepository.existsByChapter(chapter)) {
-            throw new GeneralException(ErrorStatus.NO_EVENTS_TO_DELETE);
-        }
-
-        eventRepository.deleteByChapter(chapter);
-    }
-
-    @Transactional
-    public void deleteChapterSummary(Long bookId, Integer chapterIdx) {
-        // 1. 챕터가 존재하는지 확인
-        Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
-
-        // 2. POV 요약본이 존재하는지 확인
-        if (!characterPovSummaryRepository.existsByChapter(chapter)) {
-            throw new GeneralException(ErrorStatus.NO_SUMMARY_TO_DELETE);
-        }
-
-        // 3. 해당 챕터의 모든 챕터 요약본을 삭제
-        characterPovSummaryRepository.deleteByChapter(chapter);
-
-        // 4. 해당 챕터의 요약 상태를 업데이트
-        chapter.markPovSummariesAsUncached();
-    }
-
-    @Transactional
-    public void deleteRelationships(Long bookId, Integer chapterIdx, Integer eventIdx) {
-        Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
-
-        Event event = eventRepository.findByChapterAndIdx(chapter, eventIdx)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND));
-
-        if (!eventRelationshipEdgeRepository.existsByEvent(event)) {
-            throw new GeneralException(ErrorStatus.NO_RELATIONSHIPS_TO_DELETE);
-        }
-
-        eventRelationshipEdgeRepository.deleteByEvent(event);
     }
 }

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -36,7 +36,7 @@ public class AdminController {
         return ApiResponse.onSuccess(response);
     }
 
-    @Operation(summary = "챕터 요약본 업로드 API", description = "특정 책에 대한 챕터별 요약 정보가 담긴 JSON 파일들을 업로드합니다. 파일 이름에서 챕터 번호를 자동 인식합니다.")
+    @Operation(summary = "챕터 요약본 다중 업로드 API", description = "특정 책에 대한 챕터별 요약 정보가 담긴 JSON 파일들을 업로드합니다. 파일 이름에서 챕터 번호를 자동 인식합니다.")
     @PostMapping(value = "/books/{bookId}/summary", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadChapterSummaries(
             @Parameter(description = "요약본을 추가할 책의 ID") @PathVariable Long bookId,
@@ -73,14 +73,15 @@ public class AdminController {
         return ApiResponse.onSuccess("Characters for the book have been successfully deleted.");
     }
 
-    @Operation(summary = "이벤트 정보 업로드 API", description = "책의 특정 챕터에 대한 이벤트 정보(JSON)를 업로드합니다.")
-    @PostMapping(value = "/books/{bookId}/chapters/{chapterIdx}/events", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    // 기존의 단일 이벤트 업로드 API를 다중 업로드 API로 수정
+    @Operation(summary = "이벤트 정보 다중 업로드 API", description = "특정 책에 대한 챕터별 이벤트 정보가 담긴 JSON 파일들을 업로드합니다. 파일 이름에서 챕터 번호를 자동 인식합니다.")
+    @PostMapping(value = "/books/{bookId}/events", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadEvents(
-            @Parameter(description = "이벤트 정보를 추가할 책의 ID") @PathVariable(name = "bookId") Long bookId,
-            @Parameter(description = "이벤트 정보를 추가할 챕터의 순서(index)") @PathVariable(name = "chapterIdx") Integer chapterIdx,
-            @Parameter(description = "이벤트 정보가 담긴 JSON 파일") @RequestParam("file") MultipartFile file) {
-        adminService.uploadEvents(bookId, chapterIdx, file);
-        return ApiResponse.onSuccess("Events uploaded successfully.");
+            @Parameter(description = "이벤트를 추가할 책의 ID") @PathVariable Long bookId,
+            @Parameter(description = "챕터별 이벤트 정보가 담긴 JSON 파일 목록 (파일명: chapter<번호>_events.json)") @RequestParam("files") List<MultipartFile> files) {
+
+        adminService.uploadEvents(bookId, files);
+        return ApiResponse.onSuccess("Events have been successfully uploaded.");
     }
 
     @Operation(summary = "이벤트 정보 삭제 API", description = "특정 챕터에 대한 모든 이벤트 정보를 삭제합니다. 이벤트 정보 업로드 실패 시 사용합니다.")

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -4,7 +4,6 @@ import com.kw.readwith.apiPayload.ApiResponse;
 import com.kw.readwith.dto.admin.UnsummarizedItemDTO;
 import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.service.AdminService;
-import com.kw.readwith.service.BookService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -20,76 +19,39 @@ import java.util.List;
 public class AdminController {
 
     private final AdminService adminService;
-    private final BookService bookService; // BookService 의존성 추가
-
-    @Operation(summary = "미요약 도서 목록 조회 API", description = "전체 책 중에서 요약이 완료되지 않은 책들의 목록을 조회합니다.")
-    @GetMapping("/books/unsummarized")
-    public ApiResponse<List<BookSummaryDTO>> getUnsummarizedBooks() {
-        List<BookSummaryDTO> response = bookService.getUnsummarizedBooks();
-        return ApiResponse.onSuccess(response);
-    }
-
-    @Operation(summary = "미요약 챕터 목록 조회 API", description = "전체 챕터 중에서 요약이 필요한 챕터들의 목록을 조회합니다.")
-    @GetMapping("/chapters/unsummarized")
-    public ApiResponse<List<UnsummarizedItemDTO>> getUnsummarizedChapters() {
-        List<UnsummarizedItemDTO> response = bookService.getUnsummarizedChapters();
-        return ApiResponse.onSuccess(response);
-    }
-
-    @Operation(summary = "챕터 요약본 다중 업로드 API", description = "특정 책에 대한 챕터별 요약 정보가 담긴 JSON 파일들을 업로드합니다. 파일 이름에서 챕터 번호를 자동 인식합니다.")
-    @PostMapping(value = "/books/{bookId}/summary", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<String> uploadChapterSummaries(
-            @Parameter(description = "요약본을 추가할 책의 ID") @PathVariable Long bookId,
-            @Parameter(description = "인물별 요약 정보가 담긴 JSON 파일 목록 (파일명: chapter<번호>_perspective_summaries.json)") @RequestParam("files") List<MultipartFile> files) {
-
-        bookService.uploadChapterSummaries(bookId, files);
-        return ApiResponse.onSuccess("Chapter summaries have been successfully uploaded.");
-    }
-
-    @Operation(summary = "챕터 요약본 삭제 API", description = "특정 챕터에 대한 요약본 정보를 삭제합니다. 요약본 업로드 실패 시 사용합니다.")
-    @DeleteMapping("/books/{bookId}/chapters/{chapterIdx}/summary")
-    public ApiResponse<String> deleteChapterSummary(
-            @Parameter(description = "요약본을 삭제할 책의 ID") @PathVariable Long bookId,
-            @Parameter(description = "요약본을 삭제할 챕터의 순서(index)") @PathVariable Integer chapterIdx) {
-        bookService.deleteChapterSummary(bookId, chapterIdx);
-        return ApiResponse.onSuccess("Chapter summary has been successfully deleted.");
-    }
 
     @Operation(summary = "인물 정보 업로드 API", description = "특정 책에 대한 인물 정보가 담긴 JSON 파일을 업로드합니다.")
     @PostMapping(value = "/books/{bookId}/characters", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadCharacters(
             @Parameter(description = "인물 정보를 추가할 책의 ID") @PathVariable Long bookId,
             @Parameter(description = "인물 정보가 담긴 JSON 파일") @RequestParam("file") MultipartFile file) {
-
         adminService.uploadCharacters(bookId, file);
         return ApiResponse.onSuccess("Characters have been successfully uploaded.");
     }
 
-    @Operation(summary = "인물 정보 삭제 API", description = "특정 책에 대한 모든 인물 정보를 삭제합니다. 인물 정보 업로드 실패 시 사용합니다.")
+    @Operation(summary = "인물 정보 삭제 API", description = "특정 책에 대한 모든 인물 정보를 삭제합니다.")
     @DeleteMapping("/books/{bookId}/characters")
     public ApiResponse<String> deleteCharacters(
             @Parameter(description = "인물 정보를 삭제할 책의 ID") @PathVariable Long bookId) {
-        bookService.deleteCharacters(bookId);
+        adminService.deleteCharacters(bookId);
         return ApiResponse.onSuccess("Characters for the book have been successfully deleted.");
     }
 
-    // 기존의 단일 이벤트 업로드 API를 다중 업로드 API로 수정
-    @Operation(summary = "이벤트 정보 다중 업로드 API", description = "특정 책에 대한 챕터별 이벤트 정보가 담긴 JSON 파일들을 업로드합니다. 파일 이름에서 챕터 번호를 자동 인식합니다.")
+    @Operation(summary = "이벤트 정보 다중 업로드 API", description = "특정 책에 대한 챕터별 이벤트 정보가 담긴 JSON 파일들을 업로드합니다.")
     @PostMapping(value = "/books/{bookId}/events", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadEvents(
             @Parameter(description = "이벤트를 추가할 책의 ID") @PathVariable Long bookId,
-            @Parameter(description = "챕터별 이벤트 정보가 담긴 JSON 파일 목록 (파일명: chapter<번호>_events.json)") @RequestParam("files") List<MultipartFile> files) {
-
+            @Parameter(description = "챕터별 이벤트 정보 파일 목록 (파일명: chapter<번호>_events.json)") @RequestParam("files") List<MultipartFile> files) {
         adminService.uploadEvents(bookId, files);
         return ApiResponse.onSuccess("Events have been successfully uploaded.");
     }
 
-    @Operation(summary = "이벤트 정보 삭제 API", description = "특정 챕터에 대한 모든 이벤트 정보를 삭제합니다. 이벤트 정보 업로드 실패 시 사용합니다.")
+    @Operation(summary = "이벤트 정보 삭제 API", description = "특정 챕터에 대한 모든 이벤트 정보를 삭제합니다.")
     @DeleteMapping("/books/{bookId}/chapters/{chapterIdx}/events")
     public ApiResponse<String> deleteEvents(
             @Parameter(description = "이벤트 정보를 삭제할 책의 ID") @PathVariable Long bookId,
             @Parameter(description = "이벤트 정보를 삭제할 챕터의 순서(index)") @PathVariable Integer chapterIdx) {
-        bookService.deleteEvents(bookId, chapterIdx);
+        adminService.deleteEvents(bookId, chapterIdx);
         return ApiResponse.onSuccess("Events for the chapter have been successfully deleted.");
     }
 
@@ -104,13 +66,45 @@ public class AdminController {
         return ApiResponse.onSuccess("Relationships uploaded successfully.");
     }
 
-    @Operation(summary = "관계 정보 삭제 API", description = "특정 이벤트에 대한 모든 관계 정보(엣지)를 삭제합니다. 관계 정보 업로드 실패 시 사용합니다.")
+    @Operation(summary = "관계 정보 삭제 API", description = "특정 이벤트에 대한 모든 관계 정보(엣지)를 삭제합니다.")
     @DeleteMapping("/books/{bookId}/chapters/{chapterIdx}/events/{eventIdx}/relationships")
     public ApiResponse<String> deleteRelationships(
             @Parameter(description = "관계 정보를 삭제할 책의 ID") @PathVariable Long bookId,
             @Parameter(description = "관계 정보를 삭제할 챕터의 순서(index)") @PathVariable Integer chapterIdx,
             @Parameter(description = "관계 정보를 삭제할 이벤트의 순서(index)") @PathVariable Integer eventIdx) {
-        bookService.deleteRelationships(bookId, chapterIdx, eventIdx);
+        adminService.deleteRelationships(bookId, chapterIdx, eventIdx);
         return ApiResponse.onSuccess("Relationships have been successfully deleted.");
+    }
+
+    @Operation(summary = "챕터 요약본 다중 업로드 API", description = "특정 책에 대한 챕터별 요약 정보가 담긴 JSON 파일들을 업로드합니다.")
+    @PostMapping(value = "/books/{bookId}/summary", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<String> uploadChapterSummaries(
+            @Parameter(description = "요약본을 추가할 책의 ID") @PathVariable Long bookId,
+            @Parameter(description = "인물별 요약 정보 파일 목록 (파일명: chapter<번호>_perspective_summaries.json)") @RequestParam("files") List<MultipartFile> files) {
+        adminService.uploadChapterSummaries(bookId, files);
+        return ApiResponse.onSuccess("Chapter summaries have been successfully uploaded.");
+    }
+
+    @Operation(summary = "챕터 요약본 삭제 API", description = "특정 챕터에 대한 요약본 정보를 삭제합니다.")
+    @DeleteMapping("/books/{bookId}/chapters/{chapterIdx}/summary")
+    public ApiResponse<String> deleteChapterSummary(
+            @Parameter(description = "요약본을 삭제할 책의 ID") @PathVariable Long bookId,
+            @Parameter(description = "요약본을 삭제할 챕터의 순서(index)") @PathVariable Integer chapterIdx) {
+        adminService.deleteChapterSummary(bookId, chapterIdx);
+        return ApiResponse.onSuccess("Chapter summary has been successfully deleted.");
+    }
+
+    @Operation(summary = "미요약 도서 목록 조회 API", description = "전체 책 중에서 요약이 완료되지 않은 책들의 목록을 조회합니다.")
+    @GetMapping("/books/unsummarized")
+    public ApiResponse<List<BookSummaryDTO>> getUnsummarizedBooks() {
+        List<BookSummaryDTO> response = adminService.getUnsummarizedBooks();
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(summary = "미요약 챕터 목록 조회 API", description = "전체 챕터 중에서 요약이 필요한 챕터들의 목록을 조회합니다.")
+    @GetMapping("/chapters/unsummarized")
+    public ApiResponse<List<UnsummarizedItemDTO>> getUnsummarizedChapters() {
+        List<UnsummarizedItemDTO> response = adminService.getUnsummarizedChapters();
+        return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -36,15 +36,14 @@ public class AdminController {
         return ApiResponse.onSuccess(response);
     }
 
-    @Operation(summary = "챕터 요약본 업로드 API", description = "특정 챕터에 대한 인물별 요약 정보가 담긴 JSON 파일을 업로드합니다.")
-    @PostMapping(value = "/books/{bookId}/chapters/{chapterIdx}/summary", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<String> uploadChapterSummary(
+    @Operation(summary = "챕터 요약본 업로드 API", description = "특정 책에 대한 챕터별 요약 정보가 담긴 JSON 파일들을 업로드합니다. 파일 이름에서 챕터 번호를 자동 인식합니다.")
+    @PostMapping(value = "/books/{bookId}/summary", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<String> uploadChapterSummaries(
             @Parameter(description = "요약본을 추가할 책의 ID") @PathVariable Long bookId,
-            @Parameter(description = "요약본을 추가할 챕터의 순서(index)") @PathVariable Integer chapterIdx,
-            @Parameter(description = "인물별 요약 정보가 담긴 JSON 파일") @RequestParam("file") MultipartFile file) {
+            @Parameter(description = "인물별 요약 정보가 담긴 JSON 파일 목록 (파일명: chapter<번호>_perspective_summaries.json)") @RequestParam("files") List<MultipartFile> files) {
 
-        bookService.uploadChapterSummary(bookId, chapterIdx, file);
-        return ApiResponse.onSuccess("Chapter summary has been successfully uploaded.");
+        bookService.uploadChapterSummaries(bookId, files);
+        return ApiResponse.onSuccess("Chapter summaries have been successfully uploaded.");
     }
 
     @Operation(summary = "챕터 요약본 삭제 API", description = "특정 챕터에 대한 요약본 정보를 삭제합니다. 요약본 업로드 실패 시 사용합니다.")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: create
+          auto: update
         default_batch_fetch_size: 1000
   servlet:
     multipart:


### PR DESCRIPTION
# 🧑🏻‍💻 PR 작업 내역 요약
#14 
관리자 기능 분리, 다중 파일 업로드 기능 구현, 그리고 미요약 챕터 목록 조회 api 개선

## 📋 변경 사항
1. 관리자 기능 서비스 분리
- 기존 BookService에 섞여 있던 '정보 업로드/삭제'와 '미요약 목록 조회' 등 관리자 관련 로직이 AdminService로 이전.

2. 다중 파일 업로드 기능 구현
- 이제 'POV 요약과 이벤트 정보'를 개별 파일이 아닌, 여러 개의 JSON 파일을 한 번에 업로드 가능.
- 업로드된 파일의 이름(예: chapter<번호>_events.json)을 분석해 챕터 번호를 자동으로 인식하는 기능 추가.
- 인물 정보는 기존에도 책 단위로 업로드하기 때문에 수정할 필요 없음.
- TODO: 관계 정보 다중 업로드 기능 구현 및 인물 가중치 테이블 분할

3. 미요약 챕터 목록 조회 api 개선
- POV 요약본이 아직 없는 챕터 목록을 조회하는 API의 내부 로직을 수정.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
