### PR TITLE
feat: [M3] v2 읽기 API 정리 및 Admin 업로드·analysisStatus 연동

### DIFF
--- a/src/main/java/com/kw/readwith/dto/admin/CharacterDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/CharacterDTO.java
@@ -1,27 +1,33 @@
 package com.kw.readwith.dto.admin;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @NoArgsConstructor
 public class CharacterDTO {
 
-    private Long id;
+    @JsonAlias("id")
+    private String characterId;
 
-    @JsonProperty("common_name")
+    @JsonAlias("common_name")
     private String commonName;
 
     private List<String> names;
 
-    @JsonProperty("main_character")
+    @JsonAlias("main_character")
     private boolean isMainCharacter;
 
-    private String description_ko;
+    private Map<String, String> descriptions;
 
-    @JsonProperty("portrait_prompt")
+    @JsonProperty("description_ko")
+    private String legacyDescriptionKo;
+
+    @JsonAlias("portrait_prompt")
     private String portraitPrompt;
 }

--- a/src/main/java/com/kw/readwith/dto/admin/CharacterListDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/CharacterListDTO.java
@@ -1,5 +1,6 @@
 package com.kw.readwith.dto.admin;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,5 +9,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class CharacterListDTO {
-    private List<CharacterDTO> characters;
+
+    @JsonAlias("characters")
+    private List<CharacterDTO> items;
 }

--- a/src/main/java/com/kw/readwith/dto/admin/EventDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/EventDTO.java
@@ -1,6 +1,6 @@
 package com.kw.readwith.dto.admin;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,8 +18,7 @@ public class EventDTO {
     private String text;
     private String eventText;
 
-    @JsonProperty("event_id")
+    @JsonAlias("event_id")
     private String eventId;
-
 }
     

--- a/src/main/java/com/kw/readwith/dto/admin/EventUploadDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/EventUploadDTO.java
@@ -1,0 +1,14 @@
+package com.kw.readwith.dto.admin;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class EventUploadDTO {
+
+    private Integer chapterIndex;
+    private List<EventDTO> items;
+}

--- a/src/main/java/com/kw/readwith/dto/admin/RelationshipDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/RelationshipDTO.java
@@ -1,5 +1,6 @@
 package com.kw.readwith.dto.admin;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,9 +9,18 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class RelationshipDTO {
-    private Long id1;
-    private Long id2;
-    private List<String> relation;
+
+    @JsonAlias("id1")
+    private String fromCharacterId;
+
+    @JsonAlias("id2")
+    private String toCharacterId;
+
+    @JsonAlias("relation")
+    private List<String> labels;
+
     private Double positivity;
-    private Integer count;
+
+    @JsonAlias("count")
+    private Integer evidenceCount;
 }

--- a/src/main/java/com/kw/readwith/dto/admin/RelationshipUploadDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/RelationshipUploadDTO.java
@@ -1,19 +1,22 @@
 package com.kw.readwith.dto.admin;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.util.List;
 import java.util.Map;
 
 @Getter
-@Setter
 @NoArgsConstructor
 public class RelationshipUploadDTO {
-    private List<RelationshipDTO> relations;
 
-    @JsonProperty("node_weights_accum")
-    private Map<String, NodeWeightDTO> nodeWeightsAccum;
+    private Integer chapterIndex;
+    private String eventId;
+
+    @JsonAlias("relations")
+    private List<RelationshipDTO> items;
+
+    @JsonAlias("node_weights_accum")
+    private Map<String, NodeWeightDTO> nodeWeights;
 }

--- a/src/main/java/com/kw/readwith/dto/admin/SummaryItemDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/SummaryItemDTO.java
@@ -1,0 +1,13 @@
+package com.kw.readwith.dto.admin;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SummaryItemDTO {
+
+    private String characterId;
+    private String characterName;
+    private String summary;
+}

--- a/src/main/java/com/kw/readwith/dto/admin/SummaryUploadDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/SummaryUploadDTO.java
@@ -1,0 +1,15 @@
+package com.kw.readwith.dto.admin;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class SummaryUploadDTO {
+
+    private Integer chapterIndex;
+    private String language;
+    private List<SummaryItemDTO> items;
+}

--- a/src/main/java/com/kw/readwith/dto/progress/ProgressResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/progress/ProgressResponseDTO.java
@@ -1,7 +1,11 @@
 package com.kw.readwith.dto.progress;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.kw.readwith.dto.common.LocatorDTO;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
@@ -13,8 +17,20 @@ public class ProgressResponseDTO {
 
     private Long bookId;
 
-    private LocatorDTO locator;
+    private LocatorDTO startLocator;
+
+    private LocatorDTO endLocator;
+
+    private Integer startTxtOffset;
+
+    private Integer endTxtOffset;
+
+    private String locatorVersion;
 
     private LocalDateTime updatedAt;
 
+    @JsonProperty("locator")
+    public LocatorDTO getLocator() {
+        return startLocator;
+    }
 }

--- a/src/main/java/com/kw/readwith/dto/progress/SaveProgressRequestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/progress/SaveProgressRequestDTO.java
@@ -1,8 +1,12 @@
 package com.kw.readwith.dto.progress;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.kw.readwith.dto.common.LocatorDTO;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
@@ -10,10 +14,14 @@ import lombok.*;
 @AllArgsConstructor
 public class SaveProgressRequestDTO {
 
-    @NotNull(message = "책 ID는 필수입니다.")
+    @NotNull(message = "bookId is required.")
     private Long bookId;
 
-    @NotNull(message = "locator는 필수입니다.")
-    private LocatorDTO locator;
+    @JsonAlias("locator")
+    @NotNull(message = "startLocator is required.")
+    private LocatorDTO startLocator;
 
+    public LocatorDTO getLocator() {
+        return startLocator;
+    }
 }

--- a/src/main/java/com/kw/readwith/repository/BookRepository.java
+++ b/src/main/java/com/kw/readwith/repository/BookRepository.java
@@ -19,6 +19,10 @@ public interface BookRepository extends JpaRepository<Book, Long> {
      */
     List<Book> findBySummaryIsFalse();
 
+    List<Book> findByNormalizationStatus(NormalizationStatus normalizationStatus);
+
+    Optional<Book> findByIdAndNormalizationStatus(Long id, NormalizationStatus normalizationStatus);
+
     /**
      * 접근 가능한 도서 목록 조회 (사용자별)
      * 기본 제공 도서는 READY만 노출, 업로더 본인 도서는 상태와 무관하게 노출

--- a/src/main/java/com/kw/readwith/repository/EventCharacterStatRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventCharacterStatRepository.java
@@ -2,14 +2,20 @@ package com.kw.readwith.repository;
 
 import com.kw.readwith.domain.Event;
 import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.mapping.EventCharacterStat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
 public interface EventCharacterStatRepository extends JpaRepository<EventCharacterStat, Long> {
+
+    @Query("SELECT CASE WHEN COUNT(stat) > 0 THEN true ELSE false END FROM EventCharacterStat stat WHERE stat.event.book = :book")
+    boolean existsByBook(@Param("book") Book book);
 
     Optional<EventCharacterStat> findByEventAndCharacter(Event event, Character character);
 

--- a/src/main/java/com/kw/readwith/repository/EventCharacterStatRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventCharacterStatRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,6 +19,10 @@ public interface EventCharacterStatRepository extends JpaRepository<EventCharact
     boolean existsByBook(@Param("book") Book book);
 
     Optional<EventCharacterStat> findByEventAndCharacter(Event event, Character character);
+
+    List<EventCharacterStat> findByEvent(Event event);
+
+    List<EventCharacterStat> findByEventIn(List<Event> events);
 
     boolean existsByEvent(Event event);
 

--- a/src/main/java/com/kw/readwith/repository/EventRelationshipEdgeRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventRelationshipEdgeRepository.java
@@ -2,13 +2,19 @@ package com.kw.readwith.repository;
 
 import com.kw.readwith.domain.Character;
 import com.kw.readwith.domain.Event;
+import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.mapping.EventRelationshipEdge;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
 public interface EventRelationshipEdgeRepository extends JpaRepository<EventRelationshipEdge, Long> {
+    @Query("SELECT CASE WHEN COUNT(edge) > 0 THEN true ELSE false END FROM EventRelationshipEdge edge WHERE edge.event.book = :book")
+    boolean existsByBook(@Param("book") Book book);
+
     boolean existsByEvent(Event event);
 
     /**

--- a/src/main/java/com/kw/readwith/repository/EventRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventRepository.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
 
+    boolean existsByBook(Book book);
+
     boolean existsByBookAndChapter(Book book, Chapter chapter);
     Optional<Event> findByChapterAndIdx(Chapter chapter, Integer idx);
 

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -22,6 +22,7 @@ import com.kw.readwith.util.LocatorSupport;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -39,12 +40,12 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true) // 기본적으로 읽기 전용 트랜잭션으로 설정
+@Transactional(readOnly = true) // 疫꿸퀡??怨몄몵嚥???꾨┛ ?袁⑹뒠 ?紐껋삏?????곗쨮 ??쇱젟
 public class AdminService {
 
     private static final Logger log = LoggerFactory.getLogger(AdminService.class);
 
-    // 모든 관리자 기능에 필요한 Repository 및 ObjectMapper 의존성 주입
+    // 筌뤴뫀諭??온?귐딆쁽 疫꿸퀡????袁⑹뒄??Repository 獄?ObjectMapper ??뤵??雅뚯눘??
     private final BookRepository bookRepository;
     private final CharacterRepository characterRepository;
     private final ChapterRepository chapterRepository;
@@ -54,6 +55,7 @@ public class AdminService {
     private final EventCharacterStatRepository statRepository;
     private final ObjectMapper objectMapper;
     private final CharacterImageService characterImageService;
+    private final BookAnalysisStatusService bookAnalysisStatusService;
     private final LocatorSupport locatorSupport;
     private final V2TransitionGuard transitionGuard;
     private final NormalizationVersionService normalizationVersionService;
@@ -63,17 +65,17 @@ public class AdminService {
 
     /*
      * =====================================================================================
-     * 1. 데이터 업로드
+     * 1. ?怨쀬뵠????낆쨮??
      * =====================================================================================
      */
 
     /**
-     * 등장인물 정보가 담긴 JSON 파일을 업로드합니다.
+     * ?源놁삢?紐꺪??類ｋ궖揶쎛 ??용┸ JSON ???뵬????낆쨮??쀫???덈뼄.
      */
     @Transactional
     public int uploadCharacters(Long bookId, MultipartFile file) {
         if (file == null || file.isEmpty()) {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST, "업로드 파일이 비어있습니다.");
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "Upload file is empty.");
         }
 
         Book book = bookRepository.findById(bookId)
@@ -81,13 +83,13 @@ public class AdminService {
 
         try {
             CharacterListDTO characterListDTO = objectMapper.readValue(file.getInputStream(), CharacterListDTO.class);
-
             if (characterListDTO == null || characterListDTO.getItems() == null) {
-                throw new GeneralException(ErrorStatus._BAD_REQUEST, "캐릭터 데이터가 올바르지 않습니다.");
+                throw new GeneralException(ErrorStatus._BAD_REQUEST, "Character payload is invalid.");
             }
 
             if (characterListDTO.getItems().isEmpty()) {
-                log.warn("업로드할 캐릭터가 없습니다.");
+                log.warn("No characters found in upload payload.");
+                bookAnalysisStatusService.refreshStatus(bookId);
                 return 0;
             }
 
@@ -100,7 +102,7 @@ public class AdminService {
 
                 Optional<Character> existingCharacter = characterRepository.findByBookAndCharacterId(book, characterId);
                 if (existingCharacter.isPresent()) {
-                    log.info("캐릭터 ID '{}' 이미 존재하여 스킵", characterId);
+                    log.info("Skip existing character id={}", characterId);
                     continue;
                 }
 
@@ -119,309 +121,338 @@ public class AdminService {
             }
 
             if (newCharacters.isEmpty()) {
-                log.info("저장할 새로운 캐릭터가 없습니다.");
+                log.info("No new characters to save.");
+                bookAnalysisStatusService.refreshStatus(bookId);
                 return 0;
             }
 
-            //  DB 저장 with 예외 처리
             List<Character> savedCharacters;
             try {
                 savedCharacters = characterRepository.saveAll(newCharacters);
-                log.info("캐릭터 {}명 DB 저장 완료", savedCharacters.size());
+                log.info("Saved {} characters.", savedCharacters.size());
             } catch (Exception e) {
-                log.error("캐릭터 DB 저장 실패", e);
-                throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "캐릭터 저장 중 데이터베이스 오류가 발생했습니다.");
+                log.error("Failed to save characters.", e);
+                throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "Failed to save characters.");
             }
-                
-            // 캐릭터 ID만 추출하여 비동기 메서드에 전달
+
             List<Long> characterIds = savedCharacters.stream()
                     .map(Character::getId)
                     .collect(Collectors.toList());
-            
-            // 이미지 생성 (실패해도 계속 진행)
+
             try {
-                log.info("캐릭터 이미지 생성 백그라운드 작업 시작");
                 characterImageService.generateImagesAsync(characterIds);
             } catch (Exception e) {
-                log.error("캐릭터 이미지 생성 시작 실패 (백그라운드 작업, 계속 진행)", e);
+                log.error("Failed to start character image generation.", e);
             }
-            
-            return savedCharacters.size();
 
+            bookAnalysisStatusService.refreshStatus(bookId);
+            return savedCharacters.size();
         } catch (IOException e) {
-            log.error("캐릭터 JSON 파일 파싱 실패", e);
-            throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "JSON 파일 형식이 올바르지 않습니다.");
+            log.error("Failed to parse character upload JSON.", e);
+            GeneralException exception = new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "Invalid character JSON payload.");
+            markAnalysisRejectedIfNeeded(book, exception);
+            throw exception;
         } catch (GeneralException e) {
+            markAnalysisRejectedIfNeeded(book, e);
             throw e;
         } catch (Exception e) {
-            log.error("캐릭터 업로드 중 예상치 못한 오류", e);
-            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "캐릭터 업로드 처리 중 오류가 발생했습니다.");
+            log.error("Unexpected failure while uploading characters.", e);
+            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "Failed to upload characters.");
         }
     }
 
     /**
-     * 여러 챕터의 이벤트 JSON 파일들을 한번에 업로드합니다.
+     * ????筌?벤苑????源??JSON ???뵬??쇱뱽 ??뺤쓰????낆쨮??쀫???덈뼄.
      */
     @Transactional
     public int uploadEvents(Long bookId, List<MultipartFile> eventFiles) {
         if (eventFiles == null || eventFiles.isEmpty()) {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST, "업로드할 이벤트 파일이 없습니다.");
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "No event files provided.");
         }
 
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
         transitionGuard.ensureLocatorWritesEnabled("admin event upload");
 
-        List<Event> allNewEvents = new ArrayList<>();
+        try {
+            List<Event> allNewEvents = new ArrayList<>();
 
-        for (MultipartFile eventFile : eventFiles) {
-            if (eventFile == null || eventFile.isEmpty()) {
-                log.warn("빈 파일이 포함되어 스킵합니다.");
-                continue;
-            }
-
-            try {
-                EventUploadDTO uploadDTO = objectMapper.readValue(eventFile.getInputStream(), EventUploadDTO.class);
-                if (uploadDTO == null || uploadDTO.getChapterIndex() == null) {
-                    throw new GeneralException(ErrorStatus._BAD_REQUEST, "event payload chapterIndex는 필수입니다.");
-                }
-
-                Integer chapterIdx = uploadDTO.getChapterIndex();
-                Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
-                        .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND, "챕터 인덱스 " + chapterIdx + "를 찾을 수 없습니다."));
-                transitionGuard.ensureLocatorMetadataReady(book, chapter, "admin event upload");
-
-                if (eventRepository.existsByChapter(chapter)) {
-                    throw new GeneralException(ErrorStatus.EVENT_DATA_ALREADY_EXISTS, "챕터 " + chapterIdx + "의 이벤트는 이미 존재합니다.");
-                }
-
-                List<EventDTO> eventDTOs = uploadDTO.getItems();
-                if (eventDTOs == null || eventDTOs.isEmpty()) {
-                    log.warn("파일 '{}'에 이벤트 데이터가 없습니다.", eventFile.getOriginalFilename());
+            for (MultipartFile eventFile : eventFiles) {
+                if (eventFile == null || eventFile.isEmpty()) {
+                    log.warn("Skip empty event file.");
                     continue;
                 }
 
-                Set<Integer> seenEventIndexes = new LinkedHashSet<>();
-                List<Event> newEventsFromFile = new ArrayList<>();
-                for (EventDTO dto : eventDTOs) {
-                    String eventId = requireText(dto.getEventId(), "event.eventId");
-                    if (dto.getChapterIndex() != null && !chapterIdx.equals(dto.getChapterIndex())) {
-                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "payload chapterIndex가 root chapterIndex와 일치하지 않습니다.");
+                try {
+                    EventUploadDTO uploadDTO = objectMapper.readValue(eventFile.getInputStream(), EventUploadDTO.class);
+                    if (uploadDTO == null || uploadDTO.getChapterIndex() == null) {
+                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "event payload chapterIndex is required.");
                     }
 
-                    Integer startTxtOffset = dto.getStartTxtOffset() != null ? dto.getStartTxtOffset() : dto.getStart();
-                    Integer endTxtOffset = dto.getEndTxtOffset() != null ? dto.getEndTxtOffset() : dto.getEnd();
-                    if (startTxtOffset == null || endTxtOffset == null) {
-                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "이벤트 위치 정보가 없습니다: " + eventId);
-                    }
-                    if (startTxtOffset >= endTxtOffset) {
-                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "이벤트 txtOffset 범위가 올바르지 않습니다: " + eventId);
-                    }
+                    Integer chapterIdx = uploadDTO.getChapterIndex();
+                    Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
+                            .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND, "Chapter not found: " + chapterIdx));
+                    transitionGuard.ensureLocatorMetadataReady(book, chapter, "admin event upload");
 
-                    String rawText = requireRawText(dto.getEventText() != null ? dto.getEventText() : dto.getText(), "event.eventText");
-                    validateEventText(chapter, startTxtOffset, endTxtOffset, rawText, eventId);
-
-                    Integer eventIdx = parseEventIdx(eventId, chapterIdx);
-                    if (!seenEventIndexes.add(eventIdx)) {
-                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "중복 eventId가 포함되어 있습니다: " + eventId);
+                    if (eventRepository.existsByChapter(chapter)) {
+                        throw new GeneralException(ErrorStatus.EVENT_DATA_ALREADY_EXISTS, "Events already exist for chapter " + chapterIdx);
                     }
 
-                    String normalizedEventId = normalizeEventId(eventId, chapterIdx, eventIdx);
-                    LocatorDTO startLocator = resolveEventLocator(chapter, startTxtOffset);
-                    LocatorDTO endLocator = resolveEventLocator(chapter, endTxtOffset);
+                    List<EventDTO> eventDTOs = uploadDTO.getItems();
+                    if (eventDTOs == null || eventDTOs.isEmpty()) {
+                        log.warn("No events found in file {}", eventFile.getOriginalFilename());
+                        continue;
+                    }
 
