### PR TITLE
feat: 관계 정보 다중 파일 업로드 기능 구현

### DIFF
--- a/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
@@ -52,6 +52,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NO_SUMMARY_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4013", "삭제할 POV 요약본이 존재하지 않습니다."),
     NO_RELATIONSHIPS_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4015", "삭제할 관계 정보가 존재하지 않습니다."),
     INVALID_FILE_NAME_FORMAT(HttpStatus.BAD_REQUEST, "ADMIN4016", "잘못된 형식의 파일 이름입니다. 'chapter<숫자>_perspective_summaries.json' 형식을 따라야 합니다."),
+    NODE_WEIGHT_ALREADY_EXISTS(HttpStatus.CONFLICT, "ADMIN4018", "해당 이벤트의 캐릭터 가중치 데이터가 이미 존재합니다."),
 
     // Bookmark
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOKMARK4001", "해당 북마크를 찾을 수 없습니다."),

--- a/src/main/java/com/kw/readwith/config/DataLoader.java
+++ b/src/main/java/com/kw/readwith/config/DataLoader.java
@@ -367,9 +367,7 @@ public class DataLoader implements CommandLineRunner {
                 .fromCharacter(harry)
                 .toCharacter(hagrid)
                 .event(event)
-                .edgeWeight(3.5f)  // Admin API의 weight 필드
                 .sentimentScore(0.8f)  // Admin API의 positivity 필드
-                .interactionCount(2)  // Admin API의 count 필드
                 .relationTags("[\"care\", \"protection\"]")  // Admin API의 relation 필드 (JSON 문자열)
                 .build();
         eventRelationshipEdgeRepository.save(harryHagrid);
@@ -379,9 +377,7 @@ public class DataLoader implements CommandLineRunner {
                 .fromCharacter(hagrid)
                 .toCharacter(harry)
                 .event(event)
-                .edgeWeight(3.5f)
                 .sentimentScore(0.7f)
-                .interactionCount(2)
                 .relationTags("[\"mentorship\", \"guidance\"]")
                 .build();
         eventRelationshipEdgeRepository.save(hagridHarry);
@@ -421,9 +417,7 @@ public class DataLoader implements CommandLineRunner {
                 .fromCharacter(frodo)
                 .toCharacter(gandalf)
                 .event(event)
-                .edgeWeight(4.0f)
                 .sentimentScore(0.9f)
-                .interactionCount(3)
                 .relationTags("[\"trust\", \"guidance\", \"friendship\"]")
                 .build();
         eventRelationshipEdgeRepository.save(frodoGandalf);
@@ -433,9 +427,7 @@ public class DataLoader implements CommandLineRunner {
                 .fromCharacter(gandalf)
                 .toCharacter(frodo)
                 .event(event)
-                .edgeWeight(4.2f)
                 .sentimentScore(0.85f)
-                .interactionCount(3)
                 .relationTags("[\"protection\", \"mentorship\"]")
                 .build();
         eventRelationshipEdgeRepository.save(gandalfFrodo);

--- a/src/main/java/com/kw/readwith/domain/Character.java
+++ b/src/main/java/com/kw/readwith/domain/Character.java
@@ -1,7 +1,7 @@
 package com.kw.readwith.domain;
 
 import com.kw.readwith.domain.cache.ChapterCharacterStat;
-import com.kw.readwith.domain.cache.EventCharacterStat;
+import com.kw.readwith.domain.mapping.EventCharacterStat;
 import com.kw.readwith.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/kw/readwith/domain/mapping/EventCharacterStat.java
+++ b/src/main/java/com/kw/readwith/domain/mapping/EventCharacterStat.java
@@ -1,4 +1,4 @@
-package com.kw.readwith.domain.cache;
+package com.kw.readwith.domain.mapping;
 
 import com.kw.readwith.domain.Character;
 import com.kw.readwith.domain.Event;
@@ -23,5 +23,10 @@ public class EventCharacterStat extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(nullable = false)
     private Character character;
 
-    private int mentionCount;
+    @Column(name = "node_weight")
+    private double nodeWeight;
+
+    public void updateNodeWeight(double nodeWeight) {
+        this.nodeWeight = nodeWeight;
+    }
 }

--- a/src/main/java/com/kw/readwith/domain/mapping/EventRelationshipEdge.java
+++ b/src/main/java/com/kw/readwith/domain/mapping/EventRelationshipEdge.java
@@ -44,7 +44,4 @@ public class EventRelationshipEdge extends BaseEntity {
     private SentimentLabel sentimentLabel;
 
     private String edgeColorHex;
-
-    @Column(name = "edge_weight")
-    private Float edgeWeight;
 }

--- a/src/main/java/com/kw/readwith/dto/admin/NodeWeightDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/NodeWeightDTO.java
@@ -1,0 +1,13 @@
+package com.kw.readwith.dto.admin;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class NodeWeightDTO {
+    private double weight;
+    private int count;
+}

--- a/src/main/java/com/kw/readwith/dto/admin/RelationshipDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/RelationshipDTO.java
@@ -8,9 +8,9 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class RelationshipDTO {
+    private Long id1;
+    private Long id2;
     private List<String> relation;
-    private Double id1;
-    private Double id2;
     private Double positivity;
     private Double weight;
     private Integer count;

--- a/src/main/java/com/kw/readwith/dto/admin/RelationshipUploadDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/RelationshipUploadDTO.java
@@ -1,12 +1,21 @@
 package com.kw.readwith.dto.admin;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
+import java.util.Map;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class RelationshipUploadDTO {
     private List<RelationshipDTO> relations;
+
+    @JsonProperty("node_weights_accum")
+    private Map<String, NodeWeightDTO> nodeWeightsAccum;
+
+    private Map<String, Object> log;
 }

--- a/src/main/java/com/kw/readwith/repository/ChapterRepository.java
+++ b/src/main/java/com/kw/readwith/repository/ChapterRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface ChapterRepository extends JpaRepository<Chapter, Long> {
 
     // POV 요약이 완료되지 않은 모든 챕터를 조회
-    @Query("SELECT c FROM Chapter c WHERE c.povSummariesCached = false")
+    @Query("SELECT c FROM Chapter c JOIN FETCH c.book WHERE c.povSummariesCached = false")
     List<Chapter> findUnsummarizedChapters();
 
     // bookId와 chapterIdx로 확인

--- a/src/main/java/com/kw/readwith/repository/EventCharacterStatRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventCharacterStatRepository.java
@@ -1,0 +1,15 @@
+package com.kw.readwith.repository;
+
+import com.kw.readwith.domain.Event;
+import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.mapping.EventCharacterStat;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EventCharacterStatRepository extends JpaRepository<EventCharacterStat, Long> {
+
+    Optional<EventCharacterStat> findByEventAndCharacter(Event event, Character character);
+}

--- a/src/main/java/com/kw/readwith/repository/EventRelationshipEdgeRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventRelationshipEdgeRepository.java
@@ -1,5 +1,6 @@
 package com.kw.readwith.repository;
 
+import com.kw.readwith.domain.Character;
 import com.kw.readwith.domain.Event;
 import com.kw.readwith.domain.mapping.EventRelationshipEdge;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,14 +10,14 @@ import java.util.List;
 @Repository
 public interface EventRelationshipEdgeRepository extends JpaRepository<EventRelationshipEdge, Long> {
     boolean existsByEvent(Event event);
-    
+
     /**
      * 특정 이벤트의 모든 관계 엣지 조회 (세밀 그래프용)
      */
     List<EventRelationshipEdge> findByEvent(Event event);
 
     void deleteByEvent(Event event);
-    
+
+    boolean existsByEventAndFromCharacterAndToCharacter(Event event, Character fromCharacter, Character toCharacter);
 
 }
-

--- a/src/main/java/com/kw/readwith/repository/EventRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventRepository.java
@@ -16,9 +16,12 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     boolean existsByBookAndChapter(Book book, Chapter chapter);
     Optional<Event> findByChapterAndIdx(Chapter chapter, Integer idx);
 
-    // Event를 찾는 메소드
-    Optional<Event> findByBookAndChapterAndIdx(Book book, Chapter chapter, Integer idx);
-    
+    /**
+     * 이벤트를 찾는 메서드
+     */
+    @Query("SELECT e FROM Event e JOIN e.chapter c WHERE e.book.id = :bookId AND c.idx = :chapterIdx AND e.idx = :eventIdx")
+    Optional<Event> findByBookIdAndChapterIdxAndEventIdx(@Param("bookId") Long bookId, @Param("chapterIdx") int chapterIdx, @Param("eventIdx") int eventIdx);
+
     /**
      * 특정 챕터의 모든 이벤트를 인덱스 순으로 조회
      */

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -53,7 +53,7 @@ public class AdminService {
     private final EventCharacterStatRepository statRepository; // 의존성 추가
     private final ObjectMapper objectMapper;
 
-    // 파일명에서 챕터와 이벤트 인덱스를 추출하기 위한 정규식 패턴 (새로 추가)
+    // 파일명에서 챕터와 이벤트 인덱스를 추출하기 위한 정규표현식 패턴 (새로 추가)
     private static final Pattern RELATIONSHIP_FILE_PATTERN = Pattern.compile("chapter(\\d+)_.*?_event_(\\d+)\\.json");
 
     /*
@@ -218,130 +218,130 @@ public class AdminService {
 
     /**
      * 여러 관계 JSON 파일을 업로드하고 DB에 저장
-     * 파일 이름 규칙(chapter<번호>_..._event_<번호>.json)을 기반으로
-     * 자동으로 챕터와 이벤트를 매핑하여 관계 데이터를 저장합니다.
+     * 파일 이름 규칙: chapter<번호>_..._event_<번호>.json
      *
      * @param bookId 관계 정보를 추가할 책의 ID
      * @param files  업로드할 관계 정보 JSON 파일 목록
      */
     @Transactional
     public void uploadRelationships(Long bookId, List<MultipartFile> files) {
-        // 입력된 bookId로 Book 엔터티를 조회합니다. 없으면 예외를 발생시킴
+        // 입력된 bookId로 Book 엔터티를 조회
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
         // 업로드된 각 파일에 대해 반복 처리를 시작
         for (MultipartFile file : files) {
             String filename = file.getOriginalFilename();
-            // 파일명에서 챕터 번호와 이벤트 번호를 추출하기 위해 정규식 매칭을 시도
+            // 파일명 규칙을 기반으로 챕터와 이벤트 인덱스 추출
             Matcher matcher = RELATIONSHIP_FILE_PATTERN.matcher(filename);
 
-            // 파일명이 지정된 패턴과 일치하지 않으면, 예외를 발생시켜 작업을 중단
             if (!matcher.find()) {
                 throw new GeneralException(ErrorStatus.INVALID_FILE_NAME_FORMAT, "파일명 형식이 올바르지 않습니다: " + filename);
             }
 
-            // 정규식 그룹에서 챕터 번호(group 1)와 이벤트 번호(group 2)를 추출
+            // 정규표현식 그룹에서 챕터와 이벤트 인덱스 추출
             int chapterIdx = Integer.parseInt(matcher.group(1));
             int eventIdx = Integer.parseInt(matcher.group(2));
 
-            // 추출된 ID들을 사용하여 정확한 Event 엔터티를 조회합니다. 없으면 예외를 발생시킴
+            // 파일명에서 얻은 정보로 Event 엔터티를 DB에서 조회
             Event event = eventRepository.findByBookIdAndChapterIdxAndEventIdx(bookId, chapterIdx, eventIdx)
                     .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND,
-                            String.format("Event not found for bookId=%d, chapterIdx=%d, eventIdx=%d", bookId, chapterIdx, eventIdx)));
+                            String.format("이벤트를 찾을 수 없습니다 (책 ID: %d, 챕터: %d, 이벤트: %d)", bookId, chapterIdx, eventIdx)));
 
             try {
-                // JSON 파일의 내용을 RelationshipUploadDTO 객체로 변환
+                // JSON 파일을 DTO 객체로 변환
                 RelationshipUploadDTO dto = objectMapper.readValue(file.getInputStream(), RelationshipUploadDTO.class);
 
-                // 'node_weights_accum' 데이터를 처리하여 EventCharacterStat 테이블에 저장
+                // DTO의 각 부분을 처리하는 헬퍼 메서드 호출
                 processNodeWeights(event, book, dto.getNodeWeightsAccum());
-                // 'relations' 데이터를 처리하여 EventRelationshipEdge 테이블에 저장
                 processRelations(event, book, dto.getRelations());
 
             } catch (IOException e) {
-                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "Failed to parse relationship JSON file: " + filename);
+                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "관계 정보 JSON 파일 파싱에 실패했습니다: " + filename);
             }
         }
     }
 
     /**
-     * [새로 추가됨] JSON의 'node_weights_accum' 부분을 처리하는 헬퍼 메서드입니다.
-     * 각 캐릭터의 가중치(weight)를 EventCharacterStat 테이블에 저장하거나 업데이트합니다.
+     * JSON의 'node_weights_accum' 부분을 처리하는 헬퍼 메서드
+     * 각 캐릭터의 가중치(weight)를 저장하기 전, 중복 데이터가 있는지 확인
      *
-     * @param event          현재 처리 중인 이벤트 엔티티
-     * @param book           현재 처리 중인 책 엔티티
+     * @param event          현재 처리 중인 이벤트 엔터티
+     * @param book           현재 처리 중인 책 엔터티
      * @param nodeWeightsMap JSON에서 파싱된 캐릭터 ID와 가중치 정보가 담긴 맵
      */
     private void processNodeWeights(Event event, Book book, Map<String, NodeWeightDTO> nodeWeightsMap) {
-        // 처리할 데이터가 없으면 즉시 반환
         if (nodeWeightsMap == null) return;
 
-        // 맵의 각 항목(캐릭터 ID, 가중치 정보)에 대해 반복
+        List<EventCharacterStat> newStats = new ArrayList<>();
         for (Map.Entry<String, NodeWeightDTO> entry : nodeWeightsMap.entrySet()) {
-            // 맵의 키(String)를 캐릭터의 책 내 ID(Long)로 변환
             Long characterBookId = Long.parseLong(entry.getKey());
             NodeWeightDTO weightDTO = entry.getValue();
 
-            // 책과 캐릭터 ID를 이용해 Character 엔터티를 조회
             Character character = characterRepository.findByBookAndCharacterId(book, characterBookId)
-                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "Character not found for book-local id: " + characterBookId));
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "책에 정의된 ID가 " + characterBookId + "인 캐릭터를 찾을 수 없습니다."));
 
