### PR TITLE
feat: [M1] v2 전환 feature flag 반영

### DIFF
--- a/src/main/java/com/kw/readwith/config/ApiContractMode.java
+++ b/src/main/java/com/kw/readwith/config/ApiContractMode.java
@@ -1,0 +1,39 @@
+package com.kw.readwith.config;
+
+import java.util.Locale;
+
+public enum ApiContractMode {
+    PREPARE("prepare"),
+    V2_ONLY("v2_only"),
+    V2_ONLY_STRICT("v2_only_strict");
+
+    private final String propertyValue;
+
+    ApiContractMode(String propertyValue) {
+        this.propertyValue = propertyValue;
+    }
+
+    public String getPropertyValue() {
+        return propertyValue;
+    }
+
+    public boolean blocksLegacyRoutes() {
+        return this != PREPARE;
+    }
+
+    public boolean isStrict() {
+        return this == V2_ONLY_STRICT;
+    }
+
+    public static ApiContractMode from(String value) {
+        if (value == null || value.isBlank()) {
+            return PREPARE;
+        }
+
+        String normalized = value.trim()
+                .toUpperCase(Locale.ROOT)
+                .replace('-', '_');
+
+        return valueOf(normalized);
+    }
+}

--- a/src/main/java/com/kw/readwith/config/ApiContractProperties.java
+++ b/src/main/java/com/kw/readwith/config/ApiContractProperties.java
@@ -1,0 +1,19 @@
+package com.kw.readwith.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "api.contract")
+@Getter
+@Setter
+public class ApiContractProperties {
+
+    private String mode = ApiContractMode.PREPARE.getPropertyValue();
+
+    public ApiContractMode getResolvedMode() {
+        return ApiContractMode.from(mode);
+    }
+}

--- a/src/main/java/com/kw/readwith/config/EpubNormalizationProperties.java
+++ b/src/main/java/com/kw/readwith/config/EpubNormalizationProperties.java
@@ -1,0 +1,15 @@
+package com.kw.readwith.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "epub.normalization")
+@Getter
+@Setter
+public class EpubNormalizationProperties {
+
+    private boolean enabled = false;
+}

--- a/src/main/java/com/kw/readwith/config/LocatorMode.java
+++ b/src/main/java/com/kw/readwith/config/LocatorMode.java
@@ -1,0 +1,39 @@
+package com.kw.readwith.config;
+
+import java.util.Locale;
+
+public enum LocatorMode {
+    OFF("off"),
+    ON("on"),
+    STRICT("strict");
+
+    private final String propertyValue;
+
+    LocatorMode(String propertyValue) {
+        this.propertyValue = propertyValue;
+    }
+
+    public String getPropertyValue() {
+        return propertyValue;
+    }
+
+    public boolean isOff() {
+        return this == OFF;
+    }
+
+    public boolean isStrict() {
+        return this == STRICT;
+    }
+
+    public static LocatorMode from(String value) {
+        if (value == null || value.isBlank()) {
+            return ON;
+        }
+
+        String normalized = value.trim()
+                .toUpperCase(Locale.ROOT)
+                .replace('-', '_');
+
+        return valueOf(normalized);
+    }
+}

--- a/src/main/java/com/kw/readwith/config/LocatorProperties.java
+++ b/src/main/java/com/kw/readwith/config/LocatorProperties.java
@@ -1,0 +1,19 @@
+package com.kw.readwith.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "locator")
+@Getter
+@Setter
+public class LocatorProperties {
+
+    private String mode = LocatorMode.ON.getPropertyValue();
+
+    public LocatorMode getResolvedMode() {
+        return LocatorMode.from(mode);
+    }
+}

--- a/src/main/java/com/kw/readwith/config/SecurityConfig.java
+++ b/src/main/java/com/kw/readwith/config/SecurityConfig.java
@@ -32,60 +32,47 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                // CSRF 비활성화 (JWT 사용)
                 .csrf(AbstractHttpConfigurer::disable)