-                    Event event = Event.builder()
-                            .book(book)
-                            .chapter(chapter)
-                            .idx(eventIdx)
-                            .eventId(normalizedEventId)
-                            .startBlockIndex(startLocator != null ? startLocator.getBlockIndex() : null)
-                            .startOffset(startLocator != null ? startLocator.getOffset() : null)
-                            .endBlockIndex(endLocator != null ? endLocator.getBlockIndex() : null)
-                            .endOffset(endLocator != null ? endLocator.getOffset() : null)
-                            .startTxtOffset(startTxtOffset)
-                            .endTxtOffset(endTxtOffset)
-                            .rawText(rawText != null ? rawText : "")
-                            .build();
-                    newEventsFromFile.add(event);
+                    Set<Integer> seenEventIndexes = new LinkedHashSet<>();
+                    List<Event> newEventsFromFile = new ArrayList<>();
+                    for (EventDTO dto : eventDTOs) {
+                        String eventId = requireText(dto.getEventId(), "event.eventId");
+                        if (dto.getChapterIndex() != null && !chapterIdx.equals(dto.getChapterIndex())) {
+                            throw new GeneralException(ErrorStatus._BAD_REQUEST, "Root chapterIndex and item chapterIndex do not match.");
+                        }
+
+                        Integer startTxtOffset = dto.getStartTxtOffset() != null ? dto.getStartTxtOffset() : dto.getStart();
+                        Integer endTxtOffset = dto.getEndTxtOffset() != null ? dto.getEndTxtOffset() : dto.getEnd();
+                        if (startTxtOffset == null || endTxtOffset == null) {
+                            throw new GeneralException(ErrorStatus._BAD_REQUEST, "Missing txt offsets for event " + eventId);
+                        }
+                        if (startTxtOffset >= endTxtOffset) {
+                            throw new GeneralException(ErrorStatus._BAD_REQUEST, "Invalid txt offset range for event " + eventId);
+                        }
+
+                        String rawText = requireRawText(dto.getEventText() != null ? dto.getEventText() : dto.getText(), "event.eventText");
+                        validateEventText(chapter, startTxtOffset, endTxtOffset, rawText, eventId);
+
+                        Integer eventIdx = parseEventIdx(eventId, chapterIdx);
+                        if (!seenEventIndexes.add(eventIdx)) {
+                            throw new GeneralException(ErrorStatus._BAD_REQUEST, "Duplicate eventId in payload: " + eventId);
+                        }
+
+                        String normalizedEventId = normalizeEventId(eventId, chapterIdx, eventIdx);
+                        LocatorDTO startLocator = resolveEventLocator(chapter, startTxtOffset);
+                        LocatorDTO endLocator = resolveEventLocator(chapter, endTxtOffset);
+
+                        Event event = Event.builder()
+                                .book(book)
+                                .chapter(chapter)
+                                .idx(eventIdx)
+                                .eventId(normalizedEventId)
+                                .startBlockIndex(startLocator != null ? startLocator.getBlockIndex() : null)
+                                .startOffset(startLocator != null ? startLocator.getOffset() : null)
+                                .endBlockIndex(endLocator != null ? endLocator.getBlockIndex() : null)
+                                .endOffset(endLocator != null ? endLocator.getOffset() : null)
+                                .startTxtOffset(startTxtOffset)
+                                .endTxtOffset(endTxtOffset)
+                                .rawText(rawText)
+                                .build();
+                        newEventsFromFile.add(event);
+                    }
+
+                    allNewEvents.addAll(newEventsFromFile);
+                    log.info("Parsed {} events from {}", newEventsFromFile.size(), eventFile.getOriginalFilename());
+                } catch (IOException e) {
+                    log.error("Failed to parse event file {}", eventFile.getOriginalFilename(), e);
+                    throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "Failed to parse event JSON: " + eventFile.getOriginalFilename());
                 }
-
-                allNewEvents.addAll(newEventsFromFile);
-                log.info("파일 '{}' 처리 완료: {}개 이벤트", eventFile.getOriginalFilename(), newEventsFromFile.size());
-
-            } catch (IOException e) {
-                log.error("이벤트 JSON 파일 파싱 실패: {}", eventFile.getOriginalFilename(), e);
-                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "JSON 파일 파싱 실패: " + eventFile.getOriginalFilename());
             }
-        }
 
-        if (allNewEvents.isEmpty()) {
-            log.warn("저장할 이벤트가 없습니다.");
-            return 0;
-        }
-        
-        int batchSize = 500;
-        int totalSaved = 0;
-        
-        try {
-            for (int i = 0; i < allNewEvents.size(); i += batchSize) {
-                int end = Math.min(i + batchSize, allNewEvents.size());
-                List<Event> batch = allNewEvents.subList(i, end);
-                
-                eventRepository.saveAll(batch);
-                entityManager.flush();   // 즉시 DB 반영
-                entityManager.clear();   // 1차 캐시 비우기 (메모리 절약)
-                
-                totalSaved += batch.size();
-                log.info("이벤트 배치 진행: {}/{}", totalSaved, allNewEvents.size());
+            if (allNewEvents.isEmpty()) {
+                log.warn("No new events to save.");
+                bookAnalysisStatusService.refreshStatus(bookId);
+                return 0;
             }
-            log.info("이벤트 {}개 DB 저장 완료", totalSaved);
-        } catch (Exception e) {
-            log.error("이벤트 DB 저장 실패", e);
-            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "이벤트 저장 중 데이터베이스 오류가 발생했습니다.");
+
+            int batchSize = 500;
+            int totalSaved = 0;
+            try {
+                for (int i = 0; i < allNewEvents.size(); i += batchSize) {
+                    int end = Math.min(i + batchSize, allNewEvents.size());
+                    List<Event> batch = allNewEvents.subList(i, end);
+                    eventRepository.saveAll(batch);
+                    entityManager.flush();
+                    entityManager.clear();
+                    totalSaved += batch.size();
+                }
+                log.info("Saved {} events.", totalSaved);
+            } catch (Exception e) {
+                log.error("Failed to save events.", e);
+                throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "Failed to save events.");
+            }
+
+            bookAnalysisStatusService.refreshStatus(bookId);
+            return totalSaved;
+        } catch (GeneralException e) {
+            markAnalysisRejectedIfNeeded(book, e);
+            throw e;
         }
-        
-        return totalSaved;
     }
 
     /**
-     * 여러 챕터의 POV 요약 JSON 파일들을 한번에 업로드합니다.
+     * ????筌?벤苑??POV ?遺용튋 JSON ???뵬??쇱뱽 ??뺤쓰????낆쨮??쀫???덈뼄.
      */
     @Transactional
     public int uploadChapterSummaries(Long bookId, List<MultipartFile> summaryFiles) {
         if (summaryFiles == null || summaryFiles.isEmpty()) {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST, "업로드할 요약 파일이 없습니다.");
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "No summary files provided.");
         }
 
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
-        List<CharacterPovSummary> allNewSummaries = new ArrayList<>();
-
-        for (MultipartFile summaryFile : summaryFiles) {
-            if (summaryFile == null || summaryFile.isEmpty()) {
-                log.warn("빈 요약 파일이 포함되어 스킵합니다.");
-                continue;
-            }
-
-            SummaryUploadDTO uploadDTO;
-            try {
-                uploadDTO = objectMapper.readValue(summaryFile.getInputStream(), SummaryUploadDTO.class);
-            } catch (IOException e) {
-                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
-            }
-
-            if (uploadDTO == null || uploadDTO.getChapterIndex() == null) {
-                throw new GeneralException(ErrorStatus._BAD_REQUEST, "summary payload chapterIndex는 필수입니다.");
-            }
-            if (uploadDTO.getLanguage() != null && !"ko".equalsIgnoreCase(uploadDTO.getLanguage())) {
-                log.info("요약 파일 '{}'은(는) ko가 아니므로 스킵합니다. language={}",
-                        summaryFile.getOriginalFilename(), uploadDTO.getLanguage());
-                continue;
-            }
-
-            Integer chapterIdx = uploadDTO.getChapterIndex();
-            Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
-                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND, "챕터 인덱스 " + chapterIdx + "를 찾을 수 없습니다."));
-
-            if (characterPovSummaryRepository.existsByChapter(chapter)) {
-                throw new GeneralException(ErrorStatus.CHAPTER_ALREADY_SUMMARIZED, "챕터 " + chapterIdx + "의 요약본은 이미 존재합니다.");
-            }
-
-            if (uploadDTO.getItems() != null) {
-                List<CharacterPovSummary> newSummariesFromFile = uploadDTO.getItems().stream()
-                        .map(item -> {
-                            Long characterId = parseCharacterId(item.getCharacterId(), "summary.characterId");
-                            Character character = characterRepository.findByBookAndCharacterId(chapter.getBook(), characterId)
-                                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND,
-                                            "Character not found with jsonId: " + characterId));
-
-                            return CharacterPovSummary.builder()
-                                    .book(chapter.getBook())
-                                    .chapter(chapter)
-                                    .character(character)
-                                    .summaryText(requireText(item.getSummary(), "summary.summary"))
-                                    .build();
-                        })
-                        .collect(Collectors.toList());
-                allNewSummaries.addAll(newSummariesFromFile);
-            }
-            chapter.markAsSummarized();
-        }
-
-        if (!allNewSummaries.isEmpty()) {
-            try {
-                characterPovSummaryRepository.saveAll(allNewSummaries);
-                log.info("챕터 요약 {}개 DB 저장 완료", allNewSummaries.size());
-            } catch (Exception e) {
-                log.error("챕터 요약 DB 저장 실패", e);
-                throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "챕터 요약 저장 중 데이터베이스 오류가 발생했습니다.");
-            }
-        }
-
         try {
-            checkAndUpdateBookSummaryStatus(book);
-        } catch (Exception e) {
-            log.error("책 요약 상태 업데이트 중 오류 발생", e);
+            List<CharacterPovSummary> allNewSummaries = new ArrayList<>();
+
+            for (MultipartFile summaryFile : summaryFiles) {
+                if (summaryFile == null || summaryFile.isEmpty()) {
+                    log.warn("Skip empty summary file.");
+                    continue;
+                }
+
+                SummaryUploadDTO uploadDTO;
+                try {
+                    uploadDTO = objectMapper.readValue(summaryFile.getInputStream(), SummaryUploadDTO.class);
+                } catch (IOException e) {
+                    throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "Failed to parse summary JSON.");
+                }
+
+                if (uploadDTO == null || uploadDTO.getChapterIndex() == null) {
+                    throw new GeneralException(ErrorStatus._BAD_REQUEST, "summary payload chapterIndex is required.");
+                }
+                if (uploadDTO.getLanguage() != null && !"ko".equalsIgnoreCase(uploadDTO.getLanguage())) {
+                    log.info("Skip non-ko summary file {} language={}", summaryFile.getOriginalFilename(), uploadDTO.getLanguage());
+                    continue;
+                }
+
+                Integer chapterIdx = uploadDTO.getChapterIndex();
+                Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
+                        .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND, "Chapter not found: " + chapterIdx));
+
+                if (characterPovSummaryRepository.existsByChapter(chapter)) {
+                    throw new GeneralException(ErrorStatus.CHAPTER_ALREADY_SUMMARIZED, "Chapter summary already exists: " + chapterIdx);
+                }
+
+                if (uploadDTO.getItems() != null) {
+                    List<CharacterPovSummary> newSummariesFromFile = uploadDTO.getItems().stream()
+                            .map(this::validateSummaryItem)
+                            .map(item -> buildCharacterPovSummary(chapter, item))
+                            .collect(Collectors.toList());
+                    allNewSummaries.addAll(newSummariesFromFile);
+                }
+
+                chapter.markAsSummarized();
+            }
+
+            if (!allNewSummaries.isEmpty()) {
+                try {
+                    characterPovSummaryRepository.saveAll(allNewSummaries);
+                    log.info("Saved {} chapter POV summaries.", allNewSummaries.size());
+                } catch (Exception e) {
+                    log.error("Failed to save chapter summaries.", e);
+                    throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "Failed to save chapter summaries.");
+                }
+            }
+
+            try {
+                checkAndUpdateBookSummaryStatus(book);
+            } catch (Exception e) {
+                log.error("Failed to update legacy summary flag.", e);
+            }
+
+            bookAnalysisStatusService.refreshStatus(bookId);
+            return allNewSummaries.size();
+        } catch (GeneralException e) {
+            markAnalysisRejectedIfNeeded(book, e);
+            throw e;
         }
-        return allNewSummaries.size();
     }
 
     /**
-     * 여러 관계 JSON 파일을 업로드하고 DB에 저장
-     * 파일 이름 규칙: chapter<번호>_..._event_<번호>.json
+     * ?????온??JSON ???뵬????낆쨮??쀫릭??DB??????
+     * ???뵬 ??已?域뱀뮇?? chapter<甕곕뜇??_..._event_<甕곕뜇??.json
      *
-     * @param bookId 관계 정보를 추가할 책의 ID
-     * @param files  업로드할 관계 정보 JSON 파일 목록
+     * @param bookId ?온???類ｋ궖???곕떽???筌?굞??ID
+     * @param files  ??낆쨮??쀫막 ?온???類ｋ궖 JSON ???뵬 筌뤴뫖以?
      */
     @Transactional
     public int uploadRelationships(Long bookId, List<MultipartFile> files) {
         if (files == null || files.isEmpty()) {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST, "업로드할 관계 파일이 없습니다.");
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "No relationship files provided.");
         }
 
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
-        int totalProcessedCount = 0;
+        try {
+            int totalProcessedCount = 0;
 
-        for (MultipartFile file : files) {
-            if (file == null || file.isEmpty()) {
-                log.warn("빈 관계 파일이 포함되어 스킵합니다.");
-                continue;
-            }
-
-            try {
-                RelationshipUploadDTO dto = objectMapper.readValue(file.getInputStream(), RelationshipUploadDTO.class);
-                if (dto == null || dto.getChapterIndex() == null) {
-                    throw new GeneralException(ErrorStatus._BAD_REQUEST, "relationship payload chapterIndex는 필수입니다.");
+            for (MultipartFile file : files) {
+                if (file == null || file.isEmpty()) {
+                    log.warn("Skip empty relationship file.");
+                    continue;
                 }
-                String eventId = requireText(dto.getEventId(), "relationship.eventId");
-                int chapterIdx = dto.getChapterIndex();
-                int eventIdx = parseEventIdx(eventId, chapterIdx);
 
-                Event event = eventRepository.findByBookIdAndChapterIdxAndEventIdx(bookId, chapterIdx, eventIdx)
-                        .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND,
-                                String.format("이벤트를 찾을 수 없습니다 (책 ID: %d, 챕터: %d, 이벤트: %d)", bookId, chapterIdx, eventIdx)));
+                try {
+                    RelationshipUploadDTO dto = objectMapper.readValue(file.getInputStream(), RelationshipUploadDTO.class);
+                    if (dto == null || dto.getChapterIndex() == null) {
+                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "relationship payload chapterIndex is required.");
+                    }
 
-                totalProcessedCount += processNodeWeights(event, book, dto.getNodeWeights());
-                totalProcessedCount += processRelations(event, book, dto.getItems());
+                    String eventId = requireText(dto.getEventId(), "relationship.eventId");
+                    int chapterIdx = dto.getChapterIndex();
+                    int eventIdx = parseEventIdx(eventId, chapterIdx);
 
-            } catch (IOException e) {
-                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "관계 정보 JSON 파일 파싱에 실패했습니다: " + file.getOriginalFilename());
+                    Event event = eventRepository.findByBookIdAndChapterIdxAndEventIdx(bookId, chapterIdx, eventIdx)
+                            .orElseThrow(() -> new GeneralException(
+                                    ErrorStatus.EVENT_NOT_FOUND,
+                                    String.format("Event not found for book=%d chapter=%d event=%d", bookId, chapterIdx, eventIdx)
+                            ));
+
+                    totalProcessedCount += processNodeWeights(event, book, dto.getNodeWeights());
+                    totalProcessedCount += processRelations(event, book, dto.getItems());
+                } catch (IOException e) {
+                    throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "Failed to parse relationship JSON: " + file.getOriginalFilename());
+                }
             }
+
+            bookAnalysisStatusService.refreshStatus(bookId);
+            return totalProcessedCount;
+        } catch (GeneralException e) {
+            markAnalysisRejectedIfNeeded(book, e);
+            throw e;
         }
-        return totalProcessedCount;
     }
 
     /**
-     * JSON의 'node_weights_accum' 부분을 처리하는 헬퍼 메서드
-     * 각 캐릭터의 가중치(weight)를 저장하기 전, 중복 데이터가 있는지 확인
+     * JSON??'node_weights_accum' ?봔?브쑴??筌ｌ꼶???롫뮉 ????筌롫뗄苑??
+     * 揶?筌?Ŧ??怨쀬벥 揶쎛餓λ쵐??weight)?????館釉?묾??? 餓λ쵎???怨쀬뵠?怨? ??덈뮉筌왖 ?類ㅼ뵥
      *
-     * @param event          현재 처리 중인 이벤트 엔터티
-     * @param book           현재 처리 중인 책 엔터티
-     * @param nodeWeightsMap JSON에서 파싱된 캐릭터 ID와 가중치 정보가 담긴 맵
+     * @param event          ?袁⑹삺 筌ｌ꼶??餓λ쵐????源???酉苑??
+     * @param book           ?袁⑹삺 筌ｌ꼶??餓λ쵐??筌??酉苑??
+     * @param nodeWeightsMap JSON?癒?퐣 ???뼓??筌?Ŧ???ID?? 揶쎛餓λ쵐???類ｋ궖揶쎛 ??용┸ 筌?
      */
+    private SummaryItemDTO validateSummaryItem(SummaryItemDTO item) {
+        requireText(item.getCharacterId(), "summary.characterId");
+        requireText(item.getSummary(), "summary.summary");
+        return item;
+    }
+
+    private CharacterPovSummary buildCharacterPovSummary(Chapter chapter, SummaryItemDTO item) {
+        Long characterId = parseCharacterId(item.getCharacterId(), "summary.characterId");
+        Character character = characterRepository.findByBookAndCharacterId(chapter.getBook(), characterId)
+                .orElseThrow(() -> new GeneralException(
+                        ErrorStatus.CHARACTER_NOT_FOUND,
+                        "Character not found with jsonId: " + characterId
+                ));
+
+        return CharacterPovSummary.builder()
+                .book(chapter.getBook())
+                .chapter(chapter)
+                .character(character)
+                .summaryText(requireText(item.getSummary(), "summary.summary"))
+                .build();
+    }
+
     private int processNodeWeights(Event event, Book book, Map<String, NodeWeightDTO> nodeWeightsMap) {
         if (nodeWeightsMap == null || nodeWeightsMap.isEmpty()) {
             return 0;
@@ -432,16 +463,16 @@ public class AdminService {
             Long characterBookId = parseCharacterId(entry.getKey(), "relationship.nodeWeights.characterId");
             NodeWeightDTO weightDTO = entry.getValue();
             if (weightDTO == null) {
-                throw new GeneralException(ErrorStatus._BAD_REQUEST, "nodeWeights payload가 비어 있습니다: " + characterBookId);
+                throw new GeneralException(ErrorStatus._BAD_REQUEST, "nodeWeights payload揶쎛 ??쑴堉???됰뮸??덈뼄: " + characterBookId);
             }
 
             Character character = characterRepository.findByBookAndCharacterId(book, characterBookId)
                     .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_CHARACTER_NOT_FOUND,
-                            "해당 책에 등록된 캐릭터를 찾을 수 없습니다: " + characterBookId));
+                            "????筌?굞肉??源낆쨯??筌?Ŧ??怨? 筌≪뼚??????곷뮸??덈뼄: " + characterBookId));
 
             if (statRepository.findByEventAndCharacter(event, character).isPresent()) {
                 throw new GeneralException(ErrorStatus.NODE_WEIGHT_ALREADY_EXISTS,
-                        String.format("해당 이벤트에 대한 '%s' 캐릭터의 가중치 데이터가 이미 존재합니다.", character.getName()));
+                        String.format("??????源?紐꾨퓠 ????'%s' 筌?Ŧ??怨쀬벥 揶쎛餓λ쵐???怨쀬뵠?怨? ??? 鈺곕똻???몃빍??", character.getName()));
             }
 
             EventCharacterStat stat = EventCharacterStat.builder()
