### PR TITLE
feat: 챕터당 각 인물별 시점요약 조회 api 구현

### DIFF
--- a/src/main/java/com/kw/readwith/config/DataLoader.java
+++ b/src/main/java/com/kw/readwith/config/DataLoader.java
@@ -7,6 +7,7 @@ import com.kw.readwith.domain.Event;
 import com.kw.readwith.domain.User;
 import com.kw.readwith.domain.mapping.EventRelationshipEdge;
 import com.kw.readwith.domain.mapping.EventCharacterStat;
+import com.kw.readwith.domain.mapping.CharacterPovSummary;
 import com.kw.readwith.domain.enums.Provider;
 import com.kw.readwith.repository.BookRepository;
 import com.kw.readwith.repository.ChapterRepository;
@@ -15,6 +16,7 @@ import com.kw.readwith.repository.EventRepository;
 import com.kw.readwith.repository.UserRepository;
 import com.kw.readwith.repository.EventRelationshipEdgeRepository;
 import com.kw.readwith.repository.EventCharacterStatRepository;
+import com.kw.readwith.repository.CharacterPovSummaryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
@@ -31,6 +33,7 @@ public class DataLoader implements CommandLineRunner {
     private final CharacterRepository characterRepository;
     private final EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
     private final EventCharacterStatRepository eventCharacterStatRepository;
+    private final CharacterPovSummaryRepository characterPovSummaryRepository;
 
     @Override
     public void run(String... args) throws Exception {
@@ -261,6 +264,9 @@ public class DataLoader implements CommandLineRunner {
         
         // EventRelationshipEdge 관계 데이터 추가 (Admin API 업로드 형태와 동일)
         createHarryPotterRelationships(book, savedEvent3, harry, hermione, ron, hagrid);
+        
+        // 챕터 시점요약 데이터 추가
+        createHarryPotterPovSummaries(book, savedChapter1, chapter2, chapter3, harry, hermione, ron, hagrid);
     }
 
     /**
@@ -356,6 +362,9 @@ public class DataLoader implements CommandLineRunner {
         
         // 반지의 제왕 관계 데이터 추가
         createLordOfTheRingsRelationships(book, event2, frodo, gandalf, aragorn);
+        
+        // 챕터 시점요약 데이터 추가
+        createLordOfTheRingsPovSummaries(book, savedChapter1, frodo, gandalf, aragorn);
     }
 
     /**
@@ -483,5 +492,115 @@ public class DataLoader implements CommandLineRunner {
                 .nodeWeight(6.0)  // 아라고른은 중요한 왕족
                 .build();
         eventCharacterStatRepository.save(aragornStat);
+    }
+
+    /**
+     * 해리포터 챕터 시점요약 데이터 생성
+     */
+    private void createHarryPotterPovSummaries(Book book, Chapter chapter1, Chapter chapter2, Chapter chapter3, 
+                                              Character harry, Character hermione, Character ron, Character hagrid) {
+        
+        // 1장: 살아남은 아이 - 각 인물별 시점요약
+        CharacterPovSummary harryChapter1 = CharacterPovSummary.builder()
+                .book(book)
+                .chapter(chapter1)
+                .character(harry)
+                .summaryText("해리의 시점에서는 이 챕터에서 직접적인 경험은 없지만, 그의 운명이 결정되는 중요한 순간이다. " +
+                           "부모님을 잃고 더즐리 가족에게 맡겨지게 되는 비극적인 시작이지만, 동시에 마법 세계에서 '살아남은 아이'로 불리게 되는 전설의 시작이기도 하다.")
+                .build();
+        characterPovSummaryRepository.save(harryChapter1);
+
+        CharacterPovSummary hagridChapter1 = CharacterPovSummary.builder()
+                .book(book)
+                .chapter(chapter1)
+                .character(hagrid)
+                .summaryText("해그리드의 시점에서 이 챕터는 깊은 슬픔과 책임감이 교차하는 순간이다. " +
+                           "제임스와 릴리 포터의 죽음을 목격하고, 아기 해리를 구출해 덤블도어에게 데려오는 중요한 임무를 수행한다. " +
+                           "해리에 대한 각별한 애정과 보호 의지가 시작되는 지점이다.")
+                .build();
+        characterPovSummaryRepository.save(hagridChapter1);
+
+        // 2장: 사라진 유리 - 각 인물별 시점요약  
+        CharacterPovSummary harryChapter2 = CharacterPovSummary.builder()
+                .book(book)
+                .chapter(chapter2)
+                .character(harry)
+                .summaryText("해리의 시점에서 이 챕터는 자신의 특별한 능력을 처음 인식하게 되는 순간이다. " +
+                           "더즐리 가족의 냉대 속에서도 뱀과 대화할 수 있는 신비한 능력을 발견하며, " +
+                           "자신이 평범하지 않다는 것을 깨닫기 시작한다. 동물원에서의 사건은 그에게 혼란과 동시에 희망을 준다.")
+                .build();
+        characterPovSummaryRepository.save(harryChapter2);
+
+        CharacterPovSummary hermioneChapter2 = CharacterPovSummary.builder()
+                .book(book)
+                .chapter(chapter2)
+                .character(hermione)
+                .summaryText("헤르미온느는 아직 해리와 만나지 않았지만, 이 시기 그녀는 호그와트 입학을 준비하며 " +
+                           "마법에 대한 모든 것을 열심히 공부하고 있었을 것이다. 머글 출신으로서 마법 세계에 대한 " +
+                           "강한 호기심과 학습 욕구로 가득 찬 시기였다.")
+                .build();
+        characterPovSummaryRepository.save(hermioneChapter2);
+
+        // 3장: 편지들 - 각 인물별 시점요약
+        CharacterPovSummary harryChapter3 = CharacterPovSummary.builder()
+                .book(book)
+                .chapter(chapter3)
+                .character(harry)
+                .summaryText("해리의 시점에서 이 챕터는 자신의 정체성에 대한 진실이 조금씩 드러나는 흥미진진한 순간이다. " +
+                           "호그와트에서 온 편지들을 통해 자신이 마법사라는 사실을 알게 되고, " +
+                           "더즐리 가족이 숨겨온 진실들이 하나씩 밝혀지면서 새로운 세계에 대한 기대감이 커진다.")
+                .build();
+        characterPovSummaryRepository.save(harryChapter3);
+
+        CharacterPovSummary ronChapter3 = CharacterPovSummary.builder()
+                .book(book)
+                .chapter(chapter3)
+                .character(ron)
+                .summaryText("론의 시점에서는 아직 해리와 만나지 않았지만, 위즐리 가족의 막내 아들로서 " +
+                           "호그와트 입학을 앞두고 설렘과 긴장감을 느끼고 있었을 것이다. " +
+                           "형들의 이야기를 들으며 호그와트 생활에 대한 기대와 걱정을 동시에 품고 있었다.")
+                .build();
+        characterPovSummaryRepository.save(ronChapter3);
+    }
+
+    /**
+     * 반지의 제왕 챕터 시점요약 데이터 생성
+     */
+    private void createLordOfTheRingsPovSummaries(Book book, Chapter chapter1, 
+                                                 Character frodo, Character gandalf, Character aragorn) {
+        
+        // 1장: 오랫동안 기다려온 파티 - 각 인물별 시점요약
+        CharacterPovSummary frodoChapter1 = CharacterPovSummary.builder()
+                .book(book)
+                .chapter(chapter1)
+                .character(frodo)
+                .summaryText("프로도의 시점에서 이 챕터는 평온한 샤이어 생활의 마지막 순간들이다. " +
+                           "빌보 삼촌의 생일 파티를 준비하며 일상적인 호빗의 삶을 즐기고 있지만, " +
+                           "빌보의 갑작스러운 실종과 반지에 대한 이야기를 듣게 되면서 " +
+                           "자신의 운명이 바뀔 것임을 예감하기 시작한다.")
+                .build();
+        characterPovSummaryRepository.save(frodoChapter1);
+
+        CharacterPovSummary gandalfChapter1 = CharacterPovSummary.builder()
+                .book(book)
+                .chapter(chapter1)
+                .character(gandalf)
+                .summaryText("간달프의 시점에서 이 챕터는 오랫동안 품어온 의심이 확신으로 바뀌는 중요한 순간이다. " +
+                           "빌보가 가진 반지가 정말로 '하나의 반지'임을 확신하게 되고, " +
+                           "이제 프로도에게 진실을 알려주고 위험한 여정을 시작해야 할 때가 왔음을 깨닫는다. " +
+                           "마법사로서의 책임감과 걱정이 교차하는 복잡한 심경이다.")
+                .build();
+        characterPovSummaryRepository.save(gandalfChapter1);
+
+        CharacterPovSummary aragornChapter1 = CharacterPovSummary.builder()
+                .book(book)
+                .chapter(chapter1)
+                .character(aragorn)
+                .summaryText("아라고른의 시점에서는 아직 프로도와 직접적인 만남은 없지만, " +
+                           "레인저로서 샤이어 주변을 순찰하며 어둠의 세력들의 움직임을 감지하고 있다. " +
+                           "곤도르의 왕위 계승자로서의 숨겨진 정체성과 함께, " +
+                           "중간계를 지켜야 할 사명감을 품고 있는 시기이다.")
+                .build();
+        characterPovSummaryRepository.save(aragornChapter1);
     }
 }

--- a/src/main/java/com/kw/readwith/dto/book/ChapterPovSummaryDTO.java
+++ b/src/main/java/com/kw/readwith/dto/book/ChapterPovSummaryDTO.java
@@ -1,0 +1,15 @@
+package com.kw.readwith.dto.book;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChapterPovSummaryDTO {
+    private Long characterId;
+    private String characterName;
+    private String summaryText;
+    private boolean isMainCharacter;
+}

--- a/src/main/java/com/kw/readwith/dto/book/ChapterPovSummaryResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/book/ChapterPovSummaryResponseDTO.java
@@ -1,0 +1,17 @@
+package com.kw.readwith.dto.book;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChapterPovSummaryResponseDTO {
+    private Long bookId;
+    private Integer chapterIdx;
+    private String chapterTitle;
+    private List<ChapterPovSummaryDTO> povSummaries;
+}

--- a/src/main/java/com/kw/readwith/repository/CharacterPovSummaryRepository.java
+++ b/src/main/java/com/kw/readwith/repository/CharacterPovSummaryRepository.java
@@ -3,6 +3,8 @@ package com.kw.readwith.repository;
 import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.mapping.CharacterPovSummary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,6 +13,13 @@ import java.util.List;
 public interface CharacterPovSummaryRepository extends JpaRepository<CharacterPovSummary, Long> {
 
     List<CharacterPovSummary> findByChapterId(Long chapterId);
+
+    @Query("SELECT cps FROM CharacterPovSummary cps " +
+           "JOIN FETCH cps.character c " +
+           "JOIN FETCH cps.chapter ch " +
+           "WHERE cps.book.id = :bookId AND ch.idx = :chapterIdx " +
+           "ORDER BY c.isMainCharacter DESC, c.name ASC")
+    List<CharacterPovSummary> findByBookIdAndChapterIdx(@Param("bookId") Long bookId, @Param("chapterIdx") Integer chapterIdx);
 
     boolean existsByChapter(Chapter chapter);
 

--- a/src/main/java/com/kw/readwith/service/CharacterPovSummaryService.java
+++ b/src/main/java/com/kw/readwith/service/CharacterPovSummaryService.java
@@ -2,11 +2,14 @@ package com.kw.readwith.service;
 
 import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
-// import com.kw.readwith.domain.Book; // Book을 직접 import할 필요는 없습니다.
+import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.Character;
 import com.kw.readwith.domain.mapping.CharacterPovSummary;
 import com.kw.readwith.dto.admin.CharacterPovSummaryDTO;
+import com.kw.readwith.dto.book.ChapterPovSummaryDTO;
+import com.kw.readwith.dto.book.ChapterPovSummaryResponseDTO;
+import com.kw.readwith.repository.BookRepository;
 import com.kw.readwith.repository.ChapterRepository;
 import com.kw.readwith.repository.CharacterPovSummaryRepository;
 import com.kw.readwith.repository.CharacterRepository;
@@ -25,6 +28,7 @@ public class CharacterPovSummaryService {
     private final CharacterPovSummaryRepository characterPovSummaryRepository;
     private final ChapterRepository chapterRepository;
     private final CharacterRepository characterRepository;
+    private final BookRepository bookRepository;
 
     @Transactional
     public Long createCharacterPovSummary(Long chapterId, Long characterId, String summaryText) {
@@ -58,5 +62,59 @@ public class CharacterPovSummaryService {
                         summary.getCharacter().getId(),
                         summary.getSummaryText()))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * 특정 책의 특정 챕터에 대한 인물별 시점요약을 조회합니다.
+     * @param bookId 책 ID
+     * @param chapterIdx 챕터 인덱스 (1-based)
+     * @param userId 사용자 ID
+     * @return 챕터 시점요약 응답 DTO
+     */
+    public ChapterPovSummaryResponseDTO getChapterPovSummaries(Long bookId, Integer chapterIdx, Long userId) {
+        // 책 접근 권한 확인 및 조회
+        Book book = validateBookAccess(bookId, userId);
+
+        // 챕터 존재 여부 확인
+        Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+
+        // 시점요약 조회
+        List<CharacterPovSummary> povSummaries = characterPovSummaryRepository.findByBookIdAndChapterIdx(bookId, chapterIdx);
+
+        // DTO 변환
+        List<ChapterPovSummaryDTO> povSummaryDTOs = povSummaries.stream()
+                .map(summary -> new ChapterPovSummaryDTO(
+                        summary.getCharacter().getId(),
+                        summary.getCharacter().getName(),
+                        summary.getSummaryText(),
+                        summary.getCharacter().isMainCharacter()
+                ))
+                .collect(Collectors.toList());
+
+        return new ChapterPovSummaryResponseDTO(
+                bookId,
+                chapterIdx,
+                chapter.getTitle(),
+                povSummaryDTOs
+        );
+    }
+
+    /**
+     * 책 접근 권한 확인 및 조회
+     */
+    private Book validateBookAccess(Long bookId, Long userId) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+
+        // 접근 권한 확인: 기본 제공 도서 또는 본인이 업로드한 도서
+        boolean hasAccess = book.isDefault() || 
+                           (book.getUploadedBy() != null && book.getUploadedBy().getId().equals(userId));
+        
+        if (!hasAccess) {
+            throw new GeneralException(ErrorStatus.BOOK_ACCESS_DENIED);
+        }
+
+        return book;
     }
 }

--- a/src/main/java/com/kw/readwith/web/controller/ChapterController.java
+++ b/src/main/java/com/kw/readwith/web/controller/ChapterController.java
@@ -1,0 +1,34 @@
+package com.kw.readwith.web.controller;
+
+import com.kw.readwith.apiPayload.ApiResponse;
+import com.kw.readwith.dto.book.ChapterPovSummaryResponseDTO;
+import com.kw.readwith.service.CharacterPovSummaryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/books")
+@RequiredArgsConstructor
+@Tag(name = "Chapter", description = "챕터 관련 API")
+public class ChapterController {
+
+    private final CharacterPovSummaryService characterPovSummaryService;
+
+    // 챕터당 각 인물별 시점요약 조회
+    @GetMapping("/{bookId}/chapters/{chapterIdx}/pov-summaries")
+    @Operation(summary = "챕터당 각 인물별 시점요약 조회", 
+               description = "특정 챕터에서 등장하는 각 인물의 시점에서 바라본 해당 챕터의 요약 정보를 조회합니다.")
+    public ApiResponse<ChapterPovSummaryResponseDTO> getChapterPovSummaries(
+            @Parameter(description = "책 ID", required = true)
+            @PathVariable Long bookId,
+            @Parameter(description = "챕터 인덱스 (1-based)", required = true)
+            @PathVariable Integer chapterIdx) {
+        
+        Long userId = 1L; // TODO: 실제 인증된 사용자 ID로 교체
+        ChapterPovSummaryResponseDTO response = characterPovSummaryService.getChapterPovSummaries(bookId, chapterIdx, userId);
+        return ApiResponse.onSuccess(response);
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
특정 챕터에서 등장하는 각 인물의 시점에서 바라본 해당 챕터의 요약 정보를 조회할 수 있는 새로운 API를 구현했습니다. 기존의 CharacterPovSummary 도메인을 활용하여 사용자가 동일한 챕터를 여러 인물의 관점에서 이해할 수 있도록 지원합니다.

## 📋 변경 사항
🆕 신규 파일
- ChapterPovSummaryDTO.java - 인물별 시점요약 정보 DTO
- ChapterPovSummaryResponseDTO.java - API 응답 구조 DTO
- ChapterController.java - 챕터 관련 API 컨트롤러

🔧 수정된 파일
- CharacterPovSummaryRepository.java - 새로운 쿼리 메서드 추가
- CharacterPovSummaryService.java - 시점요약 조회 비즈니스 로직 구현
- DataLoader.java - 테스트용 시점요약 데이터 추가

> 새로운 API 엔드포인트: GET /api/books/{bookId}/chapters/{chapterIdx}/pov-summaries
접근 권한 검증: 기본 제공 도서 또는 본인 업로드 도서만 접근 가능
정렬 기능: 주요 인물 우선, 동일 중요도 내에서는 이름순 정렬
테스트 데이터: 해리포터(6개), 반지의 제왕(3개) 시점요약 데이터 추가

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