-
-                // CORS 설정
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-
-                // 세션 비활성화 (JWT 사용)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
-                // 요청 권한 설정
                 .authorizeHttpRequests(auth -> auth
-                        // 공개 엔드포인트
                         .requestMatchers(
                                 "/",
-                                "/api/books/**",  // 책 목록은 비로그인도 접근 가능 (GET만)
-                                "/api/auth/google/**",  // Google 로그인
+                                "/api/books/**",
+                                "/api/v2/books/**",
+                                "/api/auth/google/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",
                                 "/webjars/**",
                                 "/favicon.ico",
                                 "/error",
-                                "/health",  // ELB 헬스체크 (EB 배포 필수)
-                                "/actuator/health",  // Spring Actuator 헬스체크
+                                "/health",
+                                "/actuator/health",
                                 "/api/admin/**",
+                                "/api/v2/admin/**",
                                 "/api/books"
                         ).permitAll()
-                        // 인증이 필요한 엔드포인트
                         .requestMatchers(
-                                "/api/auth/**",     // 인증 관련 API (토큰 갱신, 로그아웃 등)
-                                "/api/progress/**", // 진도 관리
-                                "/api/bookmarks/**", // 북마크
-                                "/api/favorites/**"  // 즐겨찾기
+                                "/api/auth/**",
+                                "/api/progress/**",
+                                "/api/v2/progress/**",
+                                "/api/bookmarks/**",
+                                "/api/v2/bookmarks/**",
+                                "/api/favorites/**"
                         ).authenticated()
-
-                        // 나머지는 인증 필요
                         .anyRequest().authenticated()
                 )
-
-                // JWT 필터 추가
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-
-                // 예외 처리 설정
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                         .accessDeniedHandler(jwtAccessDeniedHandler)
                 )
-
-                // 보안 헤더 설정
                 .headers(headers -> headers
-                        .frameOptions(frameOptions -> frameOptions.deny())  // X-Frame-Options: DENY
-                        .contentTypeOptions(contentTypeOptions -> contentTypeOptions.disable())  // X-Content-Type-Options: nosniff
+                        .frameOptions(frameOptions -> frameOptions.deny())
+                        .contentTypeOptions(contentTypeOptions -> contentTypeOptions.disable())
                         .httpStrictTransportSecurity(hstsConfig -> hstsConfig
-                                .maxAgeInSeconds(31536000)  // 1년
+                                .maxAgeInSeconds(31536000)
                                 .includeSubDomains(true)
                         )
                 );
@@ -97,32 +84,20 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        // 허용할 오리진 설정 (로컬 개발 + Vercel 배포/프리뷰 환경)
         configuration.setAllowedOriginPatterns(Arrays.asList(
-                "http://localhost:5173",                                      // 로컬 개발
-                "https://readwith-frontend.vercel.app",                      // Vercel 메인 배포
-                "https://readwith-frontend-*.vercel.app",                    // Vercel 프리뷰 (브랜치별)
-                "https://*.vercel.app"                                        // Vercel 전체 프리뷰
+                "http://localhost:5173",
+                "https://readwith-frontend.vercel.app",
+                "https://readwith-frontend-*.vercel.app",
+                "https://*.vercel.app"
         ));
-
-        // 허용할 HTTP 메서드
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-
-        // 허용할 헤더
         configuration.setAllowedHeaders(List.of("*"));
-
-        // 인증 정보 포함 허용
         configuration.setAllowCredentials(true);
-
-        // 노출할 헤더 설정
         configuration.setExposedHeaders(Arrays.asList("Authorization", "Content-Type"));
-
-        // Preflight 요청 캐시 시간 (1시간)
         configuration.setMaxAge(3600L);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
-
         return source;
     }
 