-            // 해당 이벤트와 캐릭터에 대한 기존 정보가 있는지 찾고,
-            // 없으면 새로운 EventCharacterStat 객체를 생성합니다.
-            EventCharacterStat stat = statRepository.findByEventAndCharacter(event, character)
-                    .orElse(EventCharacterStat.builder()
-                            .event(event)
-                            .character(character)
-                            .build());
+            // 기존 데이터가 있는지 확인
+            if (statRepository.findByEventAndCharacter(event, character).isPresent()) {
+                throw new GeneralException(ErrorStatus.NODE_WEIGHT_ALREADY_EXISTS,
+                        String.format("해당 이벤트에 대한 '%s' 캐릭터의 가중치 데이터가 이미 존재합니다.", character.getName()));
+            }
 
-            // DTO에서 읽어온 가중치(weight)로 통계 정보를 업데이트
-            stat.updateNodeWeight(weightDTO.getWeight());
-            // 변경된 통계 정보를 DB에 저장
-            statRepository.save(stat);
+            EventCharacterStat stat = EventCharacterStat.builder()
+                    .event(event)
+                    .character(character)
+                    .nodeWeight(weightDTO.getWeight())
+                    .build();
+            newStats.add(stat);
         }
+
+        // 모든 검사가 끝난 후, 한번에 저장
+        statRepository.saveAll(newStats);
     }
 
     /**
-     * JSON의 'relations' 부분을 처리하는 헬퍼 메서드입니다.
-     * 인물 관계들을 EventRelationshipEdge 테이블에 저장합니다.
+     * JSON의 'relations' 부분을 처리하는 헬퍼 메서드
+     * 인물 관계를 저장하기 전, 중복 데이터가 있는지 확인
      *
-     * @param event        현재 처리 중인 이벤트 엔티티
-     * @param book         현재 처리 중인 책 엔티티
+     * @param event        현재 처리 중인 이벤트 엔터티
+     * @param book         현재 처리 중인 책 엔터티
      * @param relationDTOs JSON에서 파싱된 관계 정보 DTO 목록
      */
     private void processRelations(Event event, Book book, List<RelationshipDTO> relationDTOs) {
-        // 처리할 데이터가 없으면 즉시 반환
         if (relationDTOs == null || relationDTOs.isEmpty()) {
             return;
         }
 
         List<EventRelationshipEdge> newEdges = new ArrayList<>();
         for (RelationshipDTO dto : relationDTOs) {
-            // 관계의 시작점(id1)과 끝점(id2)에 해당하는 캐릭터를 조회
             Character fromChar = characterRepository.findByBookAndCharacterId(book, dto.getId1())
-                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "From Character not found with jsonId: " + dto.getId1()));
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "id1에 해당하는 캐릭터(ID: " + dto.getId1() + ")를 찾을 수 없습니다."));
             Character toChar = characterRepository.findByBookAndCharacterId(book, dto.getId2())
