### PR TITLE
fix: 그래프 서비스 코드에서 builder시, 넣는 값 올바르게 수정

### DIFF
--- a/src/main/java/com/kw/readwith/service/FineGraphService.java
+++ b/src/main/java/com/kw/readwith/service/FineGraphService.java
@@ -102,8 +102,8 @@ public class FineGraphService {
                 .label(character.getName())
                 .isMainCharacter(character.isMainCharacter())
                 .profileImage(character.getProfileImage())
-                .description(truncateText(character.getProfileText(), 200))
-                .portraitPrompt(character.getPersonalityText())
+                .description(truncateText(character.getPersonalityText(), 200))  // 성격 설명
+                .portraitPrompt(character.getProfileText())  // 외모 묘사 (이미지 생성용)
                 .names(parseNames(character.getNames(), character.getName()))
                 .weight(weight)
                 .count(count)

--- a/src/main/java/com/kw/readwith/service/MacroGraphService.java
+++ b/src/main/java/com/kw/readwith/service/MacroGraphService.java
@@ -107,8 +107,8 @@ public class MacroGraphService {
                 .label(character.getName())
                 .isMainCharacter(character.isMainCharacter())
                 .profileImage(character.getProfileImage())
-                .description(truncateText(character.getProfileText(), 200))
-                .portraitPrompt(character.getPersonalityText())
+                .description(truncateText(character.getPersonalityText(), 200))  // 성격 설명
+                .portraitPrompt(character.getProfileText())  // 외모 묘사 (이미지 생성용)
                 .names(parseNames(character.getNames(), character.getName()))
                 .weight(weight)
                 .count(count)


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
프론트엔드에서 캐릭터 데이터의 description과 portrait_prompt 필드가 반대로 출력되는 문제를 수정하고, S3 이미지 CORS 설정 가이드를 제공했습니다.

## 📋 변경 사항

### 문제 상황
프론트에서 받은 데이터:
- description에 "A portrait of..." (외모 묘사)가 들어옴 ❌
- portrait_prompt에 "Jordan is a professional..." (성격 설명)이 들어옴 ❌

### 수정 내용
1. Manifest API 응답 수정
프론트로 보낼 때 필드명 매핑 추가
- 성격 설명 → description
- 외모 묘사 → portrait_prompt

2. 그래프 API 응답 수정
매크로/파인 그래프에서도 같은 문제 발견
둘 다 올바르게 매핑하도록 수정

3. S3 이미지 CORS 설정 안내
프론트에서 S3 이미지 로드하려면 버킷에 CORS 설정 필요
AWS 콘솔에서 설정해야 함 (코드 변경 없음)

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
