### PR TITLE
fix: spring security 설정 변경으로 health 엔드포인트 차단해제

### DIFF
--- a/src/main/java/com/kw/readwith/config/SecurityConfig.java
+++ b/src/main/java/com/kw/readwith/config/SecurityConfig.java
@@ -54,7 +54,8 @@ public class SecurityConfig {
                                 "/webjars/**",
                                 "/favicon.ico",
                                 "/error",
-                                "/actuator/health"  // 헬스체크
+                                "/health",  // ELB 헬스체크 (EB 배포 필수)
+                                "/actuator/health"  // Spring Actuator 헬스체크
                         ).permitAll()
                         // 인증이 필요한 엔드포인트
                         .requestMatchers(


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
Spring Security가 ELB 헬스체크 엔드포인트를 차단하여 EB 배포 실패하는 버그 수정

- 2개월간 GitHub Actions는 통과하지만 실제 EB 환경 배포 실패
- EB 콘솔에서 인스턴스 상태가 **Severe/Degraded** 지속
- 로그: `Target.ResponseCodeMismatch`, `HTTP 4xx 100%`

## 📋 변경 사항
**SecurityConfig.java**
- `/health` 엔드포인트를 `permitAll()` 목록에 추가
- ELB 헬스체크가 인증 없이 접근 가능하도록 수정

### 원인
- ELB가 `/health` 경로로 헬스체크 요청
- SecurityConfig에는 `/actuator/health`만 허용
- `/health` 엔드포인트가 차단되어 **401 Unauthorized** 응답
- EB가 인스턴스를 비정상으로 판단

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