-                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "To Character not found with jsonId: " + dto.getId2()));
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "id2에 해당하는 캐릭터(ID: " + dto.getId2() + ")를 찾을 수 없습니다."));
+
+            // 관계가 (A->B) 또는 (B->A) 방향으로 이미 존재하는지 확인
+            if (eventRelationshipEdgeRepository.existsByEventAndFromCharacterAndToCharacter(event, fromChar, toChar) ||
+                    eventRelationshipEdgeRepository.existsByEventAndFromCharacterAndToCharacter(event, toChar, fromChar)) {
+                throw new GeneralException(ErrorStatus.RELATIONSHIP_DATA_ALREADY_EXISTS,
+                        String.format("해당 이벤트에 대한 '%s'와(과) '%s'의 관계 데이터가 이미 존재합니다.", fromChar.getName(), toChar.getName()));
+            }
 
             try {
-                // 빌더를 사용하여 EventRelationshipEdge 엔터티를 생성
                 EventRelationshipEdge edge = EventRelationshipEdge.builder()
                         .event(event)
                         .fromCharacter(fromChar)
                         .toCharacter(toChar)
-                        // edgeWeight는 수정된 JSON 파일에서 삭제됨
                         .sentimentScore(dto.getPositivity().floatValue())
                         .interactionCount(dto.getCount())
-                        .relationTags(objectMapper.writeValueAsString(dto.getRelation())) // 기존 방식대로 relationTags 저장
+                        .relationTags(objectMapper.writeValueAsString(dto.getRelation()))
                         .build();
                 newEdges.add(edge);
             } catch (JsonProcessingException e) {
-                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "Failed to process relation tags for characters " + dto.getId1() + " and " + dto.getId2());
+                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, String.format("캐릭터 %d와(과) %d의 관계 태그 처리 중 오류가 발생했습니다.", dto.getId1(), dto.getId2()));
             }
         }
 
