### PR TITLE
feat: 이벤트 업로드 시, 존재하지 않는 챕터 자동 생성 기능 추가

### DIFF
--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -123,7 +123,13 @@ public class AdminService {
 
             Integer chapterIdx = Integer.parseInt(matcher.group(1));
             Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
-                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND, "챕터 인덱스 " + chapterIdx + "를 찾을 수 없습니다."));
+                    .orElseGet(() -> {
+                        Chapter newChapter = Chapter.builder()
+                                .book(book)
+                                .idx(chapterIdx)
+                                .build();
+                        return chapterRepository.save(newChapter);
+                    });
 
             // 이미 데이터가 있는 챕터는 업로드 불가
             if (eventRepository.existsByChapter(chapter)) {


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
관리자의 이벤트 데이터 업로드 편의성을 향상시키기 위해, 파일명에 해당하는 챕터가 DB에 존재하지 않을 경우 자동으로 생성하는 기능을 추가했습니다.

## 📋 변경 사항
AdminService의 uploadEvents 메서드 내에서 chapterRepository.findByBookIdAndIdx() 조회 결과가 없을 경우,
.orElseGet()을 사용하여 새로운 Chapter 엔터티를 생성하고 저장하도록 로직을 수정했습니다.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
