### PR TITLE
feat: 하드코딩된 userId를 실제 인증된 사용자 id로 교체

### DIFF
--- a/src/main/java/com/kw/readwith/web/controller/BookController.java
+++ b/src/main/java/com/kw/readwith/web/controller/BookController.java
@@ -1,11 +1,15 @@
 package com.kw.readwith.web.controller;
 
 import com.kw.readwith.apiPayload.ApiResponse;
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.dto.book.BookDetailDTO;
 import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.service.BookService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -21,6 +25,14 @@ public class BookController {
 
     private final BookService bookService;
 
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof Long) {
+            return (Long) authentication.getPrincipal();
+        }
+        throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+    }
+
     // 도서 목록 조회
     @GetMapping
     @Operation(summary = "도서 목록 조회", description = "검색/필터/정렬 파라미터를 이용해 도서 목록을 반환합니다.")
@@ -30,7 +42,7 @@ public class BookController {
             @RequestParam(defaultValue = "updatedAt") String sort,
             @RequestParam(required = false) Boolean favorite
     ) {
-        Long userId = 1L; // TODO 인증된 사용자
+        Long userId = getCurrentUserId();
         List<BookSummaryDTO> response = bookService.getBooks(q, language, favorite, sort, userId);
         return ApiResponse.onSuccess(response);
     }
