### PR TITLE
fix: 캐릭터 이미지 재생성 API 403 에러 수정

### DIFF
--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -106,8 +106,15 @@ public class AdminController {
         return ApiResponse.onSuccess(response);
     }
 
-    @Operation(summary = "캐릭터 이미지 재생성 API", description = "특정 캐릭터의 프로필 이미지를 재생성합니다. 이미지 생성에 실패했거나 품질이 좋지 않은 경우 사용합니다.")
-    @PostMapping("/characters/{characterId}/regenerate-image")
+    @Operation(
+        summary = "캐릭터 이미지 재생성 API", 
+        description = "특정 캐릭터의 프로필 이미지를 재생성합니다. 이미지 생성에 실패했거나 품질이 좋지 않은 경우 사용합니다.",
+        security = {}
+    )
+    @PostMapping(
+        value = "/characters/{characterId}/regenerate-image",
+        consumes = MediaType.ALL_VALUE  // body 없는 POST 요청 허용
+    )
     public ApiResponse<String> regenerateCharacterImage(
             @Parameter(description = "이미지를 재생성할 캐릭터의 ID") @PathVariable Long characterId) {
         adminService.regenerateCharacterImage(characterId);


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
캐릭터 이미지 재생성 API 호출 시 403 Forbidden 에러 발생

## 🔍 원인 분석
1. Swagger UI가 모든 API에 기본적으로 JWT 인증 요구
2. Body가 없는 POST 요청에서 Content-Type 처리 문제

## 📋 변경 사항

> @Operation(
    summary = "캐릭터 이미지 재생성 API",
    security = {}  // Swagger JWT 인증 비활성화
)
@PostMapping(
    value = "/characters/{characterId}/regenerate-image",
    consumes = MediaType.ALL_VALUE  // 모든 Content-Type 허용
) 

수정 이유
- `security = {}`:  배포전 다량의 데이터 주입을 이유로 현재 Admin API는 Spring Security에서 `permitAll()`이지만, Swagger는 글로벌 SecurityRequirement를 적용하므로 명시적으로 비활성화 필요
- `consumes = MediaType.ALL_VALUE`: Request Body가 없는 POST 요청이므로 모든 Content-Type 허용


## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
로컬로 재생성 성공
<img width="1766" height="1209" alt="image" src="https://github.com/user-attachments/assets/3dcd26dc-2d84-488a-a6cd-98578b7077bd" />
