### PR TITLE
feat: 리다이렉트 url를 받아서, 인증 진행

### DIFF
--- a/src/main/java/com/kw/readwith/dto/auth/GoogleLoginRequestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/auth/GoogleLoginRequestDTO.java
@@ -13,4 +13,9 @@ public class GoogleLoginRequestDTO {
             example = "4/0AVGzR1C2L_Wm4VjatrKl3S2cjMUkm6gpkJ6aupz1jbDYuRDyHjtNovgPuygz5l2vFzM11A",
             required = true)
     private String code;
+    
+    @Schema(description = "프론트엔드에서 사용한 redirect URI", 
+            example = "http://localhost:5173/auth/callback",
+            required = true)
+    private String redirectUri;
 }

--- a/src/main/java/com/kw/readwith/service/GoogleOAuth2Service.java
+++ b/src/main/java/com/kw/readwith/service/GoogleOAuth2Service.java
@@ -32,15 +32,12 @@ public class GoogleOAuth2Service {
     @Value("${spring.security.oauth2.client.registration.google.client-secret}")
     private String clientSecret;
 
-    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
-    private String redirectUri;
-
     /**
      * Google OAuth2 인증 코드로 사용자 정보 가져오기 및 사용자 생성/업데이트
      */
-    public User authenticateWithGoogle(String authorizationCode) {
-        // 1. 인증 코드로 액세스 토큰 요청
-        String accessToken = getAccessToken(authorizationCode);
+    public User authenticateWithGoogle(String authorizationCode, String frontendRedirectUri) {
+        // 1. 인증 코드로 액세스 토큰 요청 (프론트엔드가 사용한 redirectUri 전달)
+        String accessToken = getAccessToken(authorizationCode, frontendRedirectUri);
         
         // 2. 액세스 토큰으로 사용자 정보 요청
         OAuth2UserInfo userInfo = getUserInfo(accessToken);
@@ -49,19 +46,19 @@ public class GoogleOAuth2Service {
         return findOrCreateUser(userInfo);
     }
 
-    private String getAccessToken(String authorizationCode) {
+    private String getAccessToken(String authorizationCode, String frontendRedirectUri) {
         String tokenUrl = "https://oauth2.googleapis.com/token";
         
         log.info("Google 액세스 토큰 요청 시작");
         log.info("Client ID: {}", clientId != null ? clientId.substring(0, Math.min(10, clientId.length())) + "..." : "null");
-        log.info("Redirect URI: {}", redirectUri);
+        log.info("Redirect URI: {}", frontendRedirectUri);
         log.info("Authorization Code: {}", authorizationCode != null ? authorizationCode.substring(0, Math.min(10, authorizationCode.length())) + "..." : "null");
         
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("code", authorizationCode);
         params.add("client_id", clientId);
         params.add("client_secret", clientSecret);
-        params.add("redirect_uri", redirectUri);
+        params.add("redirect_uri", frontendRedirectUri);  // 프론트엔드가 사용한 URI
         params.add("grant_type", "authorization_code");
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/kw/readwith/web/controller/GoogleAuthController.java
+++ b/src/main/java/com/kw/readwith/web/controller/GoogleAuthController.java
@@ -58,12 +58,18 @@ public class GoogleAuthController {
         
         try {
             String authorizationCode = request.getCode();
+            String redirectUri = request.getRedirectUri();
+            
             if (authorizationCode == null || authorizationCode.isBlank()) {
                 return ApiResponse.onFailure("AUTH4001", "인증 코드가 필요합니다.", null);
             }
+            
+            if (redirectUri == null || redirectUri.isBlank()) {
+                return ApiResponse.onFailure("AUTH4001", "리다이렉트 URI가 필요합니다.", null);
+            }
 
             // Google OAuth2 서비스에서 사용자 정보 가져오기 및 사용자 생성/업데이트
-            User user = googleOAuth2Service.authenticateWithGoogle(authorizationCode);
+            User user = googleOAuth2Service.authenticateWithGoogle(authorizationCode, redirectUri);
 
             // JWT 토큰 생성
             String accessToken = jwtUtil.generateAccessToken(user.getId(), user.getEmail());


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
프론트엔드가 사용한 redirectUri를 백엔드로 전달받아 Google OAuth API 호출 시 동일한 URI를 사용하도록 수정하여 redirect_uri_mismatch 문제 해결

## 📋 변경 사항
GoogleLoginRequestDTO
- redirectUri 필드 추가 (프론트엔드에서 사용한 redirect URI 전달용)

GoogleOAuth2Service
- authenticateWithGoogle(): frontendRedirectUri 파라미터 추가
- getAccessToken(): 프론트엔드가 전달한 redirectUri를 Google API 호출에 사용
- 불필요한 환경변수 redirectUri 제거

GoogleAuthController
- 요청 본문에서 redirectUri 추출 및 검증
- Service 호출 시 redirectUri 전달

## 🔍 Code Review
- [x] 프론트엔드에서 로그인 요청 시 redirectUri 필드를 포함하는지 확인
- [ ] 로컬 환경(http://localhost:5173)에서 로그인 정상 작동 확인
- [ ] 배포 환경(https://dev.readwith.store)에서 로그인 정상 작동 확인
- [x] Google Cloud Console에 모든 환경의 redirect URI 등록 확인

## 📸 ScreenShot