-        // 리스트가 비어있지 않으면, 데이터베이스에 한번에 저장
+        // 모든 검사가 끝난 후, 한번에 저장
         if (!newEdges.isEmpty()) {
             eventRelationshipEdgeRepository.saveAll(newEdges);
         }

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -10,12 +10,9 @@ import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.Character;
 import com.kw.readwith.domain.Event;
 import com.kw.readwith.domain.mapping.CharacterPovSummary;
+import com.kw.readwith.domain.mapping.EventCharacterStat;
 import com.kw.readwith.domain.mapping.EventRelationshipEdge;
-import com.kw.readwith.dto.admin.CharacterDTO;
-import com.kw.readwith.dto.admin.EventDTO;
-import com.kw.readwith.dto.admin.RelationshipDTO;
-import com.kw.readwith.dto.admin.RelationshipUploadDTO;
-import com.kw.readwith.dto.admin.UnsummarizedItemDTO;
+import com.kw.readwith.dto.admin.*; // 새로운 DTO import
 import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.repository.*;
 import lombok.Getter;
@@ -53,7 +50,11 @@ public class AdminService {
     private final EventRepository eventRepository;
     private final EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
     private final CharacterPovSummaryRepository characterPovSummaryRepository;
+    private final EventCharacterStatRepository statRepository; // 의존성 추가
     private final ObjectMapper objectMapper;
+
+    // 파일명에서 챕터와 이벤트 인덱스를 추출하기 위한 정규식 패턴 (새로 추가)
+    private static final Pattern RELATIONSHIP_FILE_PATTERN = Pattern.compile("chapter(\\d+)_.*?_event_(\\d+)\\.json");
 
     /*
      * =====================================================================================
@@ -64,7 +65,7 @@ public class AdminService {
     /**
      * 등장인물 정보가 담긴 JSON 파일을 업로드합니다.
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void uploadCharacters(Long bookId, MultipartFile file) {
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
@@ -216,46 +217,123 @@ public class AdminService {
     }
 
     /**
-     * 특정 이벤트의 관계 정보가 담긴 JSON 파일을 업로드합니다.
+     * 여러 관계 JSON 파일을 업로드하고 DB에 저장
+     * 파일 이름 규칙(chapter<번호>_..._event_<번호>.json)을 기반으로
+     * 자동으로 챕터와 이벤트를 매핑하여 관계 데이터를 저장합니다.
+     *
+     * @param bookId 관계 정보를 추가할 책의 ID
+     * @param files  업로드할 관계 정보 JSON 파일 목록
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.READ_COMMITTED)
-    public void uploadRelationships(Long bookId, Integer chapterIdx, Integer eventIdx, MultipartFile file) {
+    @Transactional
+    public void uploadRelationships(Long bookId, List<MultipartFile> files) {
+        // 입력된 bookId로 Book 엔터티를 조회합니다. 없으면 예외를 발생시킴
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
-        Chapter chapter = chapterRepository.findByBookIdAndIdx(book.getId(), chapterIdx)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+        // 업로드된 각 파일에 대해 반복 처리를 시작
+        for (MultipartFile file : files) {
+            String filename = file.getOriginalFilename();
+            // 파일명에서 챕터 번호와 이벤트 번호를 추출하기 위해 정규식 매칭을 시도
+            Matcher matcher = RELATIONSHIP_FILE_PATTERN.matcher(filename);
 
-        Event event = eventRepository.findByBookAndChapterAndIdx(book, chapter, eventIdx)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND));
+            // 파일명이 지정된 패턴과 일치하지 않으면, 예외를 발생시켜 작업을 중단
+            if (!matcher.find()) {
+                throw new GeneralException(ErrorStatus.INVALID_FILE_NAME_FORMAT, "파일명 형식이 올바르지 않습니다: " + filename);
+            }
 
-        if (eventRelationshipEdgeRepository.existsByEvent(event)) {
-            throw new GeneralException(ErrorStatus.RELATIONSHIP_DATA_ALREADY_EXISTS);
+            // 정규식 그룹에서 챕터 번호(group 1)와 이벤트 번호(group 2)를 추출
+            int chapterIdx = Integer.parseInt(matcher.group(1));
+            int eventIdx = Integer.parseInt(matcher.group(2));
+
+            // 추출된 ID들을 사용하여 정확한 Event 엔터티를 조회합니다. 없으면 예외를 발생시킴
+            Event event = eventRepository.findByBookIdAndChapterIdxAndEventIdx(bookId, chapterIdx, eventIdx)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND,
+                            String.format("Event not found for bookId=%d, chapterIdx=%d, eventIdx=%d", bookId, chapterIdx, eventIdx)));
+
+            try {
+                // JSON 파일의 내용을 RelationshipUploadDTO 객체로 변환
+                RelationshipUploadDTO dto = objectMapper.readValue(file.getInputStream(), RelationshipUploadDTO.class);
+
+                // 'node_weights_accum' 데이터를 처리하여 EventCharacterStat 테이블에 저장
+                processNodeWeights(event, book, dto.getNodeWeightsAccum());
+                // 'relations' 데이터를 처리하여 EventRelationshipEdge 테이블에 저장
+                processRelations(event, book, dto.getRelations());
+
+            } catch (IOException e) {
+                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "Failed to parse relationship JSON file: " + filename);
+            }
         }
+    }
 
-        RelationshipUploadDTO uploadDTO;
-        try {
-            uploadDTO = objectMapper.readValue(file.getInputStream(), RelationshipUploadDTO.class);
-        } catch (IOException e) {
-            throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
+    /**
+     * [새로 추가됨] JSON의 'node_weights_accum' 부분을 처리하는 헬퍼 메서드입니다.
+     * 각 캐릭터의 가중치(weight)를 EventCharacterStat 테이블에 저장하거나 업데이트합니다.
+     *
+     * @param event          현재 처리 중인 이벤트 엔티티
+     * @param book           현재 처리 중인 책 엔티티
+     * @param nodeWeightsMap JSON에서 파싱된 캐릭터 ID와 가중치 정보가 담긴 맵
+     */
+    private void processNodeWeights(Event event, Book book, Map<String, NodeWeightDTO> nodeWeightsMap) {
+        // 처리할 데이터가 없으면 즉시 반환
+        if (nodeWeightsMap == null) return;
+
+        // 맵의 각 항목(캐릭터 ID, 가중치 정보)에 대해 반복
+        for (Map.Entry<String, NodeWeightDTO> entry : nodeWeightsMap.entrySet()) {
+            // 맵의 키(String)를 캐릭터의 책 내 ID(Long)로 변환
+            Long characterBookId = Long.parseLong(entry.getKey());
+            NodeWeightDTO weightDTO = entry.getValue();
+
+            // 책과 캐릭터 ID를 이용해 Character 엔터티를 조회
+            Character character = characterRepository.findByBookAndCharacterId(book, characterBookId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "Character not found for book-local id: " + characterBookId));
+
+            // 해당 이벤트와 캐릭터에 대한 기존 정보가 있는지 찾고,
+            // 없으면 새로운 EventCharacterStat 객체를 생성합니다.
+            EventCharacterStat stat = statRepository.findByEventAndCharacter(event, character)
+                    .orElse(EventCharacterStat.builder()
+                            .event(event)
+                            .character(character)
+                            .build());
+
+            // DTO에서 읽어온 가중치(weight)로 통계 정보를 업데이트
+            stat.updateNodeWeight(weightDTO.getWeight());
+            // 변경된 통계 정보를 DB에 저장
+            statRepository.save(stat);
+        }
+    }
+
+    /**
+     * JSON의 'relations' 부분을 처리하는 헬퍼 메서드입니다.
+     * 인물 관계들을 EventRelationshipEdge 테이블에 저장합니다.
+     *
+     * @param event        현재 처리 중인 이벤트 엔티티
+     * @param book         현재 처리 중인 책 엔티티
+     * @param relationDTOs JSON에서 파싱된 관계 정보 DTO 목록
+     */
+    private void processRelations(Event event, Book book, List<RelationshipDTO> relationDTOs) {
+        // 처리할 데이터가 없으면 즉시 반환
+        if (relationDTOs == null || relationDTOs.isEmpty()) {
+            return;
         }
 
         List<EventRelationshipEdge> newEdges = new ArrayList<>();
-        for (RelationshipDTO dto : uploadDTO.getRelations()) {
-            Character fromChar = characterRepository.findByBookAndCharacterId(book, dto.getId1().longValue())
+        for (RelationshipDTO dto : relationDTOs) {
+            // 관계의 시작점(id1)과 끝점(id2)에 해당하는 캐릭터를 조회
+            Character fromChar = characterRepository.findByBookAndCharacterId(book, dto.getId1())
                     .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "From Character not found with jsonId: " + dto.getId1()));
-            Character toChar = characterRepository.findByBookAndCharacterId(book, dto.getId2().longValue())
+            Character toChar = characterRepository.findByBookAndCharacterId(book, dto.getId2())
                     .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "To Character not found with jsonId: " + dto.getId2()));
 
             try {
+                // 빌더를 사용하여 EventRelationshipEdge 엔터티를 생성
                 EventRelationshipEdge edge = EventRelationshipEdge.builder()
+                        .event(event)
                         .fromCharacter(fromChar)
                         .toCharacter(toChar)
-                        .event(event)
-                        .edgeWeight(dto.getWeight().floatValue())
+                        // edgeWeight는 수정된 JSON 파일에서 삭제됨
                         .sentimentScore(dto.getPositivity().floatValue())
                         .interactionCount(dto.getCount())
-                        .relationTags(objectMapper.writeValueAsString(dto.getRelation()))
+                        .relationTags(objectMapper.writeValueAsString(dto.getRelation())) // 기존 방식대로 relationTags 저장
                         .build();
                 newEdges.add(edge);
             } catch (JsonProcessingException e) {
@@ -263,6 +341,7 @@ public class AdminService {
             }
         }
 