@@ -456,27 +487,27 @@ public class AdminService {
         }
 
         if (newStats.isEmpty()) {
-            log.warn("저장할 노드 가중치가 없습니다.");
+            log.warn("???館釉??紐껊굡 揶쎛餓λ쵐?귛첎? ??곷뮸??덈뼄.");
             return 0;
         }
 
         try {
             statRepository.saveAll(newStats);
-            log.info("노드 가중치 {}개 DB 저장 완료", newStats.size());
+            log.info("?紐껊굡 揶쎛餓λ쵐??{}揶?DB ?????袁⑥┷", newStats.size());
         } catch (Exception e) {
-            log.error("노드 가중치 DB 저장 실패", e);
-            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "노드 가중치 저장 중 데이터베이스 오류가 발생했습니다.");
+            log.error("?紐껊굡 揶쎛餓λ쵐??DB ??????쎈솭", e);
+            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "?紐껊굡 揶쎛餓λ쵐??????餓??怨쀬뵠?怨뺤퓢??곷뮞 ??살첒揶쎛 獄쏆뮇源??됰뮸??덈뼄.");
         }
         return newStats.size();
     }
 
     /**
-     * JSON의 'relations' 부분을 처리하는 헬퍼 메서드
-     * 인물 관계를 저장하기 전, 중복 데이터가 있는지 확인
+     * JSON??'relations' ?봔?브쑴??筌ｌ꼶???롫뮉 ????筌롫뗄苑??
+     * ?紐꺪??온?④쑬? ???館釉?묾??? 餓λ쵎???怨쀬뵠?怨? ??덈뮉筌왖 ?類ㅼ뵥
      *
-     * @param event        현재 처리 중인 이벤트 엔터티
-     * @param book         현재 처리 중인 책 엔터티
-     * @param relationDTOs JSON에서 파싱된 관계 정보 DTO 목록
+     * @param event        ?袁⑹삺 筌ｌ꼶??餓λ쵐????源???酉苑??
+     * @param book         ?袁⑹삺 筌ｌ꼶??餓λ쵐??筌??酉苑??
+     * @param relationDTOs JSON?癒?퐣 ???뼓???온???類ｋ궖 DTO 筌뤴뫖以?
      */
     private int processRelations(Event event, Book book, List<RelationshipDTO> relationDTOs) {
         if (relationDTOs == null || relationDTOs.isEmpty()) {
@@ -492,20 +523,20 @@ public class AdminService {
                 continue;
             }
             if (dto.getPositivity() == null || dto.getEvidenceCount() == null) {
-                throw new GeneralException(ErrorStatus._BAD_REQUEST, "relationship positivity/evidenceCount는 필수입니다.");
+                throw new GeneralException(ErrorStatus._BAD_REQUEST, "relationship positivity/evidenceCount???袁⑸땾??낅빍??");
             }
 
             Character fromChar = characterRepository.findByBookAndCharacterId(book, fromCharacterId)
                     .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_CHARACTER_NOT_FOUND,
-                            "해당 책에 등록된 캐릭터를 찾을 수 없습니다: " + fromCharacterId));
+                            "????筌?굞肉??源낆쨯??筌?Ŧ??怨? 筌≪뼚??????곷뮸??덈뼄: " + fromCharacterId));
             Character toChar = characterRepository.findByBookAndCharacterId(book, toCharacterId)
                     .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_CHARACTER_NOT_FOUND,
-                            "해당 책에 등록된 캐릭터를 찾을 수 없습니다: " + toCharacterId));
+                            "????筌?굞肉??源낆쨯??筌?Ŧ??怨? 筌≪뼚??????곷뮸??덈뼄: " + toCharacterId));
 
             if (eventRelationshipEdgeRepository.existsByEventAndFromCharacterAndToCharacter(event, fromChar, toChar) ||
                     eventRelationshipEdgeRepository.existsByEventAndFromCharacterAndToCharacter(event, toChar, fromChar)) {
                 throw new GeneralException(ErrorStatus.RELATIONSHIP_DATA_ALREADY_EXISTS,
-                        String.format("해당 이벤트에 대한 '%s'와(과) '%s'의 관계 데이터가 이미 존재합니다.", fromChar.getName(), toChar.getName()));
+                        String.format("??????源?紐꾨퓠 ????'%s'??(?? '%s'???온???怨쀬뵠?怨? ??? 鈺곕똻???몃빍??", fromChar.getName(), toChar.getName()));
             }
 
             try {
@@ -520,33 +551,33 @@ public class AdminService {
                 newEdges.add(edge);
             } catch (JsonProcessingException e) {
                 throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR,
-                        String.format("캐릭터 %d와(과) %d의 관계 태그 처리 중 오류가 발생했습니다.", fromCharacterId, toCharacterId));
+                        String.format("筌?Ŧ???%d??(?? %d???온????볥젃 筌ｌ꼶??餓???살첒揶쎛 獄쏆뮇源??됰뮸??덈뼄.", fromCharacterId, toCharacterId));
             }
         }
 
         if (newEdges.isEmpty()) {
-            log.warn("저장할 관계 엣지가 없습니다.");
+            log.warn("???館釉??온???節?揶쎛 ??곷뮸??덈뼄.");
             return 0;
         }
 
         try {
             eventRelationshipEdgeRepository.saveAll(newEdges);
-            log.info("관계 엣지 {}개 DB 저장 완료", newEdges.size());
+            log.info("?온???節? {}揶?DB ?????袁⑥┷", newEdges.size());
         } catch (Exception e) {
-            log.error("관계 엣지 DB 저장 실패", e);
-            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "관계 데이터 저장 중 데이터베이스 오류가 발생했습니다.");
+            log.error("?온???節? DB ??????쎈솭", e);
+            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "?온???怨쀬뵠??????餓??怨쀬뵠?怨뺤퓢??곷뮞 ??살첒揶쎛 獄쏆뮇源??됰뮸??덈뼄.");
         }
         return newEdges.size();
     }
 
     /*
      * =====================================================================================
-     * 2. 데이터 조회
+     * 2. ?怨쀬뵠??鈺곌퀬??
      * =====================================================================================
      */
 
     /**
-     * 전체 요약이 완료되지 않은 책 목록을 조회합니다.
+     * ?袁⑷퍥 ?遺용튋???袁⑥┷??? ??? 筌?筌뤴뫖以??鈺곌퀬???몃빍??
      */
     public List<BookSummaryDTO> getUnsummarizedBooks() {
         List<Book> books = bookRepository.findBySummaryIsFalse().stream()
@@ -568,7 +599,7 @@ public class AdminService {
                         .needsRenormalization(normalizationVersionService.needsRenormalization(book))
                         .normalizedArtifactPath(book.getNormalizedArtifactPath())
                         .isDefault(book.isDefault())
-                        .isFavorite(false) // 관리자 페이지에서는 즐겨찾기 정보가 불필요
+                        .isFavorite(false) // ?온?귐딆쁽 ??륁뵠筌왖?癒?퐣??筌앸Þ爰쇽㎕?섎┛ ?類ｋ궖揶쎛 ?븍뜇釉??
                         .summary(book.isSummary())
                         .updatedAt(book.getUpdatedAt())
                         .build())
@@ -576,7 +607,7 @@ public class AdminService {
     }
 
     /**
-     * POV 요약본이 없는 챕터 목록을 조회합니다.
+     * POV ?遺용튋癰귣챷????용뮉 筌?벤苑?筌뤴뫖以??鈺곌퀬???몃빍??
      */
     public List<UnsummarizedItemDTO> getUnsummarizedChapters() {
         return chapterRepository.findUnsummarizedChapters().stream()
@@ -585,47 +616,47 @@ public class AdminService {
     }
 
     /**
-     * 특정 캐릭터의 프로필 이미지를 재생성합니다.
-     * 이미지 생성에 실패했거나 품질이 좋지 않은 경우 사용합니다.
+     * ?諭??筌?Ŧ??怨쀬벥 ?袁⑥쨮?????筌왖????源?源딅???덈뼄.
+     * ???筌왖 ??밴쉐????쎈솭??뉕탢????됱춳???ル뿭? ??? 野껋럩???????몃빍??
      * 
-     * @param characterId 이미지를 재생성할 캐릭터 ID
+     * @param characterId ???筌왖????源?源딅막 筌?Ŧ???ID
      */
     @Transactional
     public void regenerateCharacterImage(Long characterId) {
-        // 캐릭터 존재 여부 확인
+        // 筌?Ŧ???鈺곕똻????? ?類ㅼ뵥
         Character character = characterRepository.findById(characterId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, 
-                        "캐릭터를 찾을 수 없습니다: " + characterId));
+                        "筌?Ŧ??怨? 筌≪뼚??????곷뮸??덈뼄: " + characterId));
         
-        log.info("캐릭터 '{}' (ID: {}) 이미지 재생성 시작", character.getName(), characterId);
+        log.info("筌?Ŧ???'{}' (ID: {}) ???筌왖 ??源????뽰삂", character.getName(), characterId);
         
-        // 기존 이미지 상태 로깅
+        // 疫꿸퀣?????筌왖 ?怨밴묶 嚥≪뮄??
         if (character.getProfileImage() != null && !character.getProfileImage().isEmpty()) {
-            log.info("기존 이미지 URL: {}, 상태: {}", 
+            log.info("疫꿸퀣?????筌왖 URL: {}, ?怨밴묶: {}", 
                     character.getProfileImage(), character.getImageGenerationStatus());
         } else {
-            log.info("기존 이미지 없음, 상태: {}", character.getImageGenerationStatus());
+            log.info("疫꿸퀣?????筌왖 ??곸벉, ?怨밴묶: {}", character.getImageGenerationStatus());
         }
         
-        // 이미지 재생성 (비동기가 아닌 동기 방식으로 호출)
+        // ???筌왖 ??源??(??쑬猷욄묾怨? ?袁⑤빒 ??녿┛ 獄쎻뫗???곗쨮 ?紐꾪뀱)
         try {
             characterImageService.generateAndSaveImage(characterId);
-            log.info("캐릭터 '{}' (ID: {}) 이미지 재생성 완료", character.getName(), characterId);
+            log.info("筌?Ŧ???'{}' (ID: {}) ???筌왖 ??源???袁⑥┷", character.getName(), characterId);
         } catch (Exception e) {
-            log.error("캐릭터 '{}' (ID: {}) 이미지 재생성 실패", character.getName(), characterId, e);
+            log.error("筌?Ŧ???'{}' (ID: {}) ???筌왖 ??源????쎈솭", character.getName(), characterId, e);
             throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, 
-                    "이미지 재생성 중 오류가 발생했습니다: " + e.getMessage());
+                    "???筌왖 ??源??餓???살첒揶쎛 獄쏆뮇源??됰뮸??덈뼄: " + e.getMessage());
         }
     }
 
     /*
      * =====================================================================================
-     * 3. 데이터 삭제
+     * 3. ?怨쀬뵠??????
      * =====================================================================================
      */
 
     /**
-     * 특정 책에 속한 모든 등장인물을 삭제합니다.
+     * ?諭??筌?굞肉???곷립 筌뤴뫀諭??源놁삢?紐꺪???????몃빍??
      */
     @Transactional
     public int deleteCharacters(Long bookId) {
@@ -635,11 +666,13 @@ public class AdminService {
         if (!characterRepository.existsByBook(book)) {
             throw new GeneralException(ErrorStatus.NO_CHARACTERS_TO_DELETE);
         }
-        return characterRepository.deleteByBook(book);
+        int deletedCount = characterRepository.deleteByBook(book);
+        bookAnalysisStatusService.resetToNone(bookId);
+        return deletedCount;
     }
 
     /**
-     * 특정 챕터에 속한 모든 이벤트를 삭제합니다.
+     * ?諭??筌?벤苑????곷립 筌뤴뫀諭???源?紐? ?????몃빍??
      */
     @Transactional
     public int deleteEvents(Long bookId, Integer chapterIdx) {
@@ -649,11 +682,13 @@ public class AdminService {
         if (!eventRepository.existsByChapter(chapter)) {
             throw new GeneralException(ErrorStatus.NO_EVENTS_TO_DELETE);
         }
-        return eventRepository.deleteByChapter(chapter);
+        int deletedCount = eventRepository.deleteByChapter(chapter);
+        bookAnalysisStatusService.resetToNone(bookId);
+        return deletedCount;
     }
 
     /**
-     * 특정 챕터의 모든 POV 요약본을 삭제합니다.
+     * ?諭??筌?벤苑??筌뤴뫀諭?POV ?遺용튋癰귣챷???????몃빍??
      */
     @Transactional
     public int deleteChapterSummary(Long bookId, Integer chapterIdx) {
@@ -664,13 +699,13 @@ public class AdminService {
             throw new GeneralException(ErrorStatus.NO_SUMMARY_TO_DELETE);
         }
         int deletedCount = characterPovSummaryRepository.deleteByChapter(chapter);
-        // 챕터의 요약 상태를 '미완료'로 되돌림
         chapter.markPovSummariesAsUncached();
+        bookAnalysisStatusService.resetToNone(bookId);
         return deletedCount;
     }
 
     /**
-     * 특정 이벤트에 연결된 모든 관계 정보를 삭제합니다.
+     * ?諭????源?紐꾨퓠 ?怨뚭퍙??筌뤴뫀諭??온???類ｋ궖???????몃빍??
      */
     @Transactional
     public int deleteRelationships(Long bookId, Integer chapterIdx, Integer eventIdx) {
@@ -680,40 +715,35 @@ public class AdminService {
         Event event = eventRepository.findByChapterAndIdx(chapter, eventIdx)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND));
 
-        // 삭제할 데이터가 있는지 확인
         boolean edgesExist = eventRelationshipEdgeRepository.existsByEvent(event);
         boolean statsExist = statRepository.existsByEvent(event);
-
         if (!edgesExist && !statsExist) {
-            throw new GeneralException(ErrorStatus.NO_RELATIONSHIPS_TO_DELETE, "해당 이벤트에 삭제할 관계 정보가 없습니다.");
+            throw new GeneralException(ErrorStatus.NO_RELATIONSHIPS_TO_DELETE, "No relationships exist for the event.");
         }
 
         int deletedCount = 0;
-
-        // EventRelationshipEdge 데이터 삭제
         if (edgesExist) {
             deletedCount += eventRelationshipEdgeRepository.deleteByEvent(event);
         }
-
-        // EventCharacterStat 데이터 삭제
         if (statsExist) {
             deletedCount += statRepository.deleteByEvent(event);
         }
 
+        bookAnalysisStatusService.resetToNone(bookId);
         return deletedCount;
     }
 
     /*
      * =====================================================================================
-     * 4. 내부 헬퍼 메서드 및 클래스
+     * 4. ??? ????筌롫뗄苑??獄??????
      * =====================================================================================
      */
 
     /**
-     * 책에 속한 모든 챕터의 요약이 완료되었는지 확인하고, 책의 전체 요약 상태를 업데이트합니다.
+     * 筌?굞肉???곷립 筌뤴뫀諭?筌?벤苑???遺용튋???袁⑥┷??뤿??遺? ?類ㅼ뵥??랁? 筌?굞???袁⑷퍥 ?遺용튋 ?怨밴묶????낅쑓??꾨뱜??몃빍??
      */
     private void checkAndUpdateBookSummaryStatus(Book book) {
-        // 이미 완료된 책은 검사할 필요 없음
+        // ??? ?袁⑥┷??筌?굞? 野꺜??釉??袁⑹뒄 ??곸벉
         if (book.isSummary()) {
             return;
         }
@@ -724,12 +754,23 @@ public class AdminService {
         }
     }
 
+    private void markAnalysisRejectedIfNeeded(Book book, GeneralException exception) {
+        if (book == null || book.isAnalysisReady()) {
+            return;
+        }
+
+        HttpStatus httpStatus = exception.getErrorReasonHttpStatus().getHttpStatus();
+        if (httpStatus != null && httpStatus.is4xxClientError()) {
+            bookAnalysisStatusService.markRejectedIfPending(book.getId());
+        }
+    }
+
     private Integer parseEventIdx(String eventId, Integer chapterIdx) {
         java.util.regex.Matcher matcher = java.util.regex.Pattern.compile("^ch(\\d+)-e(\\d+)$").matcher(eventId);
         if (matcher.matches()) {
             Integer eventChapterIdx = Integer.parseInt(matcher.group(1));
             if (!chapterIdx.equals(eventChapterIdx)) {
-                throw new GeneralException(ErrorStatus._BAD_REQUEST, "eventId의 chapterIndex와 업로드 챕터가 일치하지 않습니다.");
+                throw new GeneralException(ErrorStatus._BAD_REQUEST, "eventId??chapterIndex?? ??낆쨮??筌?벤苑ｅ첎? ??깊뒄??? ??녿뮸??덈뼄.");
             }
             return Integer.parseInt(matcher.group(2));
         }
@@ -737,7 +778,7 @@ public class AdminService {
         try {
             return Integer.parseInt(eventId);
         } catch (NumberFormatException e) {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST, "eventId 형식이 올바르지 않습니다: " + eventId);
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "eventId ?類ㅻ뻼????而?몴?? ??녿뮸??덈뼄: " + eventId);
         }
     }
 
@@ -787,24 +828,24 @@ public class AdminService {
             return Long.parseLong(matcher.group(1));
         }
 
-        throw new GeneralException(ErrorStatus._BAD_REQUEST, fieldName + " 형식이 올바르지 않습니다: " + rawValue);
+        throw new GeneralException(ErrorStatus._BAD_REQUEST, fieldName + " ?類ㅻ뻼????而?몴?? ??녿뮸??덈뼄: " + rawValue);
     }
 
     private void validateEventText(Chapter chapter, int startTxtOffset, int endTxtOffset, String eventText, String eventId) {
         String chapterText = normalizeChapterText(chapter.getRawText());
         if (chapterText == null) {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST, "챕터 원문이 준비되지 않아 eventText를 검증할 수 없습니다.");
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "筌?벤苑??癒???餓Β??쑬由븝쭪? ??녿툡 eventText??野꺜筌앹빜釉?????곷뮸??덈뼄.");
         }
 
         int totalCodePoints = chapterText.codePointCount(0, chapterText.length());
         if (startTxtOffset < 0 || endTxtOffset > totalCodePoints) {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST, "이벤트 txtOffset 범위가 챕터 범위를 벗어났습니다: " + eventId);
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "??源??txtOffset 甕곕뗄?욃첎? 筌?벤苑?甕곕뗄?욅몴?甕곗щ선?????덈뼄: " + eventId);
         }
 
         String expected = substringByCodePoints(chapterText, startTxtOffset, endTxtOffset);
         String actual = normalizeChapterText(eventText);
         if (!expected.equals(actual)) {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST, "eventText와 chapterTxt[start:end]가 일치하지 않습니다: " + eventId);
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "eventText?? chapterTxt[start:end]揶쎛 ??깊뒄??? ??녿뮸??덈뼄: " + eventId);
         }
     }
 
@@ -824,14 +865,14 @@ public class AdminService {
     private String requireText(String value, String fieldName) {
         String normalized = normalizeOptionalText(value);
         if (normalized == null) {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST, fieldName + "는 필수입니다.");
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, fieldName + "???袁⑸땾??낅빍??");
         }
         return normalized;
     }
 
     private String requireRawText(String value, String fieldName) {
         if (value == null || value.isBlank()) {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST, fieldName + "는 필수입니다.");
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, fieldName + "???袁⑸땾??낅빍??");
         }
         return value;
     }
@@ -844,4 +885,3 @@ public class AdminService {
         return normalized.isEmpty() ? null : normalized;
     }
 }
-

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -1,7 +1,6 @@
 package com.kw.readwith.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
@@ -20,10 +19,7 @@ import com.kw.readwith.dto.common.LocatorDTO;
 import com.kw.readwith.repository.*;
 import com.kw.readwith.service.normalization.NormalizationVersionService;
 import com.kw.readwith.util.LocatorSupport;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -34,11 +30,11 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -65,9 +61,6 @@ public class AdminService {
     @PersistenceContext
     private EntityManager entityManager;
 
-    // 파일명에서 챕터와 이벤트 인덱스를 추출하기 위한 정규표현식 패턴
-    private static final Pattern RELATIONSHIP_FILE_PATTERN = Pattern.compile("chapter(\\d+)_.*?_event_(\\d+)\\.json");
-
     /*
      * =====================================================================================
      * 1. 데이터 업로드
@@ -79,63 +72,50 @@ public class AdminService {
      */
     @Transactional
     public int uploadCharacters(Long bookId, MultipartFile file) {
-        // 파일 유효성 검증
         if (file == null || file.isEmpty()) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST, "업로드 파일이 비어있습니다.");
         }