--- a/src/main/java/com/kw/readwith/config/V2ApiContractInterceptor.java
+++ b/src/main/java/com/kw/readwith/config/V2ApiContractInterceptor.java
@@ -1,0 +1,65 @@
+package com.kw.readwith.config;
+
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+@Component
+@RequiredArgsConstructor
+public class V2ApiContractInterceptor implements HandlerInterceptor {
+
+    private static final List<Pattern> LEGACY_TRANSITION_PATHS = List.of(
+            Pattern.compile("^/api/books/[^/]+/manifest$"),
+            Pattern.compile("^/api/progress(?:/.*)?$"),
+            Pattern.compile("^/api/bookmarks(?:/.*)?$"),
+            Pattern.compile("^/api/graph(?:/.*)?$"),
+            Pattern.compile("^/api/admin(?:/.*)?$")
+    );
+
+    private final ApiContractProperties apiContractProperties;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (!(handler instanceof HandlerMethod)) {
+            return true;
+        }
+
+        if (!apiContractProperties.getResolvedMode().blocksLegacyRoutes()) {
+            return true;
+        }
+
+        String requestUri = request.getRequestURI();
+        if (!isLegacyTransitionPath(requestUri)) {
+            return true;
+        }
+
+        throw new GeneralException(
+                ErrorStatus._FORBIDDEN,
+                "api.contract.mode=" + apiContractProperties.getResolvedMode().getPropertyValue()
+                        + " 에서는 " + toV2Path(requestUri) + " 경로만 허용됩니다."
+        );
+    }
+
+    private boolean isLegacyTransitionPath(String requestUri) {
+        if (requestUri == null || requestUri.startsWith("/api/v2/")) {
+            return false;
+        }
+
+        return LEGACY_TRANSITION_PATHS.stream().anyMatch(pattern -> pattern.matcher(requestUri).matches());
+    }
+
+    private String toV2Path(String requestUri) {
+        if (requestUri == null || !requestUri.startsWith("/api/")) {
+            return "/api/v2";
+        }
+        return "/api/v2" + requestUri.substring("/api".length());
+    }
+}

--- a/src/main/java/com/kw/readwith/config/V2TransitionGuard.java
+++ b/src/main/java/com/kw/readwith/config/V2TransitionGuard.java
@@ -1,0 +1,114 @@
+package com.kw.readwith.config;
+
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Chapter;
+import com.kw.readwith.domain.Event;
+import com.kw.readwith.util.LocatorSupport;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class V2TransitionGuard {
+
+    private final ApiContractProperties apiContractProperties;
+    private final EpubNormalizationProperties epubNormalizationProperties;
+    private final LocatorProperties locatorProperties;
+    private final LocatorSupport locatorSupport;
+
+    public void ensureV2ManifestEnabled(HttpServletRequest request) {
+        if (!isV2Request(request) || epubNormalizationProperties.isEnabled()) {
+            return;
+        }
+
+        throw new GeneralException(
+                ErrorStatus._FORBIDDEN,
+                "epub.normalization.enabled=false 상태에서는 /api/v2/books/{bookId}/manifest 경로를 사용할 수 없습니다."
+        );
+    }
+
+    public void ensureLocatorWritesEnabled(String operationName) {
+        if (!locatorProperties.getResolvedMode().isOff()) {
+            return;
+        }
+
+        throw new GeneralException(
+                ErrorStatus._FORBIDDEN,
+                "locator.mode=off 상태에서는 " + operationName + " 기능을 사용할 수 없습니다."
+        );
+    }
+
+    public void ensureLocatorMetadataReady(Book book, Chapter chapter, String operationName) {
+        if (!locatorProperties.getResolvedMode().isStrict()) {
+            return;
+        }
+
+        ensureBookLocatorVersion(book, operationName);
+        if (!locatorSupport.hasLocatorMetadata(chapter) || chapter.getTotalCodePoints() == null) {
+            throw new GeneralException(
+                    ErrorStatus._FORBIDDEN,
+                    "locator.mode=strict 상태에서는 " + operationName + " 전에 chapter locator 메타가 모두 준비되어 있어야 합니다."
+            );
+        }
+    }
+
+    public void ensureManifestReady(Book book, List<Chapter> chapters, List<Event> events) {
+        if (!apiContractProperties.getResolvedMode().isStrict()) {
+            return;
+        }
+
+        ensureBookLocatorVersion(book, "manifest 조회");
+        for (Chapter chapter : chapters) {
+            if (!locatorSupport.hasLocatorMetadata(chapter) || chapter.getTotalCodePoints() == null) {
+                throw new GeneralException(
+                        ErrorStatus._FORBIDDEN,
+                        "api.contract.mode=v2_only_strict 상태에서는 모든 chapter에 locator 메타가 준비되어 있어야 합니다."
+                );
+            }
+        }
+        for (Event event : events) {
+            ensureEventLocatorReady(event, "manifest 조회");
+        }
+    }
+
+    public void ensureEventLocatorReady(Event event, String operationName) {
+        if (!apiContractProperties.getResolvedMode().isStrict()) {
+            return;
+        }
+
+        if (event.getStartTxtOffset() == null || event.getEndTxtOffset() == null
+                || event.getStartBlockIndex() == null || event.getStartOffset() == null
+                || event.getEndBlockIndex() == null || event.getEndOffset() == null) {
+            throw new GeneralException(
+                    ErrorStatus._FORBIDDEN,
+                    "api.contract.mode=v2_only_strict 상태에서는 " + operationName + " 응답에 event locator/txtOffset 값이 모두 존재해야 합니다."
+            );
+        }
+    }
+
+    public boolean isV2Request(HttpServletRequest request) {
+        return request != null
+                && request.getRequestURI() != null
+                && request.getRequestURI().startsWith("/api/v2/");
+    }
+
+    private void ensureBookLocatorVersion(Book book, String operationName) {
+        if (book == null) {
+            return;
+        }
+        if (StringUtils.hasText(book.getLocatorVersion())) {
+            return;
+        }
+
+        throw new GeneralException(
+                ErrorStatus._FORBIDDEN,
+                "locator.version 이 없는 책에서는 " + operationName + " 를 strict 모드로 수행할 수 없습니다."
+        );
+    }
+}