+        // 리스트가 비어있지 않으면, 데이터베이스에 한번에 저장
         if (!newEdges.isEmpty()) {
             eventRelationshipEdgeRepository.saveAll(newEdges);
         }
@@ -370,7 +449,7 @@ public class AdminService {
 
     /*
      * =====================================================================================
-     * 4. 내부 헬퍼 메소드 및 클래스
+     * 4. 내부 헬퍼 메서드 및 클래스
      * =====================================================================================
      */
 

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -12,7 +12,7 @@ import com.kw.readwith.domain.Event;
 import com.kw.readwith.domain.mapping.CharacterPovSummary;
 import com.kw.readwith.domain.mapping.EventCharacterStat;
 import com.kw.readwith.domain.mapping.EventRelationshipEdge;
-import com.kw.readwith.dto.admin.*; // 새로운 DTO import
+import com.kw.readwith.dto.admin.*;
 import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.repository.*;
 import lombok.Getter;

--- a/src/main/java/com/kw/readwith/service/FineGraphService.java
+++ b/src/main/java/com/kw/readwith/service/FineGraphService.java
@@ -103,7 +103,8 @@ public class FineGraphService {
         return FineGraphEdgeDTO.builder()
                 .from(edge.getFromCharacter().getId())
                 .to(edge.getToCharacter().getId())
-                .weight(edge.getEdgeWeight() != null ? edge.getEdgeWeight().doubleValue() : 0.0)
+                // TODO: 관계 JSON에서 edge_weight 필드는 제거됨
+                // .weight(edge.getEdgeWeight() != null ? edge.getEdgeWeight().doubleValue() : 0.0)
                 .sentimentScore(edge.getSentimentScore() != null ? edge.getSentimentScore().doubleValue() : 0.0)
                 .interactionCount(edge.getInteractionCount())
                 .relationTags(relationTags)

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -55,15 +55,13 @@ public class AdminController {
         return ApiResponse.onSuccess("Events for the chapter have been successfully deleted.");
     }
 
-    @Operation(summary = "관계 정보 업로드 API", description = "특정 이벤트에 대한 인물 관계 정보(JSON)를 업로드합니다.")
-    @PostMapping(value = "/books/{bookId}/chapters/{chapterIdx}/events/{eventIdx}/relationships", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "관계 정보 다중 업로드 API", description = "특정 책에 대한 관계 정보(JSON) 파일들을 업로드합니다. 파일명 규칙: chapter<번호>_relationships_<언어>_event_<번호>.json")
+    @PostMapping(value = "/books/{bookId}/relationships", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadRelationships(
             @Parameter(description = "관계 정보를 추가할 책의 ID") @PathVariable Long bookId,
-            @Parameter(description = "관계 정보를 추가할 챕터의 순서(index)") @PathVariable Integer chapterIdx,
-            @Parameter(description = "관계 정보를 추가할 이벤트의 순서(index)") @PathVariable Integer eventIdx,
-            @Parameter(description = "관계 정보가 담긴 JSON 파일") @RequestParam("file") MultipartFile file) {
-        adminService.uploadRelationships(bookId, chapterIdx, eventIdx, file);
-        return ApiResponse.onSuccess("Relationships uploaded successfully.");
+            @Parameter(description = "관계 정보가 담긴 JSON 파일 목록") @RequestParam("files") List<MultipartFile> files) {
+        adminService.uploadRelationships(bookId, files);
+        return ApiResponse.onSuccess("Relationships for the book have been successfully uploaded.");
     }
 
     @Operation(summary = "관계 정보 삭제 API", description = "특정 이벤트에 대한 모든 관계 정보(엣지)를 삭제합니다.")


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
#14 
기존 단일 파일 업로드 기능을 확장하여 여러 개의 관계 JSON 파일을 한 번에 업로드할 수 있도록 개선하였고, 중복 방지 및 Batch 처리로 데이터 무결성이 강화되었습니다.

## 📋 변경 사항
1. 다중 파일 업로드 기능 구현
- 이제 '관계 정보'를 개별 파일이 아닌, 여러 개의 JSON 파일을 한 번에 업로드 가능
- 업로드된 파일명(chapter{번호}_..._event_{번호}.json)에서 챕터와 이벤트 인덱스를 자동으로 파싱
- 인물 가중치: event_character_stat 테이블에 저장
- 인물 관계: event_relationship_edge 테이블에 저장
- _DataLoader.java에서 edgeWeight와 interactionCount 관련 라인 삭제 (관계 JSON 파일 구조 변경)_

2. 데이터 무결성 강화 및 성능 향상
- 인물 가중치: findBy 메서드를 사용하여 (이벤트, 캐릭터) 조합의 중복 방지
- 인물 관계: existsBy 메서드를 사용하여 양방향 관계(A->B와 B->A)의 중복을 모두 방지
- 유효성 검사가 완료된 엔터티들을 saveAll 메서드를 통해 Batch 처리를 적용하여 DB 부하를 최소화

3. 후속 작업 필요
- 문제 원인: 관계 JSON 파일 구조가 변경되면서 edge_weight 필드 제거
- FineGraphService.java의 getEdgeWeight 메소드에서 오류 발생
- 임시 조치: 충돌 및 빌드 오류를 막기 위해, 일단 해당 라인을 주석으로 처리

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
