### PR TITLE
feat: 관계 정보 삭제 로직 수정 및 API 테스트를 위한 CORS 설정 추가

### DIFF
--- a/src/main/java/com/kw/readwith/config/DataLoader.java
+++ b/src/main/java/com/kw/readwith/config/DataLoader.java
@@ -335,7 +335,7 @@ public class DataLoader implements CommandLineRunner {
                 .endPos(12000)
                 .rawText("간달프가 프로도에게 반지의 진실을 말해주었다...")
                 .summaryText("간달프가 반지가 사우론의 절대반지임을 밝히고, 프로도가 반지를 파괴해야 함을 알게 된다.")
-                .povSummariesCached(true)
+                .povSummariesCached(false)
                 .build();
         chapterRepository.save(chapter2);
 

--- a/src/main/java/com/kw/readwith/config/SecurityConfig.java
+++ b/src/main/java/com/kw/readwith/config/SecurityConfig.java
@@ -34,13 +34,13 @@ public class SecurityConfig {
         http
                 // CSRF 비활성화 (JWT 사용)
                 .csrf(AbstractHttpConfigurer::disable)
-                
+
                 // CORS 설정
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                
+
                 // 세션 비활성화 (JWT 사용)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                
+
                 // 요청 권한 설정
                 .authorizeHttpRequests(auth -> auth
                         // 공개 엔드포인트
@@ -63,19 +63,22 @@ public class SecurityConfig {
                                 "/api/bookmarks/**", // 북마크
                                 "/api/favorites/**"  // 즐겨찾기
                         ).authenticated()
+
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN") // 관리자
+
                         // 나머지는 인증 필요
                         .anyRequest().authenticated()
                 )
-                
+
                 // JWT 필터 추가
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                
+
                 // 예외 처리 설정
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                         .accessDeniedHandler(jwtAccessDeniedHandler)
                 )
-                
+
                 // 보안 헤더 설정
                 .headers(headers -> headers
                         .frameOptions(frameOptions -> frameOptions.deny())  // X-Frame-Options: DENY
@@ -92,25 +95,25 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        
+
         // 허용할 오리진 설정
         configuration.setAllowedOriginPatterns(List.of("*"));
-        
+
         // 허용할 HTTP 메서드
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-        
+
         // 허용할 헤더
         configuration.setAllowedHeaders(List.of("*"));
-        
+
         // 인증 정보 포함 허용
         configuration.setAllowCredentials(true);
-        
+
         // 노출할 헤더 설정
         configuration.setExposedHeaders(Arrays.asList("Authorization", "Content-Type"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
-        
+
         return source;
     }
 

--- a/src/main/java/com/kw/readwith/config/WebConfig.java
+++ b/src/main/java/com/kw/readwith/config/WebConfig.java
@@ -4,13 +4,15 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.filter.ShallowEtagHeaderFilter;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class WebConfig {
+public class WebConfig implements WebMvcConfigurer {
 
     /**
      * Spring의 자동 ETag 지원을 위한 ShallowEtagHeaderFilter 설정
-     * 
+     *
      * 동작 원리:
      * 1. 응답 본문의 MD5 해시값으로 ETag 자동 생성
      * 2. 클라이언트의 If-None-Match 헤더와 비교
@@ -29,5 +31,15 @@ public class WebConfig {
         filterRegistrationBean.setOrder(1);
         
         return filterRegistrationBean;
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**") // /api/ 로 시작하는 모든 경로에 대해
+                .allowedOrigins("http://localhost:5173") // 프론트엔드 서버 주소 허용
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS") // 허용할 HTTP 메서드
+                .allowedHeaders("*") // 모든 헤더 허용
+                .allowCredentials(true)
+                .maxAge(3600);
     }
 }

--- a/src/main/java/com/kw/readwith/domain/User.java
+++ b/src/main/java/com/kw/readwith/domain/User.java
@@ -2,10 +2,12 @@ package com.kw.readwith.domain;
 
 import com.kw.readwith.domain.common.BaseEntity;
 import com.kw.readwith.domain.enums.Provider;
+import com.kw.readwith.domain.enums.Role;
 import com.kw.readwith.domain.mapping.UserReadState;
 import com.kw.readwith.domain.mapping.Favorite;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +39,10 @@ public class User extends BaseEntity {
 
     @Column(name = "profile_img_url", length = 255)
     private String profileImgUrl;
+
+    @Column(name = "is_admin", nullable = false)
+    @ColumnDefault("false")
+    private boolean isAdmin;
 
     @Column(name = "jwt_refresh_token", columnDefinition = "CHAR(128)")
     private String jwtRefreshToken;
@@ -70,5 +76,9 @@ public class User extends BaseEntity {
         if (profileImgUrl != null && !profileImgUrl.isBlank()) {
             this.profileImgUrl = profileImgUrl;
         }
+    }
+
+    public Role getRole() {
+        return this.isAdmin ? Role.ADMIN : Role.USER;
     }
 }

--- a/src/main/java/com/kw/readwith/domain/enums/Role.java
+++ b/src/main/java/com/kw/readwith/domain/enums/Role.java
@@ -1,0 +1,13 @@
+package com.kw.readwith.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String key;
+}

--- a/src/main/java/com/kw/readwith/repository/EventCharacterStatRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventCharacterStatRepository.java
@@ -12,4 +12,8 @@ import java.util.Optional;
 public interface EventCharacterStatRepository extends JpaRepository<EventCharacterStat, Long> {
 
     Optional<EventCharacterStat> findByEventAndCharacter(Event event, Character character);
+
+    boolean existsByEvent(Event event);
+
+    int deleteByEvent(Event event);
 }

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -164,7 +164,7 @@ public class AdminService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
         List<CharacterPovSummary> allNewSummaries = new ArrayList<>();
-        Pattern pattern = Pattern.compile("chapter(\\d+)_perspective_summaries\\.json");
+        Pattern pattern = Pattern.compile("chapter(\\d+)_perspective_summaries_Ko\\.json");
 
         for (MultipartFile summaryFile : summaryFiles) {
             String filename = summaryFile.getOriginalFilename();

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -459,10 +459,27 @@ public class AdminService {
         Event event = eventRepository.findByChapterAndIdx(chapter, eventIdx)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND));
 
-        if (!eventRelationshipEdgeRepository.existsByEvent(event)) {
-            throw new GeneralException(ErrorStatus.NO_RELATIONSHIPS_TO_DELETE);
+        // 삭제할 데이터가 있는지 확인
+        boolean edgesExist = eventRelationshipEdgeRepository.existsByEvent(event);
+        boolean statsExist = statRepository.existsByEvent(event);
+
+        if (!edgesExist && !statsExist) {
+            throw new GeneralException(ErrorStatus.NO_RELATIONSHIPS_TO_DELETE, "해당 이벤트에 삭제할 관계 정보가 없습니다.");
         }
-        return eventRelationshipEdgeRepository.deleteByEvent(event);
+
+        int deletedCount = 0;
+
+        // EventRelationshipEdge 데이터 삭제
+        if (edgesExist) {
+            deletedCount += eventRelationshipEdgeRepository.deleteByEvent(event);
+        }
+
+        // EventCharacterStat 데이터 삭제
+        if (statsExist) {
+            deletedCount += statRepository.deleteByEvent(event);
+        }
+
+        return deletedCount;
     }
 
     /*


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
로컬 프론트엔드 개발 환경에서의 API 테스트를 지원하기 위해 CORS 설정을 추가했습니다.
관리자 API 중 '관계 정보 삭제' 시, event_character_stat 테이블의 관련된 행을 함께 삭제하도록 수정했습니다.

## 📋 변경 사항
- WebConfig.java에 CORS 설정을 추가하여 로컬 프론트엔드 환경(http://localhost:5173)에서 API 접근이 가능하도록 설정
- event_relationship_edge 테이블의 데이터 삭제 시, 연관된 event_character_stat 테이블의 데이터도 함께 삭제하도록 로직 수정하여, 관계 정보가 삭제될 때 해당 이벤트의 캐릭터 통계 데이터가 Orphan Data로 남지 않도록 데이터 무결성을 확보

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