--- a/src/main/java/com/kw/readwith/config/V2TransitionStartupValidator.java
+++ b/src/main/java/com/kw/readwith/config/V2TransitionStartupValidator.java
@@ -1,0 +1,47 @@
+package com.kw.readwith.config;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class V2TransitionStartupValidator {
+
+    private final ApiContractProperties apiContractProperties;
+    private final EpubNormalizationProperties epubNormalizationProperties;
+    private final LocatorProperties locatorProperties;
+
+    @PostConstruct
+    void validate() {
+        ApiContractMode apiContractMode = apiContractProperties.getResolvedMode();
+        LocatorMode locatorMode = locatorProperties.getResolvedMode();
+
+        log.info(
+                "V2 transition flags loaded: epub.normalization.enabled={}, locator.mode={}, api.contract.mode={}",
+                epubNormalizationProperties.isEnabled(),
+                locatorMode.getPropertyValue(),
+                apiContractMode.getPropertyValue()
+        );
+
+        if (apiContractMode.blocksLegacyRoutes() && !epubNormalizationProperties.isEnabled()) {
+            throw new IllegalStateException(
+                    "api.contract.mode=" + apiContractMode.getPropertyValue()
+                            + " 를 사용하려면 epub.normalization.enabled=true 여야 합니다."
+            );
+        }
+
+        if (apiContractMode.blocksLegacyRoutes() && locatorMode.isOff()) {
+            throw new IllegalStateException(
+                    "api.contract.mode=" + apiContractMode.getPropertyValue()
+                            + " 를 사용하려면 locator.mode=on 이상이어야 합니다."
+            );
+        }
+
+        if (apiContractMode.isStrict() && !locatorMode.isStrict()) {
+            throw new IllegalStateException("api.contract.mode=v2_only_strict 는 locator.mode=strict 와 함께 사용해야 합니다.");
+        }
+    }
+}