@@ -39,7 +51,7 @@ public class BookController {
     @GetMapping("/{bookId}")
     @Operation(summary = "단일 도서 조회", description = "도서 ID로 단일 도서를 조회합니다.")
     public ApiResponse<BookDetailDTO> getBook(@PathVariable Long bookId) {
-        Long userId = 1L; // TODO 인증된 사용자
+        Long userId = getCurrentUserId();
         BookDetailDTO response = bookService.getBook(bookId, userId);
         return ApiResponse.onSuccess(response);
     }
@@ -51,7 +63,7 @@ public class BookController {
                                                     @RequestPart("title") String title,
                                                     @RequestPart("author") String author,
                                                     @RequestPart("language") String language) {
-        Long userId = 1L; // TODO 인증된 사용자
+        Long userId = getCurrentUserId();
         BookDetailDTO response = bookService.uploadBook(userId, file, title, author, language);
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/kw/readwith/web/controller/BookmarkController.java
+++ b/src/main/java/com/kw/readwith/web/controller/BookmarkController.java
@@ -1,6 +1,8 @@
 package com.kw.readwith.web.controller;
 
 import com.kw.readwith.apiPayload.ApiResponse;
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.dto.bookmark.BookmarkResponseDTO;
 import com.kw.readwith.dto.bookmark.CreateBookmarkRequestDTO;
 import com.kw.readwith.dto.bookmark.UpdateBookmarkRequestDTO;
@@ -10,6 +12,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,6 +26,14 @@ public class BookmarkController {
 
     private final BookmarkService bookmarkService;
 
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof Long) {
+            return (Long) authentication.getPrincipal();
+        }
+        throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+    }
+
     /**
      * 북마크 목록 조회
      */
@@ -33,7 +45,7 @@ public class BookmarkController {
             @Parameter(description = "정렬 방식 (time_desc: 최신순, time_asc: 오래된순)", example = "time_desc")
             @RequestParam(defaultValue = "time_desc") String sort) {
         
-        Long userId = 1L; // TODO: 실제 인증된 사용자 ID로 교체
+        Long userId = getCurrentUserId();
         List<BookmarkResponseDTO> bookmarks = bookmarkService.getBookmarks(userId, bookId, sort);
         return ApiResponse.onSuccess(bookmarks);
     }
@@ -46,7 +58,7 @@ public class BookmarkController {
     public ApiResponse<BookmarkResponseDTO> createBookmark(
             @Valid @RequestBody CreateBookmarkRequestDTO requestDTO) {
         
-        Long userId = 1L; // TODO: 실제 인증된 사용자 ID로 교체
+        Long userId = getCurrentUserId();
         BookmarkResponseDTO bookmark = bookmarkService.createBookmark(userId, requestDTO);
         return ApiResponse.onSuccess(bookmark);
     }
@@ -61,7 +73,7 @@ public class BookmarkController {
             @PathVariable Long bookmarkId,
             @Valid @RequestBody UpdateBookmarkRequestDTO requestDTO) {
         
-        Long userId = 1L; // TODO: 실제 인증된 사용자 ID로 교체
+        Long userId = getCurrentUserId();
         BookmarkResponseDTO bookmark = bookmarkService.updateBookmark(userId, bookmarkId, requestDTO);
         return ApiResponse.onSuccess(bookmark);
     }
@@ -75,7 +87,7 @@ public class BookmarkController {
             @Parameter(description = "북마크 ID", required = true)
             @PathVariable Long bookmarkId) {
         
-        Long userId = 1L; // TODO: 실제 인증된 사용자 ID로 교체
+        Long userId = getCurrentUserId();
         bookmarkService.deleteBookmark(userId, bookmarkId);
         return ApiResponse.onSuccess(null);
     }

--- a/src/main/java/com/kw/readwith/web/controller/ChapterController.java
+++ b/src/main/java/com/kw/readwith/web/controller/ChapterController.java
@@ -1,12 +1,16 @@
 package com.kw.readwith.web.controller;
 
 import com.kw.readwith.apiPayload.ApiResponse;
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.dto.book.ChapterPovSummaryResponseDTO;
 import com.kw.readwith.service.CharacterPovSummaryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,6 +20,14 @@ import org.springframework.web.bind.annotation.*;
 public class ChapterController {
 
     private final CharacterPovSummaryService characterPovSummaryService;
+
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof Long) {
+            return (Long) authentication.getPrincipal();
+        }
+        throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+    }
 
     // 챕터당 각 인물별 시점요약 조회
     @GetMapping("/{bookId}/chapters/{chapterIdx}/pov-summaries")
@@ -27,7 +39,7 @@ public class ChapterController {
             @Parameter(description = "챕터 인덱스 (1-based)", required = true)
             @PathVariable Integer chapterIdx) {
         
-        Long userId = 1L; // TODO: 실제 인증된 사용자 ID로 교체
+        Long userId = getCurrentUserId();
         ChapterPovSummaryResponseDTO response = characterPovSummaryService.getChapterPovSummaries(bookId, chapterIdx, userId);
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/kw/readwith/web/controller/FavoriteController.java
+++ b/src/main/java/com/kw/readwith/web/controller/FavoriteController.java
@@ -1,9 +1,13 @@
 package com.kw.readwith.web.controller;
 
 import com.kw.readwith.apiPayload.ApiResponse;
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.service.FavoriteService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,11 +22,19 @@ public class FavoriteController {
 
     private final FavoriteService favoriteService;
 
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof Long) {
+            return (Long) authentication.getPrincipal();
+        }
+        throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+    }
+
     // 즐겨찾기 추가
     @PostMapping("/{bookId}")
     @Operation(summary = "즐겨찾기 추가", description = "도서를 즐겨찾기 목록에 추가합니다.")
     public ApiResponse<Void> addFavorite(@PathVariable Long bookId) {
-        Long userId = 1L; // TODO 인증된 사용자
+        Long userId = getCurrentUserId();
         favoriteService.addFavorite(userId, bookId);
         return ApiResponse.onSuccess(null);
     }
@@ -31,7 +43,7 @@ public class FavoriteController {
     @DeleteMapping("/{bookId}")
     @Operation(summary = "즐겨찾기 삭제", description = "즐겨찾기 목록에서 도서를 제거합니다.")
     public ApiResponse<Void> removeFavorite(@PathVariable Long bookId) {
-        Long userId = 1L; // TODO 인증된 사용자
+        Long userId = getCurrentUserId();
         favoriteService.removeFavorite(userId, bookId);
         return ApiResponse.onSuccess(null);
     }
@@ -40,7 +52,7 @@ public class FavoriteController {
     @GetMapping
     @Operation(summary = "즐겨찾기 목록 조회", description = "사용자의 즐겨찾기 도서 목록을 조회합니다.")
     public ApiResponse<List<BookSummaryDTO>> getFavorites() {
-        Long userId = 1L; // TODO 인증된 사용자
+        Long userId = getCurrentUserId();
         List<BookSummaryDTO> response = favoriteService.getFavoriteBooks(userId);
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/kw/readwith/web/controller/GraphController.java
+++ b/src/main/java/com/kw/readwith/web/controller/GraphController.java
@@ -1,6 +1,8 @@
 package com.kw.readwith.web.controller;
 
 import com.kw.readwith.apiPayload.ApiResponse;
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.dto.graph.FineGraphResponseDTO;
 import com.kw.readwith.dto.graph.MacroGraphResponseDTO;
 import com.kw.readwith.service.FineGraphService;
@@ -9,6 +11,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,6 +23,14 @@ public class GraphController {
 
     private final FineGraphService fineGraphService;
     private final MacroGraphService macroGraphService;
+
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof Long) {
+            return (Long) authentication.getPrincipal();
+        }
+        throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+    }
 
     /**
      * 세밀(이벤트) 그래프 조회
@@ -36,7 +48,7 @@ public class GraphController {
             @Parameter(description = "이벤트 인덱스", required = true, example = "3")
             @RequestParam Integer eventIdx) {
 
-        Long userId = 1L; // TODO: 실제 인증된 사용자 ID로 교체
+        Long userId = getCurrentUserId();
         FineGraphResponseDTO response = fineGraphService.getFineGraph(bookId, chapterIdx, eventIdx, userId);
         return ApiResponse.onSuccess(response);
     }
@@ -55,7 +67,7 @@ public class GraphController {
             @Parameter(description = "조회할 마지막 챕터 인덱스", required = true, example = "3")
             @RequestParam Integer uptoChapter) {
 
-        Long userId = 1L; // TODO: 실제 인증된 사용자 ID로 교체
+        Long userId = getCurrentUserId();
         MacroGraphResponseDTO response = macroGraphService.getMacroGraph(bookId, uptoChapter, userId);
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/kw/readwith/web/controller/ManifestController.java
+++ b/src/main/java/com/kw/readwith/web/controller/ManifestController.java
@@ -1,6 +1,8 @@
 package com.kw.readwith.web.controller;
 
 import com.kw.readwith.apiPayload.ApiResponse;
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.dto.manifest.ManifestResponseDTO;
 import com.kw.readwith.service.ManifestService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,6 +10,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -17,6 +21,14 @@ import org.springframework.web.bind.annotation.*;
 public class ManifestController {
 
     private final ManifestService manifestService;
+
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof Long) {
+            return (Long) authentication.getPrincipal();
+        }
+        throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+    }
 
     /**
      * 책 구조/캐시 패키지 조회
@@ -52,10 +64,7 @@ public class ManifestController {
             )
             @PathVariable Long bookId) {
         
-        // TODO: 실제 인증된 사용자 ID 가져오기
-        // 현재는 임시로 하드코딩된 값 사용
-        Long userId = 1L; // JWT에서 추출해야 함
-        
+        Long userId = getCurrentUserId();
         ManifestResponseDTO response = manifestService.getBookManifest(bookId, userId);
         return ApiResponse.onSuccess(response);
     }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
JWT 인증 시스템이 구현된 후, 모든 API 엔드포인트에서 하드코딩되어 있던 userId = 1L을 실제 인증된 사용자 ID로 교체하는 작업을 수행했습니다.

## 📋 변경 사항
- 공통 유틸리티 메소드 추가
- userId 하드코딩 교체

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