-        
+
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
         try {
             CharacterListDTO characterListDTO = objectMapper.readValue(file.getInputStream(), CharacterListDTO.class);
-            
-            // DTO 유효성 검증
-            if (characterListDTO == null || characterListDTO.getCharacters() == null) {
+
+            if (characterListDTO == null || characterListDTO.getItems() == null) {
                 throw new GeneralException(ErrorStatus._BAD_REQUEST, "캐릭터 데이터가 올바르지 않습니다.");
             }
-            
-            if (characterListDTO.getCharacters().isEmpty()) {
+
+            if (characterListDTO.getItems().isEmpty()) {
                 log.warn("업로드할 캐릭터가 없습니다.");
                 return 0;
             }
 
             List<Character> newCharacters = new ArrayList<>();
-            for (CharacterDTO dto : characterListDTO.getCharacters()) {
-                // 필수 필드 검증
-                if (dto.getCommonName() == null || dto.getCommonName().trim().isEmpty()) {
-                    log.warn("캐릭터 이름이 없어 스킵합니다: {}", dto);
-                    continue;
-                }
-                if (dto.getId() == null) {
-                    log.warn("캐릭터 ID가 없어 스킵합니다: {}", dto.getCommonName());
-                    continue;
-                }
-                
-                // 중복 저장을 방지하기 위해, 해당 이름의 캐릭터가 없는 경우에만 추가
-                Optional<Character> existingCharacter = characterRepository.findByBookAndName(book, dto.getCommonName());
+            for (CharacterDTO dto : characterListDTO.getItems()) {
+                String commonName = requireText(dto.getCommonName(), "character.commonName");
+                Long characterId = parseCharacterId(dto.getCharacterId(), "character.characterId");
+                String descriptionKo = requireText(resolveCharacterDescription(dto), "character.descriptions.ko");
+                String portraitPrompt = requireText(dto.getPortraitPrompt(), "character.portraitPrompt");
 
-                if (existingCharacter.isEmpty()) {
-                    // names 안전 처리
-                    String namesStr = "";
-                    if (dto.getNames() != null && !dto.getNames().isEmpty()) {
-                        namesStr = String.join(",", dto.getNames());
-                    }
-                    
-                    Character character = Character.builder()
-                            .book(book)
-                            .characterId(dto.getId())
-                            .name(dto.getCommonName().trim())
-                            .names(namesStr)
-                            .isMainCharacter(dto.isMainCharacter())
-                            .personalityText(dto.getDescription_ko())
-                            .profileText(dto.getPortraitPrompt())
-                            .imageGenerationStatus(ImageGenerationStatus.PENDING)
-                            .build();
-                    newCharacters.add(character);
-                } else {
-                    log.info("캐릭터 '{}' 이미 존재하여 스킵", dto.getCommonName());
+                Optional<Character> existingCharacter = characterRepository.findByBookAndCharacterId(book, characterId);
+                if (existingCharacter.isPresent()) {
+                    log.info("캐릭터 ID '{}' 이미 존재하여 스킵", characterId);
+                    continue;
                 }
+
+                Character character = Character.builder()
+                        .book(book)
+                        .characterId(characterId)
+                        .name(commonName)
+                        .names(joinNames(dto.getNames(), commonName))
+                        .isMainCharacter(dto.isMainCharacter())
+                        .firstChapterIdx(1)
+                        .personalityText(descriptionKo)
+                        .profileText(portraitPrompt)
+                        .imageGenerationStatus(ImageGenerationStatus.PENDING)
+                        .build();
+                newCharacters.add(character);
             }
 
             if (newCharacters.isEmpty()) {
@@ -172,7 +152,6 @@ public class AdminService {
             log.error("캐릭터 JSON 파일 파싱 실패", e);
             throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "JSON 파일 형식이 올바르지 않습니다.");
         } catch (GeneralException e) {
-            // 이미 처리된 예외는 그대로 전파
             throw e;
         } catch (Exception e) {
             log.error("캐릭터 업로드 중 예상치 못한 오류", e);
@@ -182,104 +161,75 @@ public class AdminService {
 
     /**
      * 여러 챕터의 이벤트 JSON 파일들을 한번에 업로드합니다.
-     * 파일 이름(chapter<번호>_events.json)에서 챕터 번호를 자동으로 인식합니다.
-     * 
-     * 배치 처리: 대량 데이터를 500개씩 나눠서 저장 (메모리 최적화)
      */
     @Transactional
     public int uploadEvents(Long bookId, List<MultipartFile> eventFiles) {
-        // 파일 리스트 유효성 검증
         if (eventFiles == null || eventFiles.isEmpty()) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST, "업로드할 이벤트 파일이 없습니다.");
         }
-        
+
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
         transitionGuard.ensureLocatorWritesEnabled("admin event upload");
 
         List<Event> allNewEvents = new ArrayList<>();
-        // 파일명에서 챕터 번호를 추출하기 위한 정규표현식
-        Pattern pattern = Pattern.compile("chapter(\\d+)_events\\.json");
 
         for (MultipartFile eventFile : eventFiles) {
-            // 파일 유효성 검증
             if (eventFile == null || eventFile.isEmpty()) {
                 log.warn("빈 파일이 포함되어 스킵합니다.");
                 continue;
             }
-            
-            String filename = eventFile.getOriginalFilename();
-            if (filename == null || filename.trim().isEmpty()) {
-                log.warn("파일명이 없는 파일을 스킵합니다.");
-                continue;
-            }
-            
-            Matcher matcher = pattern.matcher(filename);
-
-            if (!matcher.matches()) {
-                throw new GeneralException(ErrorStatus.INVALID_FILE_NAME_FORMAT, "파일명 형식이 올바르지 않습니다: " + filename);
-            }
-
-            // 타입 변환 예외 처리
-            Integer chapterIdx;
-            try {
-                chapterIdx = Integer.parseInt(matcher.group(1));
-            } catch (NumberFormatException e) {
-                log.error("챕터 번호 파싱 실패: {}", filename, e);
-                throw new GeneralException(ErrorStatus.INVALID_FILE_NAME_FORMAT, "챕터 번호가 올바르지 않습니다: " + filename);
-            }
-            
-            Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
-                    .orElseGet(() -> {
-                        Chapter newChapter = Chapter.builder()
-                                .book(book)
-                                .idx(chapterIdx)
-                                .build();
-                        return chapterRepository.save(newChapter);
-                    });
-            transitionGuard.ensureLocatorMetadataReady(book, chapter, "admin event upload");
-
-            // 이미 데이터가 있는 챕터는 업로드 불가
-            if (eventRepository.existsByChapter(chapter)) {
-                throw new GeneralException(ErrorStatus.EVENT_DATA_ALREADY_EXISTS, "챕터 " + chapterIdx + "의 이벤트는 이미 존재합니다.");
-            }
 
             try {
-                List<EventDTO> eventDTOs = objectMapper.readValue(eventFile.getInputStream(), new TypeReference<List<EventDTO>>() {});
-                
-                // DTO 유효성 검증
+                EventUploadDTO uploadDTO = objectMapper.readValue(eventFile.getInputStream(), EventUploadDTO.class);
+                if (uploadDTO == null || uploadDTO.getChapterIndex() == null) {
+                    throw new GeneralException(ErrorStatus._BAD_REQUEST, "event payload chapterIndex는 필수입니다.");
+                }
+
+                Integer chapterIdx = uploadDTO.getChapterIndex();
+                Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
+                        .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND, "챕터 인덱스 " + chapterIdx + "를 찾을 수 없습니다."));
+                transitionGuard.ensureLocatorMetadataReady(book, chapter, "admin event upload");
+
+                if (eventRepository.existsByChapter(chapter)) {
+                    throw new GeneralException(ErrorStatus.EVENT_DATA_ALREADY_EXISTS, "챕터 " + chapterIdx + "의 이벤트는 이미 존재합니다.");
+                }
+
+                List<EventDTO> eventDTOs = uploadDTO.getItems();
                 if (eventDTOs == null || eventDTOs.isEmpty()) {
-                    log.warn("파일 '{}'에 이벤트 데이터가 없습니다.", filename);
+                    log.warn("파일 '{}'에 이벤트 데이터가 없습니다.", eventFile.getOriginalFilename());
                     continue;
                 }
-                
+
+                Set<Integer> seenEventIndexes = new LinkedHashSet<>();
                 List<Event> newEventsFromFile = new ArrayList<>();
                 for (EventDTO dto : eventDTOs) {
-                    // 필수 필드 검증
-                    if (dto.getEventId() == null) {
-                        log.warn("이벤트 ID가 없어 스킵합니다 (파일: {})", filename);
-                        continue;
-                    }
+                    String eventId = requireText(dto.getEventId(), "event.eventId");
                     if (dto.getChapterIndex() != null && !chapterIdx.equals(dto.getChapterIndex())) {
-                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "payload chapterIndex와 파일명 chapterIndex가 일치하지 않습니다.");
+                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "payload chapterIndex가 root chapterIndex와 일치하지 않습니다.");
                     }
 
                     Integer startTxtOffset = dto.getStartTxtOffset() != null ? dto.getStartTxtOffset() : dto.getStart();
                     Integer endTxtOffset = dto.getEndTxtOffset() != null ? dto.getEndTxtOffset() : dto.getEnd();
                     if (startTxtOffset == null || endTxtOffset == null) {
-                        log.warn("이벤트 위치 정보가 없어 스킵합니다 (파일: {}, eventId: {})", filename, dto.getEventId());
-                        continue;
+                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "이벤트 위치 정보가 없습니다: " + eventId);
                     }
                     if (startTxtOffset >= endTxtOffset) {
-                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "이벤트 txtOffset 범위가 올바르지 않습니다: " + dto.getEventId());
+                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "이벤트 txtOffset 범위가 올바르지 않습니다: " + eventId);
                     }
 
-                    Integer eventIdx = parseEventIdx(dto.getEventId(), chapterIdx);
-                    String normalizedEventId = normalizeEventId(dto.getEventId(), chapterIdx, eventIdx);
+                    String rawText = requireRawText(dto.getEventText() != null ? dto.getEventText() : dto.getText(), "event.eventText");
+                    validateEventText(chapter, startTxtOffset, endTxtOffset, rawText, eventId);
+
+                    Integer eventIdx = parseEventIdx(eventId, chapterIdx);
+                    if (!seenEventIndexes.add(eventIdx)) {
+                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "중복 eventId가 포함되어 있습니다: " + eventId);
+                    }
+
+                    String normalizedEventId = normalizeEventId(eventId, chapterIdx, eventIdx);
                     LocatorDTO startLocator = resolveEventLocator(chapter, startTxtOffset);
                     LocatorDTO endLocator = resolveEventLocator(chapter, endTxtOffset);
-                    String rawText = dto.getEventText() != null ? dto.getEventText() : dto.getText();
-                    
+
                     Event event = Event.builder()
                             .book(book)
                             .chapter(chapter)
@@ -295,20 +245,16 @@ public class AdminService {
                             .build();
                     newEventsFromFile.add(event);
                 }
-                
+
                 allNewEvents.addAll(newEventsFromFile);
-                log.info("파일 '{}' 처리 완료: {}개 이벤트", filename, newEventsFromFile.size());
-                
+                log.info("파일 '{}' 처리 완료: {}개 이벤트", eventFile.getOriginalFilename(), newEventsFromFile.size());
+
             } catch (IOException e) {
-                log.error("이벤트 JSON 파일 파싱 실패: {}", filename, e);
-                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "JSON 파일 파싱 실패: " + filename);
-            } catch (Exception e) {
-                log.error("이벤트 파일 처리 중 오류: {}", filename, e);
-                throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "이벤트 파일 처리 실패: " + filename);
+                log.error("이벤트 JSON 파일 파싱 실패: {}", eventFile.getOriginalFilename(), e);
+                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "JSON 파일 파싱 실패: " + eventFile.getOriginalFilename());
             }
         }
 
-        // 배치 처리로 저장 (500개씩)
         if (allNewEvents.isEmpty()) {
             log.warn("저장할 이벤트가 없습니다.");
             return 0;
@@ -343,21 +289,38 @@ public class AdminService {
      */
     @Transactional
     public int uploadChapterSummaries(Long bookId, List<MultipartFile> summaryFiles) {
+        if (summaryFiles == null || summaryFiles.isEmpty()) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "업로드할 요약 파일이 없습니다.");
+        }
+
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
         List<CharacterPovSummary> allNewSummaries = new ArrayList<>();
-        Pattern pattern = Pattern.compile("chapter(\\d+)_perspective_summaries_Ko\\.json");
 
         for (MultipartFile summaryFile : summaryFiles) {
-            String filename = summaryFile.getOriginalFilename();
-            Matcher matcher = pattern.matcher(filename);
-
-            if (!matcher.matches()) {
-                throw new GeneralException(ErrorStatus.INVALID_FILE_NAME_FORMAT, "파일명: " + filename);
+            if (summaryFile == null || summaryFile.isEmpty()) {
+                log.warn("빈 요약 파일이 포함되어 스킵합니다.");
+                continue;
             }
 
-            Integer chapterIdx = Integer.parseInt(matcher.group(1));
+            SummaryUploadDTO uploadDTO;
+            try {
+                uploadDTO = objectMapper.readValue(summaryFile.getInputStream(), SummaryUploadDTO.class);
+            } catch (IOException e) {
+                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
+            }
+
+            if (uploadDTO == null || uploadDTO.getChapterIndex() == null) {
+                throw new GeneralException(ErrorStatus._BAD_REQUEST, "summary payload chapterIndex는 필수입니다.");
+            }
+            if (uploadDTO.getLanguage() != null && !"ko".equalsIgnoreCase(uploadDTO.getLanguage())) {
+                log.info("요약 파일 '{}'은(는) ko가 아니므로 스킵합니다. language={}",
+                        summaryFile.getOriginalFilename(), uploadDTO.getLanguage());
+                continue;
+            }
+
+            Integer chapterIdx = uploadDTO.getChapterIndex();
             Chapter chapter = chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)
                     .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND, "챕터 인덱스 " + chapterIdx + "를 찾을 수 없습니다."));
 
@@ -365,29 +328,24 @@ public class AdminService {
                 throw new GeneralException(ErrorStatus.CHAPTER_ALREADY_SUMMARIZED, "챕터 " + chapterIdx + "의 요약본은 이미 존재합니다.");
             }
 
-            Map<String, PovSummaryData> summaries;
-            try {
-                summaries = objectMapper.readValue(summaryFile.getInputStream(), new TypeReference<>() {});
-            } catch (IOException e) {
-                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
+            if (uploadDTO.getItems() != null) {
+                List<CharacterPovSummary> newSummariesFromFile = uploadDTO.getItems().stream()
+                        .map(item -> {
+                            Long characterId = parseCharacterId(item.getCharacterId(), "summary.characterId");
+                            Character character = characterRepository.findByBookAndCharacterId(chapter.getBook(), characterId)
+                                    .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND,
+                                            "Character not found with jsonId: " + characterId));
+
+                            return CharacterPovSummary.builder()
+                                    .book(chapter.getBook())
+                                    .chapter(chapter)
+                                    .character(character)
+                                    .summaryText(requireText(item.getSummary(), "summary.summary"))
+                                    .build();
+                        })
+                        .collect(Collectors.toList());
+                allNewSummaries.addAll(newSummariesFromFile);
             }
-
-            List<CharacterPovSummary> newSummariesFromFile = summaries.entrySet().stream().map(entry -> {
-                Long characterId = Long.parseLong(entry.getKey());
-                PovSummaryData summaryData = entry.getValue();
-                Character character = characterRepository.findByBookAndCharacterId(chapter.getBook(), characterId)
-                        .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND, "Character not found with jsonId: " + characterId));
-
-                return CharacterPovSummary.builder()
-                        .book(chapter.getBook())
-                        .chapter(chapter)
-                        .character(character)
-                        .summaryText(summaryData.getSummary())
-                        .build();
-            }).collect(Collectors.toList());
-
-            allNewSummaries.addAll(newSummariesFromFile);
-            // 해당 챕터의 요약이 완료되었음을 표시
             chapter.markAsSummarized();
         }
 
@@ -401,12 +359,10 @@ public class AdminService {
             }
         }
 
-        // 모든 챕터의 요약이 완료되었는지 확인 후, 책의 전체 요약 상태 업데이트
         try {
             checkAndUpdateBookSummaryStatus(book);
         } catch (Exception e) {
             log.error("책 요약 상태 업데이트 중 오류 발생", e);
-            // 책 상태 업데이트 실패는 critical하지 않으므로 로그만 남김
         }
         return allNewSummaries.size();
     }
@@ -420,41 +376,39 @@ public class AdminService {
      */
     @Transactional
     public int uploadRelationships(Long bookId, List<MultipartFile> files) {
-        // 입력된 bookId로 Book 엔터티를 조회
+        if (files == null || files.isEmpty()) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "업로드할 관계 파일이 없습니다.");
+        }
+
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
         int totalProcessedCount = 0;
 
-        // 업로드된 각 파일에 대해 반복 처리를 시작
         for (MultipartFile file : files) {
-            String filename = file.getOriginalFilename();
-            // 파일명 규칙을 기반으로 챕터와 이벤트 인덱스 추출
-            Matcher matcher = RELATIONSHIP_FILE_PATTERN.matcher(filename);
-
-            if (!matcher.find()) {
-                throw new GeneralException(ErrorStatus.INVALID_FILE_NAME_FORMAT, "파일명 형식이 올바르지 않습니다: " + filename);
+            if (file == null || file.isEmpty()) {
+                log.warn("빈 관계 파일이 포함되어 스킵합니다.");
+                continue;
             }
 
-            // 정규표현식 그룹에서 챕터와 이벤트 인덱스 추출
-            int chapterIdx = Integer.parseInt(matcher.group(1));
-            int eventIdx = Integer.parseInt(matcher.group(2));
-
-            // 파일명에서 얻은 정보로 Event 엔터티를 DB에서 조회
-            Event event = eventRepository.findByBookIdAndChapterIdxAndEventIdx(bookId, chapterIdx, eventIdx)
-                    .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND,
-                            String.format("이벤트를 찾을 수 없습니다 (책 ID: %d, 챕터: %d, 이벤트: %d)", bookId, chapterIdx, eventIdx)));
-
             try {
-                // JSON 파일을 DTO 객체로 변환
                 RelationshipUploadDTO dto = objectMapper.readValue(file.getInputStream(), RelationshipUploadDTO.class);
+                if (dto == null || dto.getChapterIndex() == null) {
+                    throw new GeneralException(ErrorStatus._BAD_REQUEST, "relationship payload chapterIndex는 필수입니다.");
+                }
+                String eventId = requireText(dto.getEventId(), "relationship.eventId");
+                int chapterIdx = dto.getChapterIndex();
+                int eventIdx = parseEventIdx(eventId, chapterIdx);
 
-                // DTO의 각 부분을 처리하는 헬퍼 메서드 호출
-                totalProcessedCount += processNodeWeights(event, book, dto.getNodeWeightsAccum());
-                totalProcessedCount += processRelations(event, book, dto.getRelations());
+                Event event = eventRepository.findByBookIdAndChapterIdxAndEventIdx(bookId, chapterIdx, eventIdx)
+                        .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND,
+                                String.format("이벤트를 찾을 수 없습니다 (책 ID: %d, 챕터: %d, 이벤트: %d)", bookId, chapterIdx, eventIdx)));
+
+                totalProcessedCount += processNodeWeights(event, book, dto.getNodeWeights());
+                totalProcessedCount += processRelations(event, book, dto.getItems());
 
             } catch (IOException e) {
-                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "관계 정보 JSON 파일 파싱에 실패했습니다: " + filename);
+                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "관계 정보 JSON 파일 파싱에 실패했습니다: " + file.getOriginalFilename());
             }
         }
         return totalProcessedCount;