--- a/src/main/java/com/kw/readwith/config/WebConfig.java
+++ b/src/main/java/com/kw/readwith/config/WebConfig.java
@@ -4,32 +4,42 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.filter.ShallowEtagHeaderFilter;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    private final V2ApiContractInterceptor v2ApiContractInterceptor;
+
+    public WebConfig(V2ApiContractInterceptor v2ApiContractInterceptor) {
+        this.v2ApiContractInterceptor = v2ApiContractInterceptor;
+    }
+
     /**
-     * Spring의 자동 ETag 지원을 위한 ShallowEtagHeaderFilter 설정
+     * Spring???먮룞 ETag 吏?먯쓣 ?꾪븳 ShallowEtagHeaderFilter ?ㅼ젙
      *
-     * 동작 원리:
-     * 1. 응답 본문의 MD5 해시값으로 ETag 자동 생성
-     * 2. 클라이언트의 If-None-Match 헤더와 비교
-     * 3. 동일하면 304 Not Modified 응답 (본문 없음)
-     * 4. 다르면 200 OK 응답 (본문 포함)
+     * ?숈옉 ?먮━:
+     * 1. ?묐떟 蹂몃Ц??MD5 ?댁떆媛믪쑝濡?ETag ?먮룞 ?앹꽦
+     * 2. ?대씪?댁뼵?몄쓽 If-None-Match ?ㅻ뜑? 鍮꾧탳
+     * 3. ?숈씪?섎㈃ 304 Not Modified ?묐떟 (蹂몃Ц ?놁쓬)
+     * 4. ?ㅻⅤ硫?200 OK ?묐떟 (蹂몃Ц ?ы븿)
      */
     @Bean
     public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
-        FilterRegistrationBean<ShallowEtagHeaderFilter> filterRegistrationBean = 
-            new FilterRegistrationBean<>(new ShallowEtagHeaderFilter());
-        
-        // Manifest API에만 ETag 적용
+        FilterRegistrationBean<ShallowEtagHeaderFilter> filterRegistrationBean =
+                new FilterRegistrationBean<>(new ShallowEtagHeaderFilter());
+
         filterRegistrationBean.addUrlPatterns("/api/books/*/manifest");
-        
-        // 필터 순서 설정 (낮을수록 먼저 실행)
+        filterRegistrationBean.addUrlPatterns("/api/v2/books/*/manifest");
         filterRegistrationBean.setOrder(1);
-        
+
         return filterRegistrationBean;
     }
 
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(v2ApiContractInterceptor)
+                .addPathPatterns("/api/**", "/api/v2/**");
+    }
 }

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.config.V2TransitionGuard;
 import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.Character;
