### PR TITLE
fix: 캐릭터 이미지 비동기 생성 시 LazyInitializationException 해결 (#46)

### DIFF
--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -96,9 +96,13 @@ public class AdminService {
             if (!newCharacters.isEmpty()) {
                 List<Character> savedCharacters = characterRepository.saveAll(newCharacters);
                 
-                // 캐릭터 저장 후 이미지 생성 비동기 실행
+                // 캐릭터 ID만 추출하여 비동기 메서드에 전달
+                List<Long> characterIds = savedCharacters.stream()
+                        .map(Character::getId)
+                        .collect(Collectors.toList());
+                
                 log.info("캐릭터 {}명 저장 완료. 이미지 생성을 시작합니다.", savedCharacters.size());
-                characterImageService.generateImagesAsync(savedCharacters);
+                characterImageService.generateImagesAsync(characterIds);
             }
             return newCharacters.size();
 

--- a/src/main/java/com/kw/readwith/service/CharacterImageService.java
+++ b/src/main/java/com/kw/readwith/service/CharacterImageService.java
@@ -41,12 +41,12 @@ public class CharacterImageService {
      * 여러 캐릭터의 이미지를 비동기로 생성
      * 배치 단위로 처리하며, Rate Limit 방지를 위해 요청 간 딜레이 적용
      * 
-     * @param characters 이미지를 생성할 캐릭터 리스트
+     * @param characterIds 이미지를 생성할 캐릭터 ID 리스트
      * @return 비동기 작업 결과
      */
     @Async("imageGenerationExecutor")
-    public CompletableFuture<Void> generateImagesAsync(List<Character> characters) {
-        int totalCount = characters.size();
+    public CompletableFuture<Void> generateImagesAsync(List<Long> characterIds) {
+        int totalCount = characterIds.size();
         log.info("캐릭터 이미지 생성 시작 - 총 {}명 (배치 크기: {}명)", 
             totalCount, imageProperties.getBatchSize());
         
@@ -55,11 +55,15 @@ public class CharacterImageService {
         int failedCount = 0;
         int skippedCount = 0;
         
-        for (int i = 0; i < characters.size(); i++) {
-            Character character = characters.get(i);
+        for (int i = 0; i < characterIds.size(); i++) {
+            Long characterId = characterIds.get(i);
             processedCount++;
             
             try {
+                // 엔티티를 fetch join으로 재조회 (Book도 함께 로딩)
+                Character character = characterRepository.findByIdWithBook(characterId)
+                        .orElseThrow(() -> new RuntimeException("캐릭터를 찾을 수 없습니다: " + characterId));
+                
                 // 이미 이미지가 있거나 생성 완료된 경우 스킵
                 if (character.getProfileImage() != null && !character.getProfileImage().isEmpty() 
                     && character.getImageGenerationStatus() == ImageGenerationStatus.COMPLETED) {
@@ -70,19 +74,19 @@ public class CharacterImageService {
                 }
 
                 // 상태를 PENDING으로 설정
-                transactionService.updateStatus(character.getId(), ImageGenerationStatus.PENDING);
+                transactionService.updateStatus(characterId, ImageGenerationStatus.PENDING);
                 
                 log.info("[{}/{}] 캐릭터 '{}' 이미지 생성 시작...", 
                     processedCount, totalCount, character.getName());
                 
-                generateAndSaveImage(character);
+                generateAndSaveImage(characterId);
                 successCount++;
                 
                 log.info("[{}/{}] 캐릭터 '{}' 이미지 생성 완료 ✓", 
                     processedCount, totalCount, character.getName());
                 
                 // Rate Limit 방지: 마지막 캐릭터가 아니면 딜레이 적용
-                if (i < characters.size() - 1) {
+                if (i < characterIds.size() - 1) {
                     long delay = imageProperties.getDelayBetweenRequestsMs();
                     log.debug("다음 요청까지 {}ms 대기...", delay);
                     Thread.sleep(delay);
@@ -95,15 +99,15 @@ public class CharacterImageService {
                 }
                 
             } catch (InterruptedException e) {
-                log.error("캐릭터 '{}' 처리 중 인터럽트 발생", character.getName(), e);
+                log.error("캐릭터 ID {} 처리 중 인터럽트 발생", characterId, e);
                 Thread.currentThread().interrupt();
                 failedCount++;
-                saveFallbackImage(character);
+                saveFallbackImage(characterId);
                 break; // 인터럽트 시 중단
             } catch (Exception e) {
-                log.error("캐릭터 '{}' 이미지 생성 실패: {}", character.getName(), e.getMessage(), e);
+                log.error("캐릭터 ID {} 이미지 생성 실패: {}", characterId, e.getMessage(), e);
                 failedCount++;
-                saveFallbackImage(character);
+                saveFallbackImage(characterId);
             }
         }
         
@@ -119,15 +123,19 @@ public class CharacterImageService {
     /**
      * 단일 캐릭터의 이미지를 생성하고 저장
      * 
-     * @param character 이미지를 생성할 캐릭터
+     * @param characterId 이미지를 생성할 캐릭터 ID
      */
     @Transactional
-    public void generateAndSaveImage(Character character) {
+    public void generateAndSaveImage(Long characterId) {
+        // 엔티티를 fetch join으로 재조회 (Book도 함께 로딩)
+        Character character = characterRepository.findByIdWithBook(characterId)
+                .orElseThrow(() -> new RuntimeException("캐릭터를 찾을 수 없습니다: " + characterId));
+        
         log.info("캐릭터 '{}' 이미지 생성 시작", character.getName());
 
         try {
             // 상태를 GENERATING으로 변경
-            transactionService.updateStatus(character.getId(), ImageGenerationStatus.GENERATING);
+            transactionService.updateStatus(characterId, ImageGenerationStatus.GENERATING);
 
             // 1. 프롬프트 생성
             String prompt = buildDallePrompt(character);
@@ -162,13 +170,13 @@ public class CharacterImageService {
             log.info("캐릭터 '{}' S3 업로드 완료: {}", character.getName(), s3Url);
             
             // 6. Character 엔티티 업데이트 (URL과 상태를 COMPLETED로)
-            transactionService.updateImageAndStatus(character.getId(), s3Url, ImageGenerationStatus.COMPLETED);
+            transactionService.updateImageAndStatus(characterId, s3Url, ImageGenerationStatus.COMPLETED);
             
             log.info("캐릭터 '{}' 이미지 생성 및 저장 완료", character.getName());
 
         } catch (Exception e) {
             log.error("캐릭터 '{}' 이미지 생성 중 오류 발생", character.getName(), e);
-            transactionService.updateStatus(character.getId(), ImageGenerationStatus.FAILED);
+            transactionService.updateStatus(characterId, ImageGenerationStatus.FAILED);
             throw new RuntimeException("이미지 생성 중 오류 발생: " + character.getName(), e);
         }
     }
@@ -251,15 +259,15 @@ public class CharacterImageService {
     /**
      * 이미지 생성 실패 시 폴백 이미지로 설정
      *
-     * @param character 대상 캐릭터
+     * @param characterId 대상 캐릭터 ID
      */
-    private void saveFallbackImage(Character character) {
+    private void saveFallbackImage(Long characterId) {
         try {
             String fallbackUrl = imageProperties.getFallbackUrl();
-            transactionService.updateImageAndStatus(character.getId(), fallbackUrl, ImageGenerationStatus.FAILED);
-            log.info("캐릭터 '{}' - 폴백 이미지 설정 완료", character.getName());
+            transactionService.updateImageAndStatus(characterId, fallbackUrl, ImageGenerationStatus.FAILED);
+            log.info("캐릭터 ID {} - 폴백 이미지 설정 완료", characterId);
         } catch (Exception e) {
-            log.error("캐릭터 '{}' - 폴백 이미지 설정 실패", character.getName(), e);
+            log.error("캐릭터 ID {} - 폴백 이미지 설정 실패", characterId, e);
         }
     }
 }


### PR DESCRIPTION


## 🧑🏻‍💻 PR 작업 내역 요약
캐릭터 JSON 업로드 시 DB 저장은 되지만 이미지 생성이 실행되지 않는 문제

## 💡 해결 방안
- AdminService에서 Character 엔티티 대신 ID만 전달하도록 수정
- CharacterImageService 비동기 메서드에서 fetch join으로 엔티티 재조회
- 트랜잭션 경계 분리로 영속성 컨텍스트 문제 해결

## 📋 변경 사항
비동기 메서드에 엔티티를 직접 전달하는 대신 ID만 전달하고, 
비동기 컨텍스트 내에서 fetch join으로 재조회하도록 리팩토링

**AdminService.java**
- Character 엔티티 → Character ID 리스트로 변경하여 비동기 메서드 호출

**CharacterImageService.java**
- `generateImagesAsync()`: `List<Character>` → `List<Long>` 파라미터로 변경
- `generateAndSaveImage()`: `Character` → `Long` 파라미터로 변경
- `saveFallbackImage()`: `Character` → `Long` 파라미터로 변경
- 각 메서드 내부에서 `findByIdWithBook()` fetch join으로 엔티티 재조회


## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