@@ -475,55 +429,37 @@ public class AdminService {
 
         List<EventCharacterStat> newStats = new ArrayList<>();
         for (Map.Entry<String, NodeWeightDTO> entry : nodeWeightsMap.entrySet()) {
-            // 타입 변환 예외 처리
-            Long characterBookId;
-            try {
-                characterBookId = Long.parseLong(entry.getKey());
-            } catch (NumberFormatException e) {
-                log.warn("캐릭터 ID 형식 오류, 스킵: {}", entry.getKey());
-                continue;
-            }
-            
+            Long characterBookId = parseCharacterId(entry.getKey(), "relationship.nodeWeights.characterId");
             NodeWeightDTO weightDTO = entry.getValue();
             if (weightDTO == null) {
-                log.warn("캐릭터 ID {}의 가중치 정보가 null입니다, 스킵", characterBookId);
-                continue;
+                throw new GeneralException(ErrorStatus._BAD_REQUEST, "nodeWeights payload가 비어 있습니다: " + characterBookId);
             }
 
-            Optional<Character> characterOpt = characterRepository.findByBookAndCharacterId(book, characterBookId);
+            Character character = characterRepository.findByBookAndCharacterId(book, characterBookId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_CHARACTER_NOT_FOUND,
+                            "해당 책에 등록된 캐릭터를 찾을 수 없습니다: " + characterBookId));
 
-            // 캐릭터가 존재할 경우에만 로직을 실행
-            if (characterOpt.isPresent()) {
-                Character character = characterOpt.get();
-
-                // 1. 기존 데이터가 있는지 확인
-                if (statRepository.findByEventAndCharacter(event, character).isPresent()) {
-                    throw new GeneralException(ErrorStatus.NODE_WEIGHT_ALREADY_EXISTS,
-                            String.format("해당 이벤트에 대한 '%s' 캐릭터의 가중치 데이터가 이미 존재합니다.", character.getName()));
-                }
-
-                // 2. 새로운 stat 객체 생성
-                EventCharacterStat stat = EventCharacterStat.builder()
-                        .event(event)
-                        .character(character)
-                        .nodeWeight(weightDTO.getWeight())
-                        .build();
-
-                log.info("Character {} weight: {}, count: {} (count not stored in EventCharacterStat)",
-                        character.getName(), weightDTO.getWeight(), weightDTO.getCount());
-
-                // 3. 리스트에 추가
-                newStats.add(stat);
+            if (statRepository.findByEventAndCharacter(event, character).isPresent()) {
+                throw new GeneralException(ErrorStatus.NODE_WEIGHT_ALREADY_EXISTS,
+                        String.format("해당 이벤트에 대한 '%s' 캐릭터의 가중치 데이터가 이미 존재합니다.", character.getName()));
             }
-            // 캐릭터가 존재하지 않으면, 이 블록은 실행되지 않고 다음 데이터로 넘어감.
+
+            EventCharacterStat stat = EventCharacterStat.builder()
+                    .event(event)
+                    .character(character)
+                    .nodeWeight(weightDTO.getWeight())
+                    .build();
+
+            log.info("Character {} weight: {}, count: {} (count not stored in EventCharacterStat)",
+                    character.getName(), weightDTO.getWeight(), weightDTO.getCount());
+            newStats.add(stat);
         }
 
-        // 모든 검사가 끝난 후, 한번에 저장
         if (newStats.isEmpty()) {
             log.warn("저장할 노드 가중치가 없습니다.");
             return 0;
         }
-        
+
         try {
             statRepository.saveAll(newStats);
             log.info("노드 가중치 {}개 DB 저장 완료", newStats.size());
@@ -549,61 +485,50 @@ public class AdminService {
 
         List<EventRelationshipEdge> newEdges = new ArrayList<>();
         for (RelationshipDTO dto : relationDTOs) {
-            // 필수 필드 검증
-            if (dto.getId1() == null || dto.getId2() == null) {
-                log.warn("관계 DTO에 캐릭터 ID가 null입니다, 스킵");
+            Long fromCharacterId = parseCharacterId(dto.getFromCharacterId(), "relationship.fromCharacterId");
+            Long toCharacterId = parseCharacterId(dto.getToCharacterId(), "relationship.toCharacterId");
+
+            if (fromCharacterId.equals(toCharacterId)) {
                 continue;
             }
-            
-            // 자기 자신과의 관계는 제외
-            if (dto.getId1().equals(dto.getId2())) {
-                continue;
-            }
-            
-            // Positivity와 Count 검증
-            if (dto.getPositivity() == null || dto.getCount() == null) {
-                log.warn("관계 DTO에 필수 필드(positivity/count)가 null입니다 ({}->{}), 스킵", dto.getId1(), dto.getId2());
-                continue;
+            if (dto.getPositivity() == null || dto.getEvidenceCount() == null) {
+                throw new GeneralException(ErrorStatus._BAD_REQUEST, "relationship positivity/evidenceCount는 필수입니다.");
             }
 
-            Optional<Character> fromCharOpt = characterRepository.findByBookAndCharacterId(book, dto.getId1());
-            Optional<Character> toCharOpt = characterRepository.findByBookAndCharacterId(book, dto.getId2());
+            Character fromChar = characterRepository.findByBookAndCharacterId(book, fromCharacterId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_CHARACTER_NOT_FOUND,
+                            "해당 책에 등록된 캐릭터를 찾을 수 없습니다: " + fromCharacterId));
+            Character toChar = characterRepository.findByBookAndCharacterId(book, toCharacterId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_CHARACTER_NOT_FOUND,
+                            "해당 책에 등록된 캐릭터를 찾을 수 없습니다: " + toCharacterId));
 
-            // 두 캐릭터가 모두 존재할 경우에만 아래 로직을 실행
-            if (fromCharOpt.isPresent() && toCharOpt.isPresent()) {
-                Character fromChar = fromCharOpt.get();
-                Character toChar = toCharOpt.get();
-
-                // 관계가 (A->B) 또는 (B->A) 방향으로 이미 존재하는지 확인
-                if (eventRelationshipEdgeRepository.existsByEventAndFromCharacterAndToCharacter(event, fromChar, toChar) ||
-                        eventRelationshipEdgeRepository.existsByEventAndFromCharacterAndToCharacter(event, toChar, fromChar)) {
-                    throw new GeneralException(ErrorStatus.RELATIONSHIP_DATA_ALREADY_EXISTS,
-                            String.format("해당 이벤트에 대한 '%s'와(과) '%s'의 관계 데이터가 이미 존재합니다.", fromChar.getName(), toChar.getName()));
-                }
-
-                try {
-                    EventRelationshipEdge edge = EventRelationshipEdge.builder()
-                            .event(event)
-                            .fromCharacter(fromChar)
-                            .toCharacter(toChar)
-                            .sentimentScore(dto.getPositivity().floatValue())
-                            .interactionCount(dto.getCount())
-                            .relationTags(objectMapper.writeValueAsString(dto.getRelation()))
-                            .build();
-                    newEdges.add(edge);
-                } catch (JsonProcessingException e) {
-                    throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, String.format("캐릭터 %d와(과) %d의 관계 태그 처리 중 오류가 발생했습니다.", dto.getId1(), dto.getId2()));
-                }
+            if (eventRelationshipEdgeRepository.existsByEventAndFromCharacterAndToCharacter(event, fromChar, toChar) ||
+                    eventRelationshipEdgeRepository.existsByEventAndFromCharacterAndToCharacter(event, toChar, fromChar)) {
+                throw new GeneralException(ErrorStatus.RELATIONSHIP_DATA_ALREADY_EXISTS,
+                        String.format("해당 이벤트에 대한 '%s'와(과) '%s'의 관계 데이터가 이미 존재합니다.", fromChar.getName(), toChar.getName()));
             }
-            // 캐릭터가 하나라도 존재하지 않으면, 이 데이터는 무시하고 다음 루프로 넘어갑니다.
+
+            try {
+                EventRelationshipEdge edge = EventRelationshipEdge.builder()
+                        .event(event)
+                        .fromCharacter(fromChar)
+                        .toCharacter(toChar)
+                        .sentimentScore(dto.getPositivity().floatValue())
+                        .interactionCount(dto.getEvidenceCount())
+                        .relationTags(objectMapper.writeValueAsString(dto.getLabels() != null ? dto.getLabels() : List.of()))
+                        .build();
+                newEdges.add(edge);
+            } catch (JsonProcessingException e) {
+                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR,
+                        String.format("캐릭터 %d와(과) %d의 관계 태그 처리 중 오류가 발생했습니다.", fromCharacterId, toCharacterId));
+            }
         }
 
-        // 모든 검사가 끝난 후, 한번에 저장
         if (newEdges.isEmpty()) {
             log.warn("저장할 관계 엣지가 없습니다.");
             return 0;
         }
-        
+
         try {
             eventRelationshipEdgeRepository.saveAll(newEdges);
             log.info("관계 엣지 {}개 DB 저장 완료", newEdges.size());
@@ -800,7 +725,7 @@ public class AdminService {
     }
 
     private Integer parseEventIdx(String eventId, Integer chapterIdx) {
-        Matcher matcher = Pattern.compile("^ch(\\d+)-e(\\d+)$").matcher(eventId);
+        java.util.regex.Matcher matcher = java.util.regex.Pattern.compile("^ch(\\d+)-e(\\d+)$").matcher(eventId);
         if (matcher.matches()) {
             Integer eventChapterIdx = Integer.parseInt(matcher.group(1));
             if (!chapterIdx.equals(eventChapterIdx)) {
@@ -824,21 +749,99 @@ public class AdminService {
     }
 
     private LocatorDTO resolveEventLocator(Chapter chapter, Integer txtOffset) {
-        if (!locatorSupport.hasLocatorMetadata(chapter)) {
-            return null;
-        }
         return locatorSupport.toLocator(chapter, txtOffset);
     }
 
-    /**
-     * POV 요약본 JSON 파일 파싱을 위한 내부 전용 클래스
-     */
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    private static class PovSummaryData {
-        private String character_name;
-        private String summary;
+    private String resolveCharacterDescription(CharacterDTO dto) {
+        if (dto.getDescriptions() != null) {
+            String description = normalizeOptionalText(dto.getDescriptions().get("ko"));
+            if (description != null) {
+                return description;
+            }
+        }
+        return normalizeOptionalText(dto.getLegacyDescriptionKo());
+    }
+
+    private String joinNames(List<String> names, String fallbackName) {
+        if (names == null || names.isEmpty()) {
+            return fallbackName;
+        }
+
+        String joined = names.stream()
+                .map(this::normalizeOptionalText)
+                .filter(value -> value != null && !value.isBlank())
+                .distinct()
+                .collect(Collectors.joining(","));
+        return joined.isBlank() ? fallbackName : joined;
+    }
+
+    private Long parseCharacterId(String rawValue, String fieldName) {
+        String normalized = requireText(rawValue, fieldName);
+        if (normalized.matches("\\d+")) {
+            return Long.parseLong(normalized);
+        }
+
+        java.util.regex.Matcher matcher = java.util.regex.Pattern.compile("^c0*(\\d+)$", java.util.regex.Pattern.CASE_INSENSITIVE)
+                .matcher(normalized);
+        if (matcher.matches()) {
+            return Long.parseLong(matcher.group(1));
+        }
+
+        throw new GeneralException(ErrorStatus._BAD_REQUEST, fieldName + " 형식이 올바르지 않습니다: " + rawValue);
+    }
+
+    private void validateEventText(Chapter chapter, int startTxtOffset, int endTxtOffset, String eventText, String eventId) {
+        String chapterText = normalizeChapterText(chapter.getRawText());
+        if (chapterText == null) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "챕터 원문이 준비되지 않아 eventText를 검증할 수 없습니다.");
+        }
+
+        int totalCodePoints = chapterText.codePointCount(0, chapterText.length());
+        if (startTxtOffset < 0 || endTxtOffset > totalCodePoints) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "이벤트 txtOffset 범위가 챕터 범위를 벗어났습니다: " + eventId);
+        }
+
+        String expected = substringByCodePoints(chapterText, startTxtOffset, endTxtOffset);
+        String actual = normalizeChapterText(eventText);
+        if (!expected.equals(actual)) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "eventText와 chapterTxt[start:end]가 일치하지 않습니다: " + eventId);
+        }
+    }
+
+    private String normalizeChapterText(String rawText) {
+        if (rawText == null) {
+            return null;
+        }
+        return rawText.replace("\r\n", "\n").replace('\r', '\n');
+    }
+
+    private String substringByCodePoints(String text, int start, int end) {
+        int startIndex = text.offsetByCodePoints(0, start);
+        int endIndex = text.offsetByCodePoints(0, end);
+        return text.substring(startIndex, endIndex);
+    }
+
+    private String requireText(String value, String fieldName) {
+        String normalized = normalizeOptionalText(value);
+        if (normalized == null) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, fieldName + "는 필수입니다.");
+        }
+        return normalized;
+    }
+
+    private String requireRawText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, fieldName + "는 필수입니다.");
+        }
+        return value;
+    }
+
+    private String normalizeOptionalText(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
     }
 }
 

--- a/src/main/java/com/kw/readwith/service/BookAccessPolicy.java
+++ b/src/main/java/com/kw/readwith/service/BookAccessPolicy.java
@@ -32,14 +32,6 @@ public class BookAccessPolicy {
     }
 
     public boolean canUserAccess(Book book, Long userId) {
-        if (book == null) {
-            return false;
-        }
-        if (book.isDefault()) {
-            return true;
-        }
-        return userId != null
-                && book.getUploadedBy() != null
-                && userId.equals(book.getUploadedBy().getId());
+        return book != null;
     }
 }