@@ -57,6 +58,7 @@ public class AdminService {
     private final ObjectMapper objectMapper;
     private final CharacterImageService characterImageService;
     private final LocatorSupport locatorSupport;
+    private final V2TransitionGuard transitionGuard;
     
     @PersistenceContext
     private EntityManager entityManager;
@@ -191,6 +193,7 @@ public class AdminService {
         
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+        transitionGuard.ensureLocatorWritesEnabled("admin event upload");
 
         List<Event> allNewEvents = new ArrayList<>();
         // 파일명에서 챕터 번호를 추출하기 위한 정규표현식
@@ -232,6 +235,7 @@ public class AdminService {
                                 .build();
                         return chapterRepository.save(newChapter);
                     });
+            transitionGuard.ensureLocatorMetadataReady(book, chapter, "admin event upload");
 
             // 이미 데이터가 있는 챕터는 업로드 불가
             if (eventRepository.existsByChapter(chapter)) {

--- a/src/main/java/com/kw/readwith/service/BookmarkService.java
+++ b/src/main/java/com/kw/readwith/service/BookmarkService.java
@@ -2,6 +2,7 @@ package com.kw.readwith.service;
 
 import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.config.V2TransitionGuard;
 import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Bookmark;
 import com.kw.readwith.domain.Chapter;
@@ -32,6 +33,7 @@ public class BookmarkService {
     private final UserRepository userRepository;
     private final ChapterRepository chapterRepository;
     private final LocatorSupport locatorSupport;
+    private final V2TransitionGuard transitionGuard;
 
     /**
      * 북마크 목록 조회
@@ -62,6 +64,7 @@ public class BookmarkService {
         // 사용자와 책 존재 여부 확인
         User user = validateUserExists(userId);
         Book book = validateBookAccess(userId, requestDTO.getBookId());
+        transitionGuard.ensureLocatorWritesEnabled("bookmark 생성");
         ResolvedBookmarkRange resolvedRange = resolveRange(book, requestDTO.getStartLocator(), requestDTO.getEndLocator());
 
         List<Bookmark> existingBookmarks = bookmarkRepository.findByUserIdAndBookIdOrderByCreatedAtDesc(userId, requestDTO.getBookId());
@@ -169,6 +172,7 @@ public class BookmarkService {
 
         Chapter startChapter = chapterRepository.findByBookIdAndIdx(book.getId(), startLocator.getChapterIndex())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+        transitionGuard.ensureLocatorMetadataReady(book, startChapter, "bookmark 생성");
         int startTxtOffset = locatorSupport.toTxtOffset(startChapter, startLocator);
 
         if (endLocator == null) {
@@ -184,6 +188,7 @@ public class BookmarkService {
 
         Chapter endChapter = chapterRepository.findByBookIdAndIdx(book.getId(), endLocator.getChapterIndex())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+        transitionGuard.ensureLocatorMetadataReady(book, endChapter, "bookmark 생성");
         int endTxtOffset = locatorSupport.toTxtOffset(endChapter, endLocator);
         if (startTxtOffset >= endTxtOffset) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST, "startLocator는 endLocator보다 앞에 있어야 합니다.");

--- a/src/main/java/com/kw/readwith/service/FineGraphService.java
+++ b/src/main/java/com/kw/readwith/service/FineGraphService.java
@@ -10,6 +10,7 @@ import com.kw.readwith.dto.common.LocatorDTO;
 import com.kw.readwith.dto.graph.*;
 import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.config.V2TransitionGuard;
 import com.kw.readwith.repository.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +34,7 @@ public class FineGraphService {
     private final EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
     private final EventCharacterStatRepository eventCharacterStatRepository;
     private final ObjectMapper objectMapper;
+    private final V2TransitionGuard transitionGuard;
 
     /**
      * 세밀(이벤트) 그래프 조회 - 특정 이벤트에서의 관계
@@ -51,6 +53,7 @@ public class FineGraphService {
         // 이벤트 존재 확인
         Event event = eventRepository.findByChapterAndIdx(chapter, eventIdx)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND));
+        transitionGuard.ensureEventLocatorReady(event, "fine graph 조회");
 
         // 해당 이벤트의 모든 관계 엣지 조회
         List<EventRelationshipEdge> edges = eventRelationshipEdgeRepository.findByEvent(event);

--- a/src/main/java/com/kw/readwith/service/ManifestService.java
+++ b/src/main/java/com/kw/readwith/service/ManifestService.java
@@ -2,6 +2,7 @@ package com.kw.readwith.service;
 
 import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.config.V2TransitionGuard;
 import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.Character;
@@ -29,6 +30,7 @@ public class ManifestService {
     private final ChapterRepository chapterRepository;
     private final CharacterRepository characterRepository;
     private final EventRepository eventRepository;
+    private final V2TransitionGuard transitionGuard;
 
     /**
      * 책 구조/캐시 패키지 조회
@@ -48,6 +50,7 @@ public class ManifestService {
         List<Event> events = eventRepository.findByBookOrderByChapterIdxAscIdxAsc(book);
         Map<Long, List<Event>> eventsByChapter = events.stream()
                 .collect(Collectors.groupingBy(event -> event.getChapter().getId()));
+        transitionGuard.ensureManifestReady(book, chapters, events);
         
         // 5. Progress 메타데이터 계산
         ProgressMetadataDTO progressMetadata = calculateProgressMetadata(book);

--- a/src/main/java/com/kw/readwith/service/UserReadStateService.java
+++ b/src/main/java/com/kw/readwith/service/UserReadStateService.java
@@ -2,6 +2,7 @@ package com.kw.readwith.service;
 
 import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.config.V2TransitionGuard;
 import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.User;
@@ -31,6 +32,7 @@ public class UserReadStateService {
     private final BookRepository bookRepository;
     private final ChapterRepository chapterRepository;
     private final LocatorSupport locatorSupport;
+    private final V2TransitionGuard transitionGuard;
 
     // 진도 저장 또는 업데이트
     @Transactional
@@ -45,8 +47,10 @@ public class UserReadStateService {
         if (!hasAccessToBook(user, book)) {
             throw new GeneralException(ErrorStatus.BOOK_ACCESS_DENIED);
         }
+        transitionGuard.ensureLocatorWritesEnabled("progress 저장");
         LocatorDTO locator = requestDTO.getLocator();
         Chapter chapter = validateLocator(book, locator);
+        transitionGuard.ensureLocatorMetadataReady(book, chapter, "progress 저장");
         locatorSupport.toTxtOffset(chapter, locator);
 
         // 기존 읽기 상태가 있는지 확인

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/admin")
+@RequestMapping({"/api/admin", "/api/v2/admin"})
 public class AdminController {
 
     private final AdminService adminService;

--- a/src/main/java/com/kw/readwith/web/controller/BookmarkController.java
+++ b/src/main/java/com/kw/readwith/web/controller/BookmarkController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/bookmarks")
+@RequestMapping({"/api/bookmarks", "/api/v2/bookmarks"})
 @RequiredArgsConstructor
 @Tag(name = "Bookmarks", description = "북마크 관련 API")
 public class BookmarkController {

--- a/src/main/java/com/kw/readwith/web/controller/GraphController.java
+++ b/src/main/java/com/kw/readwith/web/controller/GraphController.java
@@ -16,7 +16,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/graph")
+@RequestMapping({"/api/graph", "/api/v2/graph"})
 @RequiredArgsConstructor
 @Tag(name = "Graph", description = "인물 관계 그래프 API")
 public class GraphController {

--- a/src/main/java/com/kw/readwith/web/controller/ManifestController.java
+++ b/src/main/java/com/kw/readwith/web/controller/ManifestController.java
@@ -3,67 +3,72 @@ package com.kw.readwith.web.controller;
 import com.kw.readwith.apiPayload.ApiResponse;
 import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.config.V2TransitionGuard;
 import com.kw.readwith.dto.manifest.ManifestResponseDTO;
 import com.kw.readwith.service.ManifestService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/books")
 @RequiredArgsConstructor
-@Tag(name = "Manifest", description = "책 구조 패키지 API")
+@Tag(name = "Manifest", description = "Book manifest API")
 public class ManifestController {
 
     private final ManifestService manifestService;
+    private final V2TransitionGuard transitionGuard;
 
     private Long getCurrentUserId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication != null && authentication.getPrincipal() instanceof Long) {
-            return (Long) authentication.getPrincipal();
+        if (authentication == null || authentication.getPrincipal() == null) {
+            return null;
+        }
+        if (authentication.getPrincipal() instanceof Long principal) {
+            return principal;
+        }
+        if ("anonymousUser".equals(authentication.getPrincipal())) {
+            return null;
         }
         throw new GeneralException(ErrorStatus._UNAUTHORIZED);
     }
 
-    /**
-     * 책 구조/캐시 패키지 조회
-     * 책 메타데이터 + 챕터/이벤트 + 인물 정보를 한 번에 제공하여 뷰어 초기화를 돕습니다.
-     * 개인화 데이터(진도, 즐겨찾기, 북마크)는 별도 API에서 조회해야 합니다.
-     */
-    @GetMapping("/{bookId}/manifest")
+    @ModelAttribute
+    void validateTransitionRoute(HttpServletRequest request) {
+        transitionGuard.ensureV2ManifestEnabled(request);
+    }
+
+    @GetMapping({"/api/books/{bookId}/manifest", "/api/v2/books/{bookId}/manifest"})
     @Operation(
-        summary = "책 구조 패키지 조회",
-        description = "책 메타데이터, 챕터/이벤트 구조, 인물 정보를 한 번에 제공합니다. " +
-                     "뷰어 초기화에 필요한 공용 데이터를 포함하며, " +
-                     "개인화 데이터(진도, 즐겨찾기 등)는 별도 API에서 조회해야 합니다."
+            summary = "Get book manifest",
+            description = "Returns the shared manifest payload used to bootstrap the reader."
     )
     @ApiResponses(value = {
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200", 
-            description = "책 구조 패키지 조회 성공"
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404", 
-            description = "책을 찾을 수 없거나 접근 권한이 없음"
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "400", 
-            description = "잘못된 요청 파라미터"
-        )
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "Manifest returned successfully"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "Book not found or not accessible"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid request"
+            )
     })
     public ApiResponse<ManifestResponseDTO> getBookManifest(
-            @Parameter(
-                description = "책 ID", 
-                required = true,
-                example = "42"
-            )
+            @Parameter(description = "Book ID", required = true, example = "42")
             @PathVariable Long bookId) {
-        
+
         Long userId = getCurrentUserId();
         ManifestResponseDTO response = manifestService.getBookManifest(bookId, userId);
         return ApiResponse.onSuccess(response);

--- a/src/main/java/com/kw/readwith/web/controller/ProgressController.java
+++ b/src/main/java/com/kw/readwith/web/controller/ProgressController.java
@@ -14,7 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/progress")
+@RequestMapping({"/api/progress", "/api/v2/progress"})
 @RequiredArgsConstructor
 @Tag(name = "Progress", description = "독서 진도 관련 API")
 public class ProgressController {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,6 +68,17 @@ spring:
           quality: standard
           n: 1
 
+epub:
+  normalization:
+    enabled: ${EPUB_NORMALIZATION_ENABLED:false}
+
+locator:
+  mode: ${LOCATOR_MODE:on}
+
+api:
+  contract:
+    mode: ${API_CONTRACT_MODE:prepare}
+
 # JWT 설정
 jwt:
   secret: ${JWT_SECRET:mySecretKey123456789012345678901234567890123456789012345678901234567890}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
M1 범위에서 v2 전환 제어를 위한 feature flag를 추가하고, 기존 `/api` 경로와 `/api/v2` 경로를 플래그 기반으로 제어할 수 있도록 정리했습니다.  
현재 서버가 즉시 `v2_only`로 강제 전환되지 않도록 기본값은 보수적으로 두고, 이후 마일스톤에서 단계적으로 전환할 수 있는 기반을 마련했습니다.

## 📋 변경 사항
- v2 전환 feature flag 추가
  - `epub.normalization.enabled`
  - `locator.mode`
  - `api.contract.mode`
- feature flag 바인딩용 config/properties 추가
  - `ApiContractProperties`
  - `LocatorProperties`
  - `EpubNormalizationProperties`
- 잘못된 플래그 조합을 서버 기동 시점에 차단하는 startup validator 추가
- `/api`와 `/api/v2` 경로를 함께 받을 수 있도록 alias 경로 반영
  - manifest
  - progress
  - bookmarks
  - graph
  - admin
- `api.contract.mode`가 `v2_only` 이상일 때 기존 legacy `/api/...` 경로를 차단하는 interceptor 추가
- `epub.normalization.enabled=false` 상태에서 `/api/v2/books/{bookId}/manifest` 접근 제한
- `locator.mode=off` 상태에서 locator 기반 write 경로 차단
  - progress 저장
  - bookmark 생성
  - admin event upload
- strict 모드에서 locator 메타 준비 여부를 검사하는 guard 추가
  - manifest
  - fine graph
  - progress
  - bookmark
  - admin event upload
- 기본 설정값 추가
  - `EPUB_NORMALIZATION_ENABLED=false`
  - `LOCATOR_MODE=on`
  - `API_CONTRACT_MODE=prepare`

## 🔍 Code Review
- 이번 PR은 v2 API를 완전 분리 구현한 것이 아니라, 기존 구현 위에 `/api/v2` alias와 feature flag 제어를 얹는 작업입니다.
- 기본 설정은 `prepare` 기준이라 기존 `/api/...` 경로는 계속 동작합니다.
- dev 환경변수에서 `API_CONTRACT_MODE=v2_only` 또는 `v2_only_strict`로 바로 올릴 경우 legacy 경로가 차단되므로, 실제 전환 시점에 맞춰 적용 필요합니다.
- `locator.mode=strict`에서는 chapter/event locator 메타가 준비되지 않은 데이터가 있으면 일부 v2 경로가 차단됩니다.
- 로컬 기준 `compileJava`는 통과했습니다.
- 전체 `test`는 이번 PR에서 재실행하지 않았습니다.

## 📸 ScreenShot
- 백엔드 feature flag / API routing 제어 작업으로 별도 UI 스크린샷은 없습니다.