--- a/src/main/java/com/kw/readwith/service/BookAnalysisStatusService.java
+++ b/src/main/java/com/kw/readwith/service/BookAnalysisStatusService.java
@@ -1,0 +1,80 @@
+package com.kw.readwith.service;
+
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Chapter;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import com.kw.readwith.repository.CharacterRepository;
+import com.kw.readwith.repository.EventCharacterStatRepository;
+import com.kw.readwith.repository.EventRelationshipEdgeRepository;
+import com.kw.readwith.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BookAnalysisStatusService {
+
+    private final BookRepository bookRepository;
+    private final ChapterRepository chapterRepository;
+    private final CharacterRepository characterRepository;
+    private final EventRepository eventRepository;
+    private final EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
+    private final EventCharacterStatRepository eventCharacterStatRepository;
+
+    @Transactional
+    public void refreshStatus(Long bookId) {
+        Book book = bookRepository.findById(bookId).orElse(null);
+        if (book == null) {
+            return;
+        }
+
+        if (isAnalysisComplete(book)) {
+            book.markAnalysisReady();
+            return;
+        }
+
+        book.resetAnalysisStatus();
+    }
+
+    @Transactional
+    public void resetToNone(Long bookId) {
+        bookRepository.findById(bookId).ifPresent(Book::resetAnalysisStatus);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markRejectedIfPending(Long bookId) {
+        bookRepository.findById(bookId).ifPresent(book -> {
+            if (!book.isAnalysisReady()) {
+                book.markAnalysisRejected();
+            }
+        });
+    }
+
+    private boolean isAnalysisComplete(Book book) {
+        if (!book.isNormalizationReady()) {
+            return false;
+        }
+        if (!characterRepository.existsByBook(book)) {
+            return false;
+        }
+        if (!eventRepository.existsByBook(book)) {
+            return false;
+        }
+
+        List<Chapter> chapters = chapterRepository.findByBookId(book.getId());
+        if (chapters.isEmpty()) {
+            return false;
+        }
+        if (chapters.stream().anyMatch(chapter -> !chapter.isPovSummariesCached())) {
+            return false;
+        }
+
+        return eventRelationshipEdgeRepository.existsByBook(book)
+                || eventCharacterStatRepository.existsByBook(book);
+    }
+}

--- a/src/main/java/com/kw/readwith/service/BookService.java
+++ b/src/main/java/com/kw/readwith/service/BookService.java
@@ -47,9 +47,7 @@ public class BookService {
                                          Boolean favoriteOnly,
                                          String sortBy,
                                          Long userId) {
-        List<Book> books = userId == null
-                ? bookRepository.findByNormalizationStatusAndIsDefaultTrue(NormalizationStatus.READY)
-                : bookRepository.findAccessibleBooks(userId, NormalizationStatus.READY);
+        List<Book> books = bookRepository.findByNormalizationStatus(NormalizationStatus.READY);
 
         if (keyword != null && !keyword.isBlank()) {
             String lower = keyword.toLowerCase();
@@ -107,10 +105,7 @@ public class BookService {
     }
 
     public BookDetailDTO getBook(Long bookId, Long userId) {
-        Book book = userId == null
-                ? bookRepository.findByIdAndNormalizationStatusAndIsDefaultTrue(bookId, NormalizationStatus.READY)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND))
-                : bookRepository.findAccessibleBook(bookId, userId, NormalizationStatus.READY)
+        Book book = bookRepository.findByIdAndNormalizationStatus(bookId, NormalizationStatus.READY)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
         boolean isFavorite = userId != null && favoriteRepository.findByUserId(userId).stream()
@@ -133,8 +128,8 @@ public class BookService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         ExtractedEpubMetadata extractedMetadata = epubMetadataExtractorService.extract(epubFile);
-        String resolvedTitle = resolveRequiredMetadata("title", extractedMetadata.title(), title);
-        String resolvedAuthor = resolveRequiredMetadata("author", extractedMetadata.author(), author);
+        String resolvedTitle = resolveRequiredMetadata("title", extractedMetadata.title(), null);
+        String resolvedAuthor = resolveRequiredMetadata("author", extractedMetadata.author(), null);
         String resolvedLanguage = resolveRequiredMetadata("language", extractedMetadata.language(), language);
 
         Book book = Book.builder()

--- a/src/main/java/com/kw/readwith/service/BookmarkService.java
+++ b/src/main/java/com/kw/readwith/service/BookmarkService.java
@@ -39,9 +39,11 @@ public class BookmarkService {
         validateUserExists(userId);
         validateReadableBook(userId, bookId);
 
-        List<Bookmark> bookmarks = "time_asc".equalsIgnoreCase(sort)
-                ? bookmarkRepository.findByUserIdAndBookIdOrderByCreatedAtAsc(userId, bookId)
-                : bookmarkRepository.findByUserIdAndBookIdOrderByCreatedAtDesc(userId, bookId);
+        List<Bookmark> bookmarks = switch (normalizeSort(sort)) {
+            case "time_asc" -> bookmarkRepository.findByUserIdAndBookIdOrderByCreatedAtAsc(userId, bookId);
+            case "time_desc" -> bookmarkRepository.findByUserIdAndBookIdOrderByCreatedAtDesc(userId, bookId);
+            default -> throw new GeneralException(ErrorStatus._BAD_REQUEST, "sort must be time_desc or time_asc.");
+        };
 
         return bookmarks.stream()
                 .map(this::convertToResponseDTO)
@@ -179,6 +181,13 @@ public class BookmarkService {
 
     private boolean equalsNullable(Integer left, Integer right) {
         return left == null ? right == null : left.equals(right);
+    }
+
+    private String normalizeSort(String sort) {
+        if (sort == null || sort.isBlank()) {
+            return "time_desc";
+        }
+        return sort.trim().toLowerCase();
     }
 
     private record ResolvedBookmarkRange(Integer startTxtOffset, Integer endTxtOffset) {

--- a/src/main/java/com/kw/readwith/service/FineGraphService.java
+++ b/src/main/java/com/kw/readwith/service/FineGraphService.java
@@ -17,10 +17,10 @@ import com.kw.readwith.dto.graph.FineGraphResponseDTO;
 import com.kw.readwith.dto.graph.GraphNodeDTO;
 import com.kw.readwith.repository.BookRepository;
 import com.kw.readwith.repository.ChapterRepository;
-import com.kw.readwith.repository.CharacterRepository;
 import com.kw.readwith.repository.EventCharacterStatRepository;
 import com.kw.readwith.repository.EventRelationshipEdgeRepository;
 import com.kw.readwith.repository.EventRepository;
+import com.kw.readwith.util.LocatorSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,9 +28,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -41,39 +42,40 @@ public class FineGraphService {
     private final BookRepository bookRepository;
     private final ChapterRepository chapterRepository;
     private final EventRepository eventRepository;
-    private final CharacterRepository characterRepository;
     private final EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
     private final EventCharacterStatRepository eventCharacterStatRepository;
     private final ObjectMapper objectMapper;
     private final V2TransitionGuard transitionGuard;
     private final BookAccessPolicy bookAccessPolicy;
+    private final LocatorSupport locatorSupport;
 
-    public FineGraphResponseDTO getFineGraph(Long bookId, Integer chapterIdx, Integer eventIdx, Long userId) {
+    public FineGraphResponseDTO getFineGraph(
+            Long bookId,
+            Integer chapterIdx,
+            Integer eventIdx,
+            LocatorDTO locator,
+            Long userId
+    ) {
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
         bookAccessPolicy.ensureReadable(book, userId);
 
         if (!book.isAnalysisReady()) {
-            return FineGraphResponseDTO.builder()
-                    .nodes(List.of())
-                    .edges(List.of())
-                    .eventInfo(null)
-                    .build();
+            return emptyResponse();
         }
 
-        Chapter chapter = chapterRepository.findByBookIdAndIdx(book.getId(), chapterIdx)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
-        Event event = eventRepository.findByChapterAndIdx(chapter, eventIdx)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND));
+        Event event = resolveEvent(book, chapterIdx, eventIdx, locator).orElse(null);
+        if (event == null) {
+            return emptyResponse();
+        }
+
         transitionGuard.ensureEventLocatorReady(event, "fine graph 조회");
 
         List<EventRelationshipEdge> edges = eventRelationshipEdgeRepository.findByEvent(event);
-        Set<Long> characterIds = edges.stream()
-                .flatMap(edge -> List.of(edge.getFromCharacter().getId(), edge.getToCharacter().getId()).stream())
-                .collect(Collectors.toSet());
+        List<EventCharacterStat> stats = eventCharacterStatRepository.findByEvent(event);
 
-        List<GraphNodeDTO> nodes = characterRepository.findAllById(characterIds).stream()
-                .map(character -> convertToGraphNodeDTO(character, event))
+        List<GraphNodeDTO> nodes = collectCharacters(edges, stats).values().stream()
+                .map(character -> convertToGraphNodeDTO(character, findStat(stats, character)))
                 .toList();
 
         List<FineGraphEdgeDTO> edgeDTOs = edges.stream()
@@ -81,8 +83,8 @@ public class FineGraphService {
                 .toList();
 
         EventInfoDTO eventInfo = EventInfoDTO.builder()
-                .chapterIdx(chapterIdx)
-                .eventIdx(eventIdx)
+                .chapterIdx(event.getChapter().getIdx())
+                .eventIdx(event.getIdx())
                 .eventId(event.getEventId())
                 .startLocator(buildEventLocator(event, true))
                 .endLocator(buildEventLocator(event, false))
@@ -97,15 +99,75 @@ public class FineGraphService {
                 .build();
     }
 
-    private GraphNodeDTO convertToGraphNodeDTO(Character character, Event event) {
-        EventCharacterStat characterStat = eventCharacterStatRepository
-                .findByEventAndCharacter(event, character)
-                .orElse(null);
+    private FineGraphResponseDTO emptyResponse() {
+        return FineGraphResponseDTO.builder()
+                .nodes(List.of())
+                .edges(List.of())
+                .eventInfo(null)
+                .build();
+    }
 
+    private Optional<Event> resolveEvent(Book book, Integer chapterIdx, Integer eventIdx, LocatorDTO locator) {
+        if (locator != null) {
+            return resolveEventByLocator(book, locator);
+        }
+        if (chapterIdx == null || eventIdx == null) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "chapterIdx/eventIdx or locator is required.");
+        }
+
+        Chapter chapter = chapterRepository.findByBookIdAndIdx(book.getId(), chapterIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+        return eventRepository.findByChapterAndIdx(chapter, eventIdx);
+    }
+
+    private Optional<Event> resolveEventByLocator(Book book, LocatorDTO locator) {
+        if (locator.getChapterIndex() == null) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "locator.chapterIndex is required.");
+        }
+
+        Chapter chapter = chapterRepository.findByBookIdAndIdx(book.getId(), locator.getChapterIndex())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+        transitionGuard.ensureLocatorMetadataReady(book, chapter, "fine graph 조회");
+
+        int txtOffset = locatorSupport.toTxtOffset(chapter, locator);
+        List<Event> events = eventRepository.findByChapterOrderByIdx(chapter);
+
+        return events.stream()
+                .filter(event -> containsOffset(event, txtOffset))
+                .findFirst()
+                .or(() -> events.stream()
+                        .filter(event -> event.getStartTxtOffset() <= txtOffset)
+                        .reduce((first, second) -> second));
+    }
+
+    private boolean containsOffset(Event event, int txtOffset) {
+        return event.getStartTxtOffset() <= txtOffset && txtOffset < event.getEndTxtOffset();
+    }
+
+    private Map<Long, Character> collectCharacters(List<EventRelationshipEdge> edges, List<EventCharacterStat> stats) {
+        Map<Long, Character> characters = new LinkedHashMap<>();
+        for (EventCharacterStat stat : stats) {
+            characters.put(stat.getCharacter().getId(), stat.getCharacter());
+        }
+        for (EventRelationshipEdge edge : edges) {
+            characters.put(edge.getFromCharacter().getId(), edge.getFromCharacter());
+            characters.put(edge.getToCharacter().getId(), edge.getToCharacter());
+        }
+        return characters;
+    }
+
+    private EventCharacterStat findStat(List<EventCharacterStat> stats, Character character) {
+        return stats.stream()
+                .filter(stat -> stat.getCharacter().getId().equals(character.getId()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private GraphNodeDTO convertToGraphNodeDTO(Character character, EventCharacterStat characterStat) {
         Float weight = characterStat != null ? (float) characterStat.getNodeWeight() : null;
 
         return GraphNodeDTO.builder()
-                .id(character.getId())
+                .id(character.getCharacterId())
                 .label(character.getName())
                 .isMainCharacter(character.isMainCharacter())
                 .profileImage(character.getProfileImage())
@@ -131,8 +193,8 @@ public class FineGraphService {
         }
 
         return FineGraphEdgeDTO.builder()
-                .from(edge.getFromCharacter().getId())
-                .to(edge.getToCharacter().getId())
+                .from(edge.getFromCharacter().getCharacterId())
+                .to(edge.getToCharacter().getCharacterId())
                 .sentimentScore(edge.getSentimentScore() != null ? edge.getSentimentScore().doubleValue() : 0.0)
                 .interactionCount(edge.getInteractionCount())
                 .relationTags(relationTags)

--- a/src/main/java/com/kw/readwith/service/MacroGraphService.java
+++ b/src/main/java/com/kw/readwith/service/MacroGraphService.java
@@ -5,17 +5,20 @@ import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.Event;
 import com.kw.readwith.domain.mapping.EventCharacterStat;
 import com.kw.readwith.domain.mapping.EventRelationshipEdge;
+import com.kw.readwith.dto.common.LocatorDTO;
 import com.kw.readwith.dto.graph.GraphNodeDTO;
 import com.kw.readwith.dto.graph.MacroGraphEdgeDTO;
 import com.kw.readwith.dto.graph.MacroGraphResponseDTO;
 import com.kw.readwith.repository.BookRepository;
-import com.kw.readwith.repository.CharacterRepository;
+import com.kw.readwith.repository.ChapterRepository;
 import com.kw.readwith.repository.EventCharacterStatRepository;
 import com.kw.readwith.repository.EventRelationshipEdgeRepository;
 import com.kw.readwith.repository.EventRepository;
+import com.kw.readwith.util.LocatorSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,9 +26,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -34,50 +37,41 @@ import java.util.stream.Collectors;
 public class MacroGraphService {
 
     private final BookRepository bookRepository;
+    private final ChapterRepository chapterRepository;
     private final EventRepository eventRepository;
     private final EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
     private final EventCharacterStatRepository eventCharacterStatRepository;
-    private final CharacterRepository characterRepository;
     private final ObjectMapper objectMapper;
     private final BookAccessPolicy bookAccessPolicy;
+    private final LocatorSupport locatorSupport;
 
-    public MacroGraphResponseDTO getMacroGraph(Long bookId, Integer uptoChapter, Long userId) {
+    public MacroGraphResponseDTO getMacroGraph(Long bookId, Integer uptoChapter, LocatorDTO uptoLocator, Long userId) {
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
         bookAccessPolicy.ensureReadable(book, userId);
 
+        Integer effectiveChapter = resolveEffectiveChapter(book, uptoChapter, uptoLocator);
         if (!book.isAnalysisReady()) {
-            return MacroGraphResponseDTO.builder()
-                    .nodes(List.of())
-                    .edges(List.of())
-                    .userCurrentChapter(uptoChapter)
-                    .build();
+            return emptyResponse(effectiveChapter);
         }
 
-        List<Event> lastEvents = eventRepository.findLastEventsByBookAndUptoChapter(book, uptoChapter);
-        if (lastEvents.isEmpty()) {
-            return MacroGraphResponseDTO.builder()
-                    .nodes(List.of())
-                    .edges(List.of())
-                    .userCurrentChapter(uptoChapter)
-                    .build();
+        List<Event> selectedEvents = resolveSelectedEvents(book, uptoChapter, uptoLocator);
+        if (selectedEvents.isEmpty()) {
+            return emptyResponse(effectiveChapter);
         }
 
-        List<EventRelationshipEdge> macroEdges = eventRelationshipEdgeRepository.findByEventIn(lastEvents);
-        Set<Long> characterIds = macroEdges.stream()
-                .flatMap(edge -> List.of(edge.getFromCharacter().getId(), edge.getToCharacter().getId()).stream())
-                .collect(Collectors.toSet());
+        List<EventRelationshipEdge> macroEdges = eventRelationshipEdgeRepository.findByEventIn(selectedEvents);
+        List<EventCharacterStat> macroStats = eventCharacterStatRepository.findByEventIn(selectedEvents);
 
-        List<GraphNodeDTO> nodes = characterRepository.findAllById(characterIds).stream()
-                .map(character -> {
-                    Event relatedEvent = macroEdges.stream()
-                            .filter(edge -> edge.getFromCharacter().getId().equals(character.getId())
-                                    || edge.getToCharacter().getId().equals(character.getId()))
-                            .map(EventRelationshipEdge::getEvent)
-                            .findFirst()
-                            .orElse(null);
-                    return convertToGraphNodeDTO(character, relatedEvent);
-                })
+        Map<Long, EventCharacterStat> latestStats = latestStatsByCharacter(selectedEvents, macroStats);
+        Map<Long, Integer> statCounts = statCountsByCharacter(macroStats);
+
+        List<GraphNodeDTO> nodes = collectCharacters(macroEdges, macroStats).values().stream()
+                .map(character -> convertToGraphNodeDTO(
+                        character,
+                        latestStats.get(character.getId()),
+                        statCounts.get(character.getId())
+                ))
                 .toList();
 
         List<MacroGraphEdgeDTO> edgeDTOs = macroEdges.stream()
@@ -87,19 +81,99 @@ public class MacroGraphService {
         return MacroGraphResponseDTO.builder()
                 .nodes(nodes)
                 .edges(edgeDTOs)
-                .userCurrentChapter(uptoChapter)
+                .userCurrentChapter(effectiveChapter)
                 .build();
     }
 
-    private GraphNodeDTO convertToGraphNodeDTO(Character character, Event event) {
-        EventCharacterStat characterStat = eventCharacterStatRepository
-                .findByEventAndCharacter(event, character)
-                .orElse(null);
+    private MacroGraphResponseDTO emptyResponse(Integer chapterIdx) {
+        return MacroGraphResponseDTO.builder()
+                .nodes(List.of())
+                .edges(List.of())
+                .userCurrentChapter(chapterIdx)
+                .build();
+    }
 
-        Float weight = characterStat != null ? (float) characterStat.getNodeWeight() : null;
+    private Integer resolveEffectiveChapter(Book book, Integer uptoChapter, LocatorDTO uptoLocator) {
+        if (uptoLocator != null) {
+            if (uptoLocator.getChapterIndex() == null) {
+                throw new GeneralException(ErrorStatus._BAD_REQUEST, "uptoLocator.chapterIndex is required.");
+            }
+            return uptoLocator.getChapterIndex();
+        }
+        if (uptoChapter == null) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "uptoChapter or uptoLocator is required.");
+        }
+        return uptoChapter;
+    }
+
+    private List<Event> resolveSelectedEvents(Book book, Integer uptoChapter, LocatorDTO uptoLocator) {
+        if (uptoLocator == null) {
+            return eventRepository.findLastEventsByBookAndUptoChapter(book, uptoChapter);
+        }
+
+        Chapter chapter = chapterRepository.findByBookIdAndIdx(book.getId(), uptoLocator.getChapterIndex())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+        int uptoTxtOffset = locatorSupport.toTxtOffset(chapter, uptoLocator);
+
+        List<Event> events = eventRepository.findByBookOrderByChapterIdxAscIdxAsc(book);
+        Map<Integer, Event> selectedByChapter = new LinkedHashMap<>();
+        for (Event event : events) {
+            int chapterIdx = event.getChapter().getIdx();
+            if (chapterIdx > chapter.getIdx()) {
+                break;
+            }
+            if (chapterIdx < chapter.getIdx()) {
+                selectedByChapter.put(chapterIdx, event);
+                continue;
+            }
+            if (event.getStartTxtOffset() <= uptoTxtOffset) {
+                selectedByChapter.put(chapterIdx, event);
+            }
+        }
+        return new ArrayList<>(selectedByChapter.values());
+    }
+
+    private Map<Long, Character> collectCharacters(List<EventRelationshipEdge> edges, List<EventCharacterStat> stats) {
+        Map<Long, Character> characters = new LinkedHashMap<>();
+        for (EventCharacterStat stat : stats) {
+            characters.put(stat.getCharacter().getId(), stat.getCharacter());
+        }
+        for (EventRelationshipEdge edge : edges) {
+            characters.put(edge.getFromCharacter().getId(), edge.getFromCharacter());
+            characters.put(edge.getToCharacter().getId(), edge.getToCharacter());
+        }
+        return characters;
+    }
+
+    private Map<Long, EventCharacterStat> latestStatsByCharacter(List<Event> selectedEvents, List<EventCharacterStat> stats) {
+        Map<Long, Integer> orderByEventId = new LinkedHashMap<>();
+        for (int i = 0; i < selectedEvents.size(); i++) {
+            orderByEventId.put(selectedEvents.get(i).getId(), i);
+        }
+
+        Map<Long, EventCharacterStat> latestStats = new LinkedHashMap<>();
+        stats.stream()
+                .sorted((left, right) -> Integer.compare(
+                        orderByEventId.getOrDefault(left.getEvent().getId(), -1),
+                        orderByEventId.getOrDefault(right.getEvent().getId(), -1)
+                ))
+                .forEach(stat -> latestStats.put(stat.getCharacter().getId(), stat));
+        return latestStats;
+    }
+
+    private Map<Long, Integer> statCountsByCharacter(List<EventCharacterStat> stats) {
+        Map<Long, Integer> counts = new LinkedHashMap<>();
+        for (EventCharacterStat stat : stats) {
+            counts.merge(stat.getCharacter().getId(), 1, Integer::sum);
+        }
+        return counts;
+    }
+
+    private GraphNodeDTO convertToGraphNodeDTO(Character character, EventCharacterStat stat, Integer count) {
+        Float weight = stat != null ? (float) stat.getNodeWeight() : null;
 
         return GraphNodeDTO.builder()
-                .id(character.getId())
+                .id(character.getCharacterId())
                 .label(character.getName())
                 .isMainCharacter(character.isMainCharacter())
                 .profileImage(character.getProfileImage())
@@ -107,7 +181,7 @@ public class MacroGraphService {
                 .portraitPrompt(character.getProfileText())
                 .names(parseNames(character.getNames(), character.getName()))
                 .weight(weight)
-                .count(null)
+                .count(count)
                 .build();
     }
 
@@ -125,8 +199,8 @@ public class MacroGraphService {
         }
 
         return MacroGraphEdgeDTO.builder()
-                .from(edge.getFromCharacter().getId())
-                .to(edge.getToCharacter().getId())
+                .from(edge.getFromCharacter().getCharacterId())
+                .to(edge.getToCharacter().getCharacterId())
                 .sentimentScore(edge.getSentimentScore() != null ? edge.getSentimentScore().doubleValue() : 0.0)
                 .interactionCount(edge.getInteractionCount())
                 .relationTags(relationTags)

--- a/src/main/java/com/kw/readwith/service/ManifestService.java
+++ b/src/main/java/com/kw/readwith/service/ManifestService.java
@@ -76,10 +76,7 @@ public class ManifestService {
     }
 
     private Book validateAndGetBook(Long bookId, Long userId) {
-        return userId == null
-                ? bookRepository.findByIdAndNormalizationStatusAndIsDefaultTrue(bookId, NormalizationStatus.READY)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND))
-                : bookRepository.findAccessibleBook(bookId, userId, NormalizationStatus.READY)
+        return bookRepository.findByIdAndNormalizationStatus(bookId, NormalizationStatus.READY)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
     }
 

--- a/src/main/java/com/kw/readwith/service/UserReadStateService.java
+++ b/src/main/java/com/kw/readwith/service/UserReadStateService.java
@@ -44,7 +44,7 @@ public class UserReadStateService {
         bookAccessPolicy.ensureReadable(book, user.getId());
         transitionGuard.ensureLocatorWritesEnabled("progress 저장");
 
-        LocatorDTO locator = requestDTO.getLocator();
+        LocatorDTO locator = requestDTO.getStartLocator();
         Chapter chapter = validateLocator(book, locator);
         transitionGuard.ensureLocatorMetadataReady(book, chapter, "progress 저장");
         locatorSupport.toTxtOffset(chapter, locator);
@@ -102,9 +102,16 @@ public class UserReadStateService {
     }
 
     private ProgressResponseDTO convertToResponseDTO(UserReadState userReadState) {
+        LocatorDTO locator = locatorSupport.readLocator(userReadState.getLastLocatorJson());
+        Integer startTxtOffset = resolveTxtOffset(userReadState.getBook(), locator);
+
         return ProgressResponseDTO.builder()
                 .bookId(userReadState.getBook().getId())
-                .locator(locatorSupport.readLocator(userReadState.getLastLocatorJson()))
+                .startLocator(locator)
+                .endLocator(null)
+                .startTxtOffset(startTxtOffset)
+                .endTxtOffset(null)
+                .locatorVersion(userReadState.getBook().getLocatorVersion())
                 .updatedAt(userReadState.getUpdatedAt())
                 .build();
     }
@@ -116,5 +123,14 @@ public class UserReadStateService {
 
         return chapterRepository.findByBookIdAndIdx(book.getId(), locator.getChapterIndex())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+    }
+
+    private Integer resolveTxtOffset(Book book, LocatorDTO locator) {
+        if (locator == null || locator.getChapterIndex() == null) {
+            return null;
+        }
+
+        Chapter chapter = validateLocator(book, locator);
+        return locatorSupport.toTxtOffset(chapter, locator);
     }
 }

--- a/src/main/java/com/kw/readwith/web/controller/BookController.java
+++ b/src/main/java/com/kw/readwith/web/controller/BookController.java
@@ -25,10 +25,24 @@ public class BookController {
 
     private final BookService bookService;
 
-    private Long getCurrentUserId() {
+    private Long getCurrentUserIdOrNull() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication != null && authentication.getPrincipal() instanceof Long) {
-            return (Long) authentication.getPrincipal();
+        if (authentication == null || authentication.getPrincipal() == null) {
+            return null;
+        }
+        if (authentication.getPrincipal() instanceof Long principal) {
+            return principal;
+        }
+        if ("anonymousUser".equals(authentication.getPrincipal())) {
+            return null;
+        }
+        throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+    }
+
+    private Long requireCurrentUserId() {
+        Long userId = getCurrentUserIdOrNull();
+        if (userId != null) {
+            return userId;
         }
         throw new GeneralException(ErrorStatus._UNAUTHORIZED);
     }
@@ -42,7 +56,7 @@ public class BookController {
             @RequestParam(defaultValue = "updatedAt") String sort,
             @RequestParam(required = false) Boolean favorite
     ) {
-        Long userId = getCurrentUserId();
+        Long userId = getCurrentUserIdOrNull();
         List<BookSummaryDTO> response = bookService.getBooks(q, language, favorite, sort, userId);
         return ApiResponse.onSuccess(response);
     }
@@ -51,7 +65,7 @@ public class BookController {
     @GetMapping("/{bookId}")
     @Operation(summary = "단일 도서 조회", description = "도서 ID로 단일 도서를 조회합니다.")
     public ApiResponse<BookDetailDTO> getBook(@PathVariable Long bookId) {
-        Long userId = getCurrentUserId();
+        Long userId = getCurrentUserIdOrNull();
         BookDetailDTO response = bookService.getBook(bookId, userId);
         return ApiResponse.onSuccess(response);
     }
@@ -63,7 +77,7 @@ public class BookController {
                                                     @RequestPart(value = "title", required = false) String title,
                                                     @RequestPart(value = "author", required = false) String author,
                                                     @RequestPart(value = "language", required = false) String language) {
-        Long userId = getCurrentUserId();
+        Long userId = requireCurrentUserId();
         BookDetailDTO response = bookService.uploadBook(userId, file, title, author, language);
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/kw/readwith/web/controller/GraphController.java
+++ b/src/main/java/com/kw/readwith/web/controller/GraphController.java
@@ -3,6 +3,7 @@ package com.kw.readwith.web.controller;
 import com.kw.readwith.apiPayload.ApiResponse;
 import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.dto.common.LocatorDTO;
 import com.kw.readwith.dto.graph.FineGraphResponseDTO;
 import com.kw.readwith.dto.graph.MacroGraphResponseDTO;
 import com.kw.readwith.service.FineGraphService;
@@ -13,12 +14,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping({"/api/graph", "/api/v2/graph"})
 @RequiredArgsConstructor
-@Tag(name = "Graph", description = "인물 관계 그래프 API")
+@Tag(name = "Graph", description = "?몃Ъ 愿怨?洹몃옒??API")
 public class GraphController {
 
     private final FineGraphService fineGraphService;
@@ -32,43 +36,66 @@ public class GraphController {
         throw new GeneralException(ErrorStatus._UNAUTHORIZED);
     }
 
-    /**
-     * 세밀(이벤트) 그래프 조회
-     */
     @GetMapping("/fine")
     @Operation(
-            summary = "세밀(이벤트) 그래프 조회",
-            description = "특정 이벤트에서의 인물 관계 그래프를 조회합니다. 해당 이벤트에 존재하는 EventRelationshipEdge를 기반으로 관계 데이터를 반환합니다."
+            summary = "?몃?(?대깽?? 洹몃옒??議고쉶",
+            description = "locator ? chapterIdx/eventIdx 湲곕컲?쇰줈 ?대깽??洹몃옒?꾨? 議고쉶?⑸땲??"
     )
     public ApiResponse<FineGraphResponseDTO> getFineGraph(
-            @Parameter(description = "책 ID", required = true, example = "1")
+            @Parameter(description = "梨?ID", required = true, example = "1")
             @RequestParam Long bookId,
-            @Parameter(description = "챕터 인덱스", required = true, example = "1")
-            @RequestParam Integer chapterIdx,
-            @Parameter(description = "이벤트 인덱스", required = true, example = "3")
-            @RequestParam Integer eventIdx) {
+            @Parameter(description = "legacy chapter index", example = "1")
+            @RequestParam(required = false) Integer chapterIdx,
+            @Parameter(description = "legacy event index", example = "3")
+            @RequestParam(required = false) Integer eventIdx,
+            @Parameter(description = "locator chapter index", example = "1")
+            @RequestParam(required = false) Integer chapterIndex,
+            @Parameter(description = "locator block index", example = "2")
+            @RequestParam(required = false) Integer blockIndex,
+            @Parameter(description = "locator offset", example = "5")
+            @RequestParam(required = false) Integer offset) {
 
         Long userId = getCurrentUserId();
-        FineGraphResponseDTO response = fineGraphService.getFineGraph(bookId, chapterIdx, eventIdx, userId);
+        LocatorDTO locator = buildLocator(chapterIndex, blockIndex, offset);
+        FineGraphResponseDTO response = fineGraphService.getFineGraph(bookId, chapterIdx, eventIdx, locator, userId);
         return ApiResponse.onSuccess(response);
     }
 
-    /**
-     * 거시(챕터 누적) 그래프 조회
-     */
     @GetMapping("/macro")
     @Operation(
-            summary = "거시(챕터 누적) 그래프 조회",
-            description = "특정 챕터까지의 누적 인물 관계 그래프를 조회합니다. ChapterRelationshipEdge 기반으로 챕터별 누적 관계를 반환합니다."
+            summary = "嫄곗떆(梨뺥꽣 ?꾩쟻) 洹몃옒??議고쉶",
+            description = "uptoLocator ? uptoChapter 湲곕컲?쇰줈 ?꾩쟻 愿怨?洹몃옒?꾨? 議고쉶?⑸땲??"
     )
     public ApiResponse<MacroGraphResponseDTO> getMacroGraph(
-            @Parameter(description = "책 ID", required = true, example = "1")
+            @Parameter(description = "梨?ID", required = true, example = "1")
             @RequestParam Long bookId,
-            @Parameter(description = "조회할 마지막 챕터 인덱스", required = true, example = "3")
-            @RequestParam Integer uptoChapter) {
+            @Parameter(description = "legacy upto chapter", example = "3")
+            @RequestParam(required = false) Integer uptoChapter,
+            @Parameter(description = "locator chapter index", example = "3")
+            @RequestParam(required = false) Integer chapterIndex,
+            @Parameter(description = "locator block index", example = "2")
+            @RequestParam(required = false) Integer blockIndex,
+            @Parameter(description = "locator offset", example = "5")
+            @RequestParam(required = false) Integer offset) {
 
         Long userId = getCurrentUserId();
-        MacroGraphResponseDTO response = macroGraphService.getMacroGraph(bookId, uptoChapter, userId);
+        LocatorDTO uptoLocator = buildLocator(chapterIndex, blockIndex, offset);
+        MacroGraphResponseDTO response = macroGraphService.getMacroGraph(bookId, uptoChapter, uptoLocator, userId);
         return ApiResponse.onSuccess(response);
+    }
+
+    private LocatorDTO buildLocator(Integer chapterIndex, Integer blockIndex, Integer offset) {
+        if (chapterIndex == null && blockIndex == null && offset == null) {
+            return null;
+        }
+        if (chapterIndex == null || blockIndex == null || offset == null) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "chapterIndex, blockIndex, offset must be provided together.");
+        }
+
+        return LocatorDTO.builder()
+                .chapterIndex(chapterIndex)
+                .blockIndex(blockIndex)
+                .offset(offset)
+                .build();
     }
 }

--- a/src/test/java/com/kw/readwith/controller/GraphControllerSmokeTest.java
+++ b/src/test/java/com/kw/readwith/controller/GraphControllerSmokeTest.java
@@ -1,0 +1,114 @@
+package com.kw.readwith.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kw.readwith.domain.User;
+import com.kw.readwith.repository.UserRepository;
+import com.kw.readwith.util.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+        "cloud.aws.credentials.accessKey=test",
+        "cloud.aws.credentials.secretKey=test",
+        "cloud.aws.region.static=ap-northeast-2",
+        "cloud.aws.s3.bucket=test-bucket",
+        "cloud.aws.path.original=original",
+        "cloud.aws.path.metadata=metadata",
+        "spring.jpa.properties.hibernate.hbm2ddl.auto=create-drop",
+        "spring.security.oauth2.client.registration.google.client-id=test",
+        "spring.security.oauth2.client.registration.google.client-secret=test",
+        "spring.ai.openai.api-key=test"
+})
+class GraphControllerSmokeTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        User user = userRepository.findAll().stream()
+                .findFirst()
+                .orElseThrow();
+        accessToken = jwtUtil.generateAccessToken(user.getId(), user.getEmail());
+    }
+
+    @Test
+    @DisplayName("legacy and locator graph queries both return the same seeded event")
+    void graphEndpointsRespondForLegacyAndLocatorQueries() throws Exception {
+        JsonNode fineLegacy = readResult(
+                mockMvc.perform(get("/api/v2/graph/fine")
+                                .param("bookId", "1")
+                                .param("chapterIdx", "1")
+                                .param("eventIdx", "3")
+                                .header("Authorization", "Bearer " + accessToken)
+                                .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andReturn()
+        );
+
+        JsonNode fineLocator = readResult(
+                mockMvc.perform(get("/api/v2/graph/fine")
+                                .param("bookId", "1")
+                                .param("chapterIndex", "1")
+                                .param("blockIndex", "0")
+                                .param("offset", "2600")
+                                .header("Authorization", "Bearer " + accessToken)
+                                .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andReturn()
+        );
+
+        JsonNode macroLocator = readResult(
+                mockMvc.perform(get("/api/v2/graph/macro")
+                                .param("bookId", "1")
+                                .param("chapterIndex", "1")
+                                .param("blockIndex", "0")
+                                .param("offset", "2600")
+                                .header("Authorization", "Bearer " + accessToken)
+                                .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andReturn()
+        );
+
+        assertThat(fineLegacy.path("event").path("eventId").asText()).isEqualTo("ch1-e3");
+        assertThat(fineLocator.path("event").path("eventId").asText()).isEqualTo("ch1-e3");
+        assertThat(fineLocator.path("characters")).isNotEmpty();
+        assertThat(fineLocator.path("characters").get(0).path("id").asLong()).isPositive();
+        assertThat(macroLocator.path("userCurrentChapter").asInt()).isEqualTo(1);
+        assertThat(macroLocator.path("characters")).isNotEmpty();
+    }
+
+    private JsonNode readResult(MvcResult result) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(root.path("isSuccess").asBoolean()).isTrue();
+        return root.path("result");
+    }
+}

--- a/src/test/java/com/kw/readwith/dto/progress/ProgressDtoContractTest.java
+++ b/src/test/java/com/kw/readwith/dto/progress/ProgressDtoContractTest.java
@@ -1,0 +1,61 @@
+package com.kw.readwith.dto.progress;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kw.readwith.dto.common.LocatorDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProgressDtoContractTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("legacy locator field is accepted as startLocator")
+    void saveProgressRequestAcceptsLegacyLocatorField() throws Exception {
+        String json = """
+                {
+                  "bookId": 1,
+                  "locator": {
+                    "chapterIndex": 2,
+                    "blockIndex": 3,
+                    "offset": 4
+                  }
+                }
+                """;
+
+        SaveProgressRequestDTO dto = objectMapper.readValue(json, SaveProgressRequestDTO.class);
+
+        assertThat(dto.getBookId()).isEqualTo(1L);
+        assertThat(dto.getStartLocator()).isEqualTo(dto.getLocator());
+        assertThat(dto.getStartLocator().getChapterIndex()).isEqualTo(2);
+        assertThat(dto.getStartLocator().getBlockIndex()).isEqualTo(3);
+        assertThat(dto.getStartLocator().getOffset()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("progress response exposes both startLocator and legacy locator")
+    void progressResponseSerializesLegacyLocatorAlias() throws Exception {
+        LocatorDTO locator = LocatorDTO.builder()
+                .chapterIndex(2)
+                .blockIndex(3)
+                .offset(4)
+                .build();
+
+        ProgressResponseDTO response = ProgressResponseDTO.builder()
+                .bookId(1L)
+                .startLocator(locator)
+                .startTxtOffset(120)
+                .locatorVersion("locator-v1")
+                .build();
+
+        JsonNode json = objectMapper.readTree(objectMapper.writeValueAsBytes(response));
+
+        assertThat(json.path("startLocator").path("chapterIndex").asInt()).isEqualTo(2);
+        assertThat(json.path("locator").path("chapterIndex").asInt()).isEqualTo(2);
+        assertThat(json.path("startTxtOffset").asInt()).isEqualTo(120);
+        assertThat(json.path("locatorVersion").asText()).isEqualTo("locator-v1");
+    }
+}

--- a/src/test/java/com/kw/readwith/service/BookAccessPolicyTest.java
+++ b/src/test/java/com/kw/readwith/service/BookAccessPolicyTest.java
@@ -42,8 +42,8 @@ class BookAccessPolicyTest {
     }
 
     @Test
-    @DisplayName("비공개 업로드 책은 업로더만 접근할 수 있다")
-    void privateUploadedBookOnlyOwnerCanAccess() {
+    @DisplayName("정규화 완료된 업로드 책은 다른 사용자도 읽을 수 있다")
+    void uploadedBookIsGloballyReadableWhenReady() {
         User owner = User.builder().id(7L).build();
         Book book = Book.builder()
                 .id(1L)
@@ -54,6 +54,7 @@ class BookAccessPolicyTest {
 
         assertThatCode(() -> bookAccessPolicy.ensureReadable(book, 7L))
                 .doesNotThrowAnyException();
-        assertThrows(GeneralException.class, () -> bookAccessPolicy.ensureReadable(book, 8L));
+        assertThatCode(() -> bookAccessPolicy.ensureReadable(book, 8L))
+                .doesNotThrowAnyException();
     }
 }

--- a/src/test/java/com/kw/readwith/service/BookAnalysisStatusServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/BookAnalysisStatusServiceTest.java
@@ -1,0 +1,131 @@
+package com.kw.readwith.service;
+
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Chapter;
+import com.kw.readwith.domain.enums.AnalysisStatus;
+import com.kw.readwith.domain.enums.NormalizationStatus;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import com.kw.readwith.repository.CharacterRepository;
+import com.kw.readwith.repository.EventCharacterStatRepository;
+import com.kw.readwith.repository.EventRelationshipEdgeRepository;
+import com.kw.readwith.repository.EventRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BookAnalysisStatusServiceTest {
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private ChapterRepository chapterRepository;
+
+    @Mock
+    private CharacterRepository characterRepository;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
+
+    @Mock
+    private EventCharacterStatRepository eventCharacterStatRepository;
+
+    @InjectMocks
+    private BookAnalysisStatusService bookAnalysisStatusService;
+
+    @Test
+    @DisplayName("정규화와 분석 입력이 모두 갖춰지면 analysisStatus를 READY로 올린다")
+    void refreshStatusMarksReadyWhenAnalysisIsComplete() {
+        Book book = Book.builder()
+                .id(1L)
+                .normalizationStatus(NormalizationStatus.READY)
+                .analysisStatus(AnalysisStatus.NONE)
+                .build();
+
+        when(bookRepository.findById(1L)).thenReturn(Optional.of(book));
+        when(characterRepository.existsByBook(book)).thenReturn(true);
+        when(eventRepository.existsByBook(book)).thenReturn(true);
+        when(chapterRepository.findByBookId(1L)).thenReturn(List.of(
+                Chapter.builder().idx(1).povSummariesCached(true).build(),
+                Chapter.builder().idx(2).povSummariesCached(true).build()
+        ));
+        when(eventRelationshipEdgeRepository.existsByBook(book)).thenReturn(false);
+        when(eventCharacterStatRepository.existsByBook(book)).thenReturn(true);
+
+        bookAnalysisStatusService.refreshStatus(1L);
+
+        assertThat(book.getAnalysisStatus()).isEqualTo(AnalysisStatus.READY);
+        assertThat(book.isSummary()).isTrue();
+    }
+
+    @Test
+    @DisplayName("분석 입력이 부분 상태면 analysisStatus를 NONE으로 유지한다")
+    void refreshStatusResetsToNoneWhenAnalysisIsIncomplete() {
+        Book book = Book.builder()
+                .id(1L)
+                .normalizationStatus(NormalizationStatus.READY)
+                .analysisStatus(AnalysisStatus.READY)
+                .summary(true)
+                .build();
+
+        when(bookRepository.findById(1L)).thenReturn(Optional.of(book));
+        when(characterRepository.existsByBook(book)).thenReturn(true);
+        when(eventRepository.existsByBook(book)).thenReturn(true);
+        when(chapterRepository.findByBookId(1L)).thenReturn(List.of(
+                Chapter.builder().idx(1).povSummariesCached(true).build(),
+                Chapter.builder().idx(2).povSummariesCached(false).build()
+        ));
+
+        bookAnalysisStatusService.refreshStatus(1L);
+
+        assertThat(book.getAnalysisStatus()).isEqualTo(AnalysisStatus.NONE);
+        assertThat(book.isSummary()).isFalse();
+    }
+
+    @Test
+    @DisplayName("READY 전 책에서 검증 실패가 나면 analysisStatus를 REJECTED로 기록한다")
+    void markRejectedIfPendingMarksRejected() {
+        Book book = Book.builder()
+                .id(1L)
+                .analysisStatus(AnalysisStatus.NONE)
+                .build();
+
+        when(bookRepository.findById(1L)).thenReturn(Optional.of(book));
+
+        bookAnalysisStatusService.markRejectedIfPending(1L);
+
+        assertThat(book.getAnalysisStatus()).isEqualTo(AnalysisStatus.REJECTED);
+        assertThat(book.isSummary()).isFalse();
+    }
+
+    @Test
+    @DisplayName("이미 READY인 책은 재업로드 실패가 나도 READY를 유지한다")
+    void markRejectedIfPendingLeavesReadyBookUntouched() {
+        Book book = Book.builder()
+                .id(1L)
+                .analysisStatus(AnalysisStatus.READY)
+                .summary(true)
+                .build();
+
+        when(bookRepository.findById(1L)).thenReturn(Optional.of(book));
+
+        bookAnalysisStatusService.markRejectedIfPending(1L);
+
+        assertThat(book.getAnalysisStatus()).isEqualTo(AnalysisStatus.READY);
+        assertThat(book.isSummary()).isTrue();
+    }
+}

--- a/src/test/java/com/kw/readwith/service/BookServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/BookServiceTest.java
@@ -1,5 +1,6 @@
 package com.kw.readwith.service;
 
+import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.User;
 import com.kw.readwith.domain.enums.AnalysisStatus;
@@ -36,8 +37,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -74,8 +77,8 @@ class BookServiceTest {
     @BeforeEach
     void setUp() {
         TransactionSynchronizationManager.initSynchronization();
-        when(normalizationVersionService.resolveStatus(any(Book.class))).thenReturn(NormalizationVersionStatus.NOT_READY);
-        when(normalizationVersionService.needsRenormalization(any(Book.class))).thenReturn(false);
+        lenient().when(normalizationVersionService.resolveStatus(any(Book.class))).thenReturn(NormalizationVersionStatus.NOT_READY);
+        lenient().when(normalizationVersionService.needsRenormalization(any(Book.class))).thenReturn(false);
     }
 
     @AfterEach
@@ -135,8 +138,8 @@ class BookServiceTest {
     }
 
     @Test
-    @DisplayName("uploadBook falls back to request metadata when EPUB metadata is missing")
-    void uploadBookFallsBackToRequestMetadata() {
+    @DisplayName("uploadBook는 제목/저자 메타데이터가 없으면 요청값이 있어도 실패한다")
+    void uploadBookRequiresTitleAndAuthorMetadataFromEpub() {
         MockMultipartFile file = new MockMultipartFile(
                 "file",
                 "custom.epub",
@@ -147,29 +150,8 @@ class BookServiceTest {
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(uploader));
         when(epubMetadataExtractorService.extract(file)).thenReturn(ExtractedEpubMetadata.empty());
-        when(bookRepository.save(any(Book.class))).thenAnswer(invocation -> {
-            Book saved = invocation.getArgument(0);
-            ReflectionTestUtils.setField(saved, "id", 202L);
-            return saved;
-        });
-        when(normalizedArtifactStorageService.newSourceVersion()).thenReturn("source-v2");
-        when(normalizedArtifactStorageService.storeSourceEpub(202L, "source-v2", file))
-                .thenReturn("books/202/source/source-v2/book.epub");
-        when(normalizationJobService.createQueuedJob(any(Book.class), eq("source-v2"), eq("UPLOAD")))
-                .thenAnswer(invocation -> ProcessingJob.builder()
-                        .id(77L)
-                        .book(invocation.getArgument(0))
-                        .pipelineType(ProcessingPipelineType.NORMALIZATION)
-                        .runId("run-2")
-                        .sourceVersion("source-v2")
-                        .status(ProcessingJobStatus.QUEUED)
-                        .build());
 
-        BookDetailDTO response = bookService.uploadBook(1L, file, "Manual Title", "Manual Author", "ko");
-
-        assertThat(response.getTitle()).isEqualTo("Manual Title");
-        assertThat(response.getAuthor()).isEqualTo("Manual Author");
-        assertThat(response.getLanguage()).isEqualTo("ko");
+        assertThrows(GeneralException.class, () -> bookService.uploadBook(1L, file, "Manual Title", "Manual Author", "ko"));
     }
 
     private User sampleUser() {

--- a/src/test/java/com/kw/readwith/service/BookmarkServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/BookmarkServiceTest.java
@@ -1,0 +1,85 @@
+package com.kw.readwith.service;
+
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.config.V2TransitionGuard;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.User;
+import com.kw.readwith.domain.enums.NormalizationStatus;
+import com.kw.readwith.domain.enums.Provider;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.BookmarkRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import com.kw.readwith.repository.UserRepository;
+import com.kw.readwith.util.LocatorSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BookmarkServiceTest {
+
+    @Mock
+    private BookmarkRepository bookmarkRepository;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ChapterRepository chapterRepository;
+
+    @Mock
+    private LocatorSupport locatorSupport;
+
+    @Mock
+    private V2TransitionGuard transitionGuard;
+
+    @Mock
+    private BookAccessPolicy bookAccessPolicy;
+
+    @InjectMocks
+    private BookmarkService bookmarkService;
+
+    @Test
+    @DisplayName("bookmark list rejects unsupported sort values")
+    void getBookmarksRejectsUnsupportedSort() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(sampleUser()));
+        when(bookRepository.findById(10L)).thenReturn(Optional.of(sampleBook()));
+
+        assertThrows(GeneralException.class, () -> bookmarkService.getBookmarks(1L, 10L, "latest"));
+
+        verifyNoInteractions(bookmarkRepository);
+    }
+
+    private User sampleUser() {
+        return User.builder()
+                .id(1L)
+                .email("user@example.com")
+                .nickname("user")
+                .provider(Provider.GOOGLE)
+                .providerUid("provider-uid")
+                .isAdmin(false)
+                .build();
+    }
+
+    private Book sampleBook() {
+        return Book.builder()
+                .id(10L)
+                .title("Book")
+                .author("Author")
+                .language("en")
+                .normalizationStatus(NormalizationStatus.READY)
+                .build();
+    }
+}

--- a/src/test/java/com/kw/readwith/service/FineGraphServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/FineGraphServiceTest.java
@@ -1,0 +1,158 @@
+package com.kw.readwith.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kw.readwith.config.V2TransitionGuard;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.Chapter;
+import com.kw.readwith.domain.Event;
+import com.kw.readwith.domain.enums.AnalysisStatus;
+import com.kw.readwith.domain.enums.NormalizationStatus;
+import com.kw.readwith.domain.mapping.EventCharacterStat;
+import com.kw.readwith.dto.common.LocatorDTO;
+import com.kw.readwith.dto.graph.FineGraphResponseDTO;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import com.kw.readwith.repository.EventCharacterStatRepository;
+import com.kw.readwith.repository.EventRelationshipEdgeRepository;
+import com.kw.readwith.repository.EventRepository;
+import com.kw.readwith.util.LocatorSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FineGraphServiceTest {
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private ChapterRepository chapterRepository;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
+
+    @Mock
+    private EventCharacterStatRepository eventCharacterStatRepository;
+
+    @Mock
+    private V2TransitionGuard transitionGuard;
+
+    @Mock
+    private BookAccessPolicy bookAccessPolicy;
+
+    @Mock
+    private LocatorSupport locatorSupport;
+
+    private FineGraphService fineGraphService;
+
+    @BeforeEach
+    void setUp() {
+        fineGraphService = new FineGraphService(
+                bookRepository,
+                chapterRepository,
+                eventRepository,
+                eventRelationshipEdgeRepository,
+                eventCharacterStatRepository,
+                new ObjectMapper(),
+                transitionGuard,
+                bookAccessPolicy,
+                locatorSupport
+        );
+    }
+
+    @Test
+    @DisplayName("fine graph locator query resolves the matching event and returns stat-only nodes")
+    void getFineGraphResolvesEventByLocator() {
+        Book book = sampleBook();
+        Chapter chapter = sampleChapter(book, 2);
+        Event firstEvent = sampleEvent(book, chapter, 1, "ch2-e1", 0, 50);
+        Event targetEvent = sampleEvent(book, chapter, 2, "ch2-e2", 50, 100);
+        Character hero = sampleCharacter(book, 101L, 1001L, "Hero");
+        EventCharacterStat heroStat = EventCharacterStat.builder()
+                .event(targetEvent)
+                .character(hero)
+                .nodeWeight(0.75)
+                .build();
+        LocatorDTO locator = LocatorDTO.builder()
+                .chapterIndex(2)
+                .blockIndex(3)
+                .offset(4)
+                .build();
+
+        when(bookRepository.findById(10L)).thenReturn(Optional.of(book));
+        when(chapterRepository.findByBookIdAndIdx(10L, 2)).thenReturn(Optional.of(chapter));
+        when(locatorSupport.toTxtOffset(chapter, locator)).thenReturn(60);
+        when(eventRepository.findByChapterOrderByIdx(chapter)).thenReturn(List.of(firstEvent, targetEvent));
+        when(eventRelationshipEdgeRepository.findByEvent(targetEvent)).thenReturn(List.of());
+        when(eventCharacterStatRepository.findByEvent(targetEvent)).thenReturn(List.of(heroStat));
+
+        FineGraphResponseDTO response = fineGraphService.getFineGraph(10L, null, null, locator, 1L);
+
+        assertThat(response.getEventInfo()).isNotNull();
+        assertThat(response.getEventInfo().getEventId()).isEqualTo("ch2-e2");
+        assertThat(response.getNodes()).hasSize(1);
+        assertThat(response.getNodes().get(0).getId()).isEqualTo(1001L);
+        assertThat(response.getNodes().get(0).getWeight()).isEqualTo(0.75f);
+        assertThat(response.getEdges()).isEmpty();
+    }
+
+    private Book sampleBook() {
+        return Book.builder()
+                .id(10L)
+                .title("Book")
+                .author("Author")
+                .language("en")
+                .normalizationStatus(NormalizationStatus.READY)
+                .analysisStatus(AnalysisStatus.READY)
+                .build();
+    }
+
+    private Chapter sampleChapter(Book book, int idx) {
+        return Chapter.builder()
+                .id((long) idx)
+                .book(book)
+                .idx(idx)
+                .build();
+    }
+
+    private Event sampleEvent(Book book, Chapter chapter, int idx, String eventId, int start, int end) {
+        return Event.builder()
+                .id((long) idx)
+                .book(book)
+                .chapter(chapter)
+                .idx(idx)
+                .eventId(eventId)
+                .startTxtOffset(start)
+                .endTxtOffset(end)
+                .startBlockIndex(0)
+                .startOffset(start)
+                .endBlockIndex(0)
+                .endOffset(end)
+                .rawText("event")
+                .build();
+    }
+
+    private Character sampleCharacter(Book book, Long id, Long characterId, String name) {
+        return Character.builder()
+                .id(id)
+                .characterId(characterId)
+                .book(book)
+                .name(name)
+                .isMainCharacter(true)
+                .build();
+    }
+}

--- a/src/test/java/com/kw/readwith/service/MacroGraphServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/MacroGraphServiceTest.java
@@ -1,0 +1,153 @@
+package com.kw.readwith.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.Chapter;
+import com.kw.readwith.domain.Event;
+import com.kw.readwith.domain.enums.AnalysisStatus;
+import com.kw.readwith.domain.enums.NormalizationStatus;
+import com.kw.readwith.domain.mapping.EventCharacterStat;
+import com.kw.readwith.dto.common.LocatorDTO;
+import com.kw.readwith.dto.graph.MacroGraphResponseDTO;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import com.kw.readwith.repository.EventCharacterStatRepository;
+import com.kw.readwith.repository.EventRelationshipEdgeRepository;
+import com.kw.readwith.repository.EventRepository;
+import com.kw.readwith.util.LocatorSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MacroGraphServiceTest {
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private ChapterRepository chapterRepository;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
+
+    @Mock
+    private EventCharacterStatRepository eventCharacterStatRepository;
+
+    @Mock
+    private BookAccessPolicy bookAccessPolicy;
+
+    @Mock
+    private LocatorSupport locatorSupport;
+
+    private MacroGraphService macroGraphService;
+
+    @BeforeEach
+    void setUp() {
+        macroGraphService = new MacroGraphService(
+                bookRepository,
+                chapterRepository,
+                eventRepository,
+                eventRelationshipEdgeRepository,
+                eventCharacterStatRepository,
+                new ObjectMapper(),
+                bookAccessPolicy,
+                locatorSupport
+        );
+    }
+
+    @Test
+    @DisplayName("macro graph uptoLocator keeps the latest event before the locator in the current chapter")
+    void getMacroGraphUsesUptoLocator() {
+        Book book = sampleBook();
+        Chapter chapter2 = sampleChapter(book, 2);
+        Event earlierEvent = sampleEvent(book, chapter2, 1, "ch2-e1", 0, 40);
+        Event laterEvent = sampleEvent(book, chapter2, 2, "ch2-e2", 50, 100);
+        Character hero = sampleCharacter(book, 101L, 1001L, "Hero");
+        EventCharacterStat stat = EventCharacterStat.builder()
+                .event(earlierEvent)
+                .character(hero)
+                .nodeWeight(0.9)
+                .build();
+        LocatorDTO uptoLocator = LocatorDTO.builder()
+                .chapterIndex(2)
+                .blockIndex(1)
+                .offset(5)
+                .build();
+
+        when(bookRepository.findById(10L)).thenReturn(Optional.of(book));
+        when(chapterRepository.findByBookIdAndIdx(10L, 2)).thenReturn(Optional.of(chapter2));
+        when(locatorSupport.toTxtOffset(chapter2, uptoLocator)).thenReturn(45);
+        when(eventRepository.findByBookOrderByChapterIdxAscIdxAsc(book)).thenReturn(List.of(earlierEvent, laterEvent));
+        when(eventRelationshipEdgeRepository.findByEventIn(List.of(earlierEvent))).thenReturn(List.of());
+        when(eventCharacterStatRepository.findByEventIn(List.of(earlierEvent))).thenReturn(List.of(stat));
+
+        MacroGraphResponseDTO response = macroGraphService.getMacroGraph(10L, null, uptoLocator, 1L);
+
+        assertThat(response.getUserCurrentChapter()).isEqualTo(2);
+        assertThat(response.getNodes()).hasSize(1);
+        assertThat(response.getNodes().get(0).getId()).isEqualTo(1001L);
+        assertThat(response.getNodes().get(0).getWeight()).isEqualTo(0.9f);
+        assertThat(response.getNodes().get(0).getCount()).isEqualTo(1);
+        assertThat(response.getEdges()).isEmpty();
+    }
+
+    private Book sampleBook() {
+        return Book.builder()
+                .id(10L)
+                .title("Book")
+                .author("Author")
+                .language("en")
+                .normalizationStatus(NormalizationStatus.READY)
+                .analysisStatus(AnalysisStatus.READY)
+                .build();
+    }
+
+    private Chapter sampleChapter(Book book, int idx) {
+        return Chapter.builder()
+                .id((long) idx)
+                .book(book)
+                .idx(idx)
+                .build();
+    }
+
+    private Event sampleEvent(Book book, Chapter chapter, int idx, String eventId, int start, int end) {
+        return Event.builder()
+                .id((long) idx)
+                .book(book)
+                .chapter(chapter)
+                .idx(idx)
+                .eventId(eventId)
+                .startTxtOffset(start)
+                .endTxtOffset(end)
+                .startBlockIndex(0)
+                .startOffset(start)
+                .endBlockIndex(0)
+                .endOffset(end)
+                .rawText("event")
+                .build();
+    }
+
+    private Character sampleCharacter(Book book, Long id, Long characterId, String name) {
+        return Character.builder()
+                .id(id)
+                .characterId(characterId)
+                .book(book)
+                .name(name)
+                .isMainCharacter(true)
+                .build();
+    }
+}

--- a/src/test/java/com/kw/readwith/service/UserReadStateServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/UserReadStateServiceTest.java
@@ -1,0 +1,162 @@
+package com.kw.readwith.service;
+
+import com.kw.readwith.config.V2TransitionGuard;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Chapter;
+import com.kw.readwith.domain.User;
+import com.kw.readwith.domain.enums.NormalizationStatus;
+import com.kw.readwith.domain.enums.Provider;
+import com.kw.readwith.domain.mapping.UserReadState;
+import com.kw.readwith.dto.common.LocatorDTO;
+import com.kw.readwith.dto.progress.ProgressResponseDTO;
+import com.kw.readwith.dto.progress.SaveProgressRequestDTO;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import com.kw.readwith.repository.UserReadStateRepository;
+import com.kw.readwith.repository.UserRepository;
+import com.kw.readwith.util.LocatorSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserReadStateServiceTest {
+
+    @Mock
+    private UserReadStateRepository userReadStateRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private ChapterRepository chapterRepository;
+
+    @Mock
+    private LocatorSupport locatorSupport;
+
+    @Mock
+    private V2TransitionGuard transitionGuard;
+
+    @Mock
+    private BookAccessPolicy bookAccessPolicy;
+
+    @InjectMocks
+    private UserReadStateService userReadStateService;
+
+    @Test
+    @DisplayName("saveProgress returns v2 fields from a point locator")
+    void saveProgressReturnsEnrichedResponse() {
+        User user = sampleUser();
+        Book book = sampleBook();
+        Chapter chapter = sampleChapter(book);
+        LocatorDTO locator = sampleLocator();
+        SaveProgressRequestDTO request = SaveProgressRequestDTO.builder()
+                .bookId(10L)
+                .startLocator(locator)
+                .build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(bookRepository.findById(10L)).thenReturn(Optional.of(book));
+        when(chapterRepository.findByBookIdAndIdx(10L, 2)).thenReturn(Optional.of(chapter));
+        when(locatorSupport.toTxtOffset(chapter, locator)).thenReturn(120);
+        when(userReadStateRepository.findByUserIdAndBookId(1L, 10L)).thenReturn(Optional.empty());
+        when(locatorSupport.writeLocator(locator)).thenReturn("{locator}");
+        when(locatorSupport.readLocator("{locator}")).thenReturn(locator);
+        when(userReadStateRepository.save(any(UserReadState.class))).thenAnswer(invocation -> {
+            UserReadState saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "updatedAt", LocalDateTime.of(2026, 4, 2, 10, 0));
+            return saved;
+        });
+
+        ProgressResponseDTO response = userReadStateService.saveProgress(1L, request);
+
+        assertThat(response.getBookId()).isEqualTo(10L);
+        assertThat(response.getStartLocator()).isEqualTo(locator);
+        assertThat(response.getLocator()).isEqualTo(locator);
+        assertThat(response.getEndLocator()).isNull();
+        assertThat(response.getStartTxtOffset()).isEqualTo(120);
+        assertThat(response.getEndTxtOffset()).isNull();
+        assertThat(response.getLocatorVersion()).isEqualTo("locator-v2");
+    }
+
+    @Test
+    @DisplayName("getProgress exposes locatorVersion and txtOffset for stored progress")
+    void getProgressReturnsEnrichedResponse() {
+        User user = sampleUser();
+        Book book = sampleBook();
+        Chapter chapter = sampleChapter(book);
+        LocatorDTO locator = sampleLocator();
+        UserReadState userReadState = UserReadState.builder()
+                .id(50L)
+                .user(user)
+                .book(book)
+                .lastLocatorJson("{locator}")
+                .build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(bookRepository.findById(10L)).thenReturn(Optional.of(book));
+        when(userReadStateRepository.findByUserIdAndBookId(1L, 10L)).thenReturn(Optional.of(userReadState));
+        when(locatorSupport.readLocator("{locator}")).thenReturn(locator);
+        when(chapterRepository.findByBookIdAndIdx(10L, 2)).thenReturn(Optional.of(chapter));
+        when(locatorSupport.toTxtOffset(chapter, locator)).thenReturn(120);
+
+        ProgressResponseDTO response = userReadStateService.getProgress(1L, 10L);
+
+        assertThat(response.getStartLocator()).isEqualTo(locator);
+        assertThat(response.getStartTxtOffset()).isEqualTo(120);
+        assertThat(response.getLocatorVersion()).isEqualTo("locator-v2");
+    }
+
+    private User sampleUser() {
+        return User.builder()
+                .id(1L)
+                .email("user@example.com")
+                .nickname("user")
+                .provider(Provider.GOOGLE)
+                .providerUid("provider-uid")
+                .isAdmin(false)
+                .build();
+    }
+
+    private Book sampleBook() {
+        return Book.builder()
+                .id(10L)
+                .title("Book")
+                .author("Author")
+                .language("en")
+                .normalizationStatus(NormalizationStatus.READY)
+                .locatorVersion("locator-v2")
+                .build();
+    }
+
+    private Chapter sampleChapter(Book book) {
+        return Chapter.builder()
+                .id(20L)
+                .book(book)
+                .idx(2)
+                .build();
+    }
+
+    private LocatorDTO sampleLocator() {
+        return LocatorDTO.builder()
+                .chapterIndex(2)
+                .blockIndex(3)
+                .offset(4)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
이번 PR은 M3에서 프론트가 바로 붙을 수 있는 읽기 API와 AI/Admin 업로드 연동을 진행한 작업입니다.

> 참고 : 코드의 절반 가량이 Test 코드 추가입니다! 테스트는 통과되었기에 핵심 로직만 보시면 됩니다.

포함 범위는 크게 3가지입니다.
- 업로드 책을 전역 Book 객체로 취급하도록 공개 접근 정책 전환
- `book1` 기준 `upload_*` payload를 backend ingestion 계약에 맞게 반영
- `manifest/progress/bookmark/graph`를 locator 기반 v2 응답으로 정리하고, 업로드 완료 시 `analysisStatus`가 실제로 반영되도록 연결

즉, 기존에 열려 있던 API 껍데기에 M2 정규화/locator 엔진과 M3 업로드 흐름을 실제로 붙여서, 프론트가 실데이터 기준으로 붙을 수 있는 상태까지 정리한 PR입니다. 금주 회의 전에 책 데이터를 넣어, 실제로 해당 api에 대한 스모크 테스트까지 진행하여 결과보고 하겠습니다!

## 📋 변경 사항
- 업로드 책 접근 정책 변경
  - 업로드 책도 `normalizationStatus=READY` 이후 전역 공개로 조회 가능하도록 변경
  - `uploadedBy`는 유지하되 접근 제어 기준에서는 제거
  - 제목/저자는 EPUB 메타데이터 기준으로 사용하도록 정리

- Admin 업로드 API 반영
  - `book_characters.json`
  - `chapter_{n}_events.json`
  - `chapter_{n}_relationships_event_{m}.json`
  - `chapter_{n}_summaries_Ko.json`
  - 위 `book1` 기준 payload를 ingest하도록 DTO/서비스 정리
  - `eventText == chapterTxt[start:end]` strict substring 검증 적용
  - `ko` summary만 공식 ingest 대상으로 반영
  - `upload_mapping`은 공식 입력에서 제외

- analysisStatus 실제 전이 연결
  - characters/events/relationships/summary 업로드 성공 시 책 상태 재평가
  - 정규화 완료 + 분석 데이터 조건 충족 시 `analysisStatus=READY`
  - 업로드 검증 실패 시 pending 상태 책은 `REJECTED`
  - 삭제 API 호출 시 `analysisStatus=NONE`으로 재설정

- v2 읽기 API 정리
  - progress
    - 요청은 `startLocator`를 공식 필드로 수용
    - legacy `locator`도 alias로 계속 허용
    - 응답에 `startLocator/endLocator/startTxtOffset/endTxtOffset/locatorVersion` 추가
    - 내부 저장은 기존 point progress를 유지하므로 `endLocator/endTxtOffset`은 현재 `null`
  - bookmark
    - locator/range 응답 유지
    - `sort` 파라미터를 명시 검증하도록 변경
  - graph
    - fine/macro graph에 locator query 반영
    - legacy `chapterIdx/eventIdx`, `uptoChapter`도 계속 허용
    - `nodeWeights`만 있는 이벤트도 노드가 응답되도록 보강
    - graph node/edge id를 `characterId` 기준으로 정리

## 🔍 Code Review
주요 확인 포인트는 아래입니다.
- progress가 현재 DB 구조상 point 저장을 유지하는 상태에서, v2 응답 필드만 확장한 방식이 프론트 사용에 충분한지
- Admin 업로드 계약이 `book1` 기준 payload와 일치하는지
- `analysisStatus` READY 판정 기준이 현재 reader gating 의도와 맞는지
- graph locator query가 legacy query와 함께 열려 있는 현재 전환 방식이 적절한지

검증한 항목
- `compileJava`, `compileTestJava`
- `ProgressDtoContractTest`
- `UserReadStateServiceTest`
- `BookmarkServiceTest`
- `BookAccessPolicyTest`
- `BookServiceTest`
- `BookAnalysisStatusServiceTest`
- `FineGraphServiceTest`
- `MacroGraphServiceTest`
- `GraphControllerSmokeTest`

참고
- `GraphControllerSmokeTest`는 `H2 + full app context` 기준 smoke입니다.
- 실제 배포 환경에서의 `EPUB 업로드 -> 정규화 -> Admin upload -> manifest/graph 확인`은 아직 수행하지 않았고, dev 배포 후 확인 예정입니다.

## 📸 ScreenShot
- 백엔드 작업으로 별도 스크린샷 없음