### PR TITLE
fix: [M3] API 안정화 및 Swagger 문서 보강

### DIFF
--- a/src/main/java/com/kw/readwith/config/SecurityConfig.java
+++ b/src/main/java/com/kw/readwith/config/SecurityConfig.java
@@ -59,7 +59,8 @@ public class SecurityConfig {
                                 "/api/v2/progress/**",
                                 "/api/bookmarks/**",
                                 "/api/v2/bookmarks/**",
-                                "/api/favorites/**"
+                                "/api/favorites/**",
+                                "/api/v2/favorites/**"
                         ).authenticated()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/kw/readwith/config/SwaggerConfig.java
+++ b/src/main/java/com/kw/readwith/config/SwaggerConfig.java
@@ -2,12 +2,12 @@ package com.kw.readwith.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.security.SecurityScheme;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
@@ -15,18 +15,16 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI melissaServerAPI() {
         Info info = new Info()
-                .title("ReadWith Server API")
-                .description("ReadWith Spring Server API 명세서")
+                .title("ReadWith 백엔드 API")
+                .description("프론트엔드와 AI 업로드 연동에 사용하는 ReadWith 백엔드 API 명세입니다.")
                 .version("1.0.0");
 
         String jwtSchemeName = "JWT TOKEN";
-        // API 요청헤더에 인증정보 포함
         SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
-        // SecuritySchemes 등록
         Components components = new Components()
                 .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
                         .name(jwtSchemeName)
-                        .type(SecurityScheme.Type.HTTP) // HTTP 방식
+                        .type(SecurityScheme.Type.HTTP)
                         .scheme("bearer")
                         .bearerFormat("JWT"));
 

--- a/src/main/java/com/kw/readwith/config/V2ApiContractInterceptor.java
+++ b/src/main/java/com/kw/readwith/config/V2ApiContractInterceptor.java
@@ -17,12 +17,21 @@ import java.util.regex.Pattern;
 public class V2ApiContractInterceptor implements HandlerInterceptor {
 
     private static final List<Pattern> LEGACY_TRANSITION_PATHS = List.of(
+            // Reader bootstrap과 locator 기반 읽기 흐름은 v2 계약으로 완전히 대체되었으므로
+            // legacy /api 경로를 차단한다.
             Pattern.compile("^/api/books/[^/]+/manifest$"),
             Pattern.compile("^/api/progress(?:/.*)?$"),
             Pattern.compile("^/api/bookmarks(?:/.*)?$"),
             Pattern.compile("^/api/graph(?:/.*)?$"),
             Pattern.compile("^/api/admin(?:/.*)?$")
     );
+    // 아래 legacy 경로는 아직 일부 클라이언트 전환이 끝나지 않아 의도적으로 열어둔다.
+    // - /api/books, /api/books/{bookId}, POST /api/books
+    //   이유: 프론트/운영에서 도서 목록/상세/업로드 진입점을 아직 /api로 호출할 수 있다.
+    // - /api/favorites/**
+    //   이유: 즐겨찾기 라우트의 v2 전환 공지가 끝났는지 운영 기준으로 재확인이 필요하다.
+    // - /api/books/{bookId}/chapters/{chapterIdx}/pov-summaries
+    //   이유: 챕터 POV summary는 최근에 v2 alias를 붙였고, 프론트 호출 경로를 더 확인한 뒤 막는 편이 안전하다.
 
     private final ApiContractProperties apiContractProperties;
 

--- a/src/main/java/com/kw/readwith/dto/admin/CharacterDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/CharacterDTO.java
@@ -2,6 +2,7 @@ package com.kw.readwith.dto.admin;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,24 +11,32 @@ import java.util.Map;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "인물 1명에 대한 업로드 항목")
 public class CharacterDTO {
 
     @JsonAlias("id")
+    @Schema(description = "책 내부 characterId. 숫자 문자열을 사용합니다.", example = "7")
     private String characterId;
 
     @JsonAlias("common_name")
+    @Schema(description = "대표 이름", example = "셜록 홈즈")
     private String commonName;
 
+    @Schema(description = "이름/별칭 목록")
     private List<String> names;
 
     @JsonAlias("main_character")
+    @Schema(description = "주요 인물 여부")
     private boolean isMainCharacter;
 
+    @Schema(description = "언어별 설명. 현재는 `ko`를 사용합니다.")
     private Map<String, String> descriptions;
 
     @JsonProperty("description_ko")
+    @Schema(description = "legacy 한국어 설명 필드", deprecated = true, nullable = true)
     private String legacyDescriptionKo;
 
     @JsonAlias("portrait_prompt")
+    @Schema(description = "이미지 생성용 프롬프트 또는 프로필 텍스트")
     private String portraitPrompt;
 }

--- a/src/main/java/com/kw/readwith/dto/admin/CharacterListDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/CharacterListDTO.java
@@ -1,6 +1,7 @@
 package com.kw.readwith.dto.admin;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,8 +9,10 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "인물 업로드 payload 루트")
 public class CharacterListDTO {
 
     @JsonAlias("characters")
+    @Schema(description = "인물 목록")
     private List<CharacterDTO> items;
 }

--- a/src/main/java/com/kw/readwith/dto/admin/EventDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/EventDTO.java
@@ -1,24 +1,37 @@
 package com.kw.readwith.dto.admin;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "이벤트 1건에 대한 업로드 항목")
 public class EventDTO {
 
+    @Schema(description = "아이템 내부 chapterIndex. 루트 chapterIndex와 같아야 합니다.", nullable = true)
     private Integer chapterIndex;
 
+    @Schema(description = "legacy 시작 offset", nullable = true, deprecated = true)
     private Integer start;
+
+    @Schema(description = "legacy 종료 offset", nullable = true, deprecated = true)
     private Integer end;
+
+    @Schema(description = "이벤트 시작 텍스트 오프셋", example = "1200")
     private Integer startTxtOffset;
+
+    @Schema(description = "이벤트 종료 텍스트 오프셋", example = "1368")
     private Integer endTxtOffset;
 
+    @Schema(description = "legacy 이벤트 텍스트", nullable = true, deprecated = true)
     private String text;
+
+    @Schema(description = "이벤트 원문. chapterTxt[start:end]와 정확히 일치해야 합니다.")
     private String eventText;
 
     @JsonAlias("event_id")
+    @Schema(description = "이벤트 식별자", example = "ch3-e4")
     private String eventId;
 }
-    

--- a/src/main/java/com/kw/readwith/dto/admin/EventUploadDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/EventUploadDTO.java
@@ -1,5 +1,6 @@
 package com.kw.readwith.dto.admin;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,8 +8,12 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "이벤트 업로드 payload 루트")
 public class EventUploadDTO {
 
+    @Schema(description = "파일이 담당하는 챕터 인덱스(1-based)", example = "3")
     private Integer chapterIndex;
+
+    @Schema(description = "이벤트 목록")
     private List<EventDTO> items;
 }

--- a/src/main/java/com/kw/readwith/dto/admin/NodeWeightDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/NodeWeightDTO.java
@@ -1,5 +1,6 @@
 package com.kw.readwith.dto.admin;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -7,7 +8,12 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@Schema(description = "한 인물의 node weight 정보")
 public class NodeWeightDTO {
+
+    @Schema(description = "가중치", example = "18.5")
     private double weight;
+
+    @Schema(description = "등장 횟수 또는 누적 횟수", example = "6")
     private int count;
 }

--- a/src/main/java/com/kw/readwith/dto/admin/RelationshipDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/RelationshipDTO.java
@@ -1,6 +1,7 @@
 package com.kw.readwith.dto.admin;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,19 +9,25 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "관계 edge 1건에 대한 업로드 항목")
 public class RelationshipDTO {
 
     @JsonAlias("id1")
+    @Schema(description = "출발 인물 characterId", example = "7")
     private String fromCharacterId;
 
     @JsonAlias("id2")
+    @Schema(description = "도착 인물 characterId", example = "9")
     private String toCharacterId;
 
     @JsonAlias("relation")
+    @Schema(description = "관계 라벨 목록", example = "[\"동료\", \"협력\"]")
     private List<String> labels;
 
+    @Schema(description = "감정 점수", example = "0.72")
     private Double positivity;
 
     @JsonAlias("count")
+    @Schema(description = "근거 개수 또는 상호작용 횟수", example = "3")
     private Integer evidenceCount;
 }

--- a/src/main/java/com/kw/readwith/dto/admin/RelationshipUploadDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/RelationshipUploadDTO.java
@@ -1,6 +1,7 @@
 package com.kw.readwith.dto.admin;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,14 +10,20 @@ import java.util.Map;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "관계 업로드 payload 루트")
 public class RelationshipUploadDTO {
 
+    @Schema(description = "파일이 담당하는 챕터 인덱스(1-based)", example = "3")
     private Integer chapterIndex;
+
+    @Schema(description = "대상 이벤트 식별자", example = "ch3-e4")
     private String eventId;
 
     @JsonAlias("relations")
+    @Schema(description = "관계 edge 목록")
     private List<RelationshipDTO> items;
 
     @JsonAlias("node_weights_accum")
+    @Schema(description = "characterId별 node weight 정보")
     private Map<String, NodeWeightDTO> nodeWeights;
 }

--- a/src/main/java/com/kw/readwith/dto/admin/SummaryItemDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/SummaryItemDTO.java
@@ -1,13 +1,20 @@
 package com.kw.readwith.dto.admin;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "인물별 챕터 요약 항목")
 public class SummaryItemDTO {
 
+    @Schema(description = "책 내부 characterId", example = "7")
     private String characterId;
+
+    @Schema(description = "인물 이름", nullable = true)
     private String characterName;
+
+    @Schema(description = "해당 인물 시점의 챕터 요약")
     private String summary;
 }

--- a/src/main/java/com/kw/readwith/dto/admin/SummaryUploadDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/SummaryUploadDTO.java
@@ -1,5 +1,6 @@
 package com.kw.readwith.dto.admin;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,9 +8,15 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "챕터 요약 업로드 payload 루트")
 public class SummaryUploadDTO {
 
+    @Schema(description = "파일이 담당하는 챕터 인덱스(1-based)", example = "3")
     private Integer chapterIndex;
+
+    @Schema(description = "요약 언어 코드. 현재는 ko만 공식 입력입니다.", example = "ko")
     private String language;
+
+    @Schema(description = "인물별 요약 목록. 비어 있으면 업로드가 거부됩니다.")
     private List<SummaryItemDTO> items;
 }

--- a/src/main/java/com/kw/readwith/dto/book/BookDetailDTO.java
+++ b/src/main/java/com/kw/readwith/dto/book/BookDetailDTO.java
@@ -1,43 +1,62 @@
 package com.kw.readwith.dto.book;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "도서 상세 응답")
 public class BookDetailDTO {
-    /** 책 식별자 */
+
+    @Schema(description = "도서 ID", example = "42")
     private Long id;
-    /** 책 상세 제목 */
+
+    @Schema(description = "도서 제목")
     private String title;
-    /** 책 상세 저자 */
+
+    @Schema(description = "저자명")
     private String author;
-    /** 책 언어 코드 */
+
+    @Schema(description = "언어 코드", example = "en")
     private String language;
-    /** 기본 제공 책인지 여부 */
+
+    @Schema(description = "기본 제공 도서 여부")
     private boolean isDefault;
-    /** 책 상세 커버 이미지 */
+
+    @Schema(description = "표지 이미지 URL", nullable = true)
     private String coverImgUrl;
-    /** 원본 EPUB 경로 */
+
+    @Schema(description = "원본 EPUB 저장 경로", nullable = true)
     private String epubPath;
-    /** 본문 읽기 가능 상태 */
+
+    @Schema(description = "정규화 상태", example = "QUEUED")
     private String normalizationStatus;
-    /** AI 분석 자료 상태 */
+
+    @Schema(description = "분석 상태", example = "NONE")
     private String analysisStatus;
-    /** 현재 활성 정규화 규칙 버전 */
+
+    @Schema(description = "정규화 규칙 버전", nullable = true)
     private String ruleVersion;
-    /** 현재 활성 locator 버전 */
+
+    @Schema(description = "locator 버전", nullable = true)
     private String locatorVersion;
-    /** 현재 활성 정규화 run id */
+
+    @Schema(description = "활성 정규화 run id", nullable = true)
     private String normalizationRunId;
-    /** 현재 엔진 기준 버전 상태 */
+
+    @Schema(description = "정규화 버전 비교 상태", nullable = true)
     private String normalizationVersionStatus;
-    /** 재정규화가 필요한 책인지 표시 */
+
+    @Schema(description = "재정규화 필요 여부")
     private boolean needsRenormalization;
-    /** 활성 정규화 산출물 루트 경로 */
+
+    @Schema(description = "정규화 산출물 루트 경로", nullable = true)
     private String normalizedArtifactPath;
-    /** 현재 사용자의 즐겨찾기 여부 */
+
+    @Schema(description = "현재 사용자 기준 즐겨찾기 여부")
     private boolean isFavorite;
-    /** 요약 자료 준비 여부 */
+
+    @Schema(description = "요약 준비 완료 여부")
     private boolean summary;
 }

--- a/src/main/java/com/kw/readwith/dto/book/BookSummaryDTO.java
+++ b/src/main/java/com/kw/readwith/dto/book/BookSummaryDTO.java
@@ -1,5 +1,6 @@
 package com.kw.readwith.dto.book;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,39 +8,57 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@Schema(description = "도서 목록 응답에서 사용하는 요약 정보")
 public class BookSummaryDTO {
-    /** 책 식별자 */
+
+    @Schema(description = "도서 ID", example = "42")
     private Long id;
-    /** 책 목록 제목 */
+
+    @Schema(description = "도서 제목", example = "Sherlock Holmes")
     private String title;
-    /** 책 목록 저자 */
+
+    @Schema(description = "저자명", example = "Arthur Conan Doyle")
     private String author;
-    /** 책 카드 커버 이미지 */
+
+    @Schema(description = "표지 이미지 URL", nullable = true)
     private String coverImgUrl;
-    /** 원본 EPUB 경로 */
+
+    @Schema(description = "원본 EPUB 저장 경로", nullable = true)
     private String epubPath;
-    /** 본문 읽기 가능 상태 */
+
+    @Schema(description = "정규화 상태", example = "READY")
     private String normalizationStatus;
-    /** AI 분석 자료 상태 */
+
+    @Schema(description = "분석 상태", example = "READY")
     private String analysisStatus;
-    /** 현재 활성 정규화 규칙 버전 */
+
+    @Schema(description = "정규화 규칙 버전", nullable = true)
     private String ruleVersion;
-    /** 현재 활성 locator 버전 */
+
+    @Schema(description = "locator 버전", nullable = true)
     private String locatorVersion;
-    /** 현재 활성 정규화 run id */
+
+    @Schema(description = "활성 정규화 run id", nullable = true)
     private String normalizationRunId;
-    /** 현재 엔진 기준 버전 상태 */
+
+    @Schema(description = "정규화 버전 비교 상태", nullable = true)
     private String normalizationVersionStatus;
-    /** 재정규화가 필요한 책인지 표시 */
+
+    @Schema(description = "재정규화 필요 여부")
     private boolean needsRenormalization;
-    /** 활성 정규화 산출물 루트 경로 */
+
+    @Schema(description = "정규화 산출물 루트 경로", nullable = true)
     private String normalizedArtifactPath;
-    /** 현재 사용자의 즐겨찾기 여부 */
+
+    @Schema(description = "현재 사용자 기준 즐겨찾기 여부")
     private boolean isFavorite;
-    /** 기본 제공 책인지 여부 */
+
+    @Schema(description = "기본 제공 도서 여부")
     private boolean isDefault;
-    /** 요약 자료 준비 여부 */
+
+    @Schema(description = "요약 준비 완료 여부")
     private boolean summary;
-    /** 목록 정렬에 쓰는 최종 수정 시각 */
+
+    @Schema(description = "마지막 수정 시각")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/kw/readwith/dto/book/ChapterPovSummaryDTO.java
+++ b/src/main/java/com/kw/readwith/dto/book/ChapterPovSummaryDTO.java
@@ -1,5 +1,6 @@
 package com.kw.readwith.dto.book;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,9 +8,18 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "한 인물에 대한 챕터 POV summary")
 public class ChapterPovSummaryDTO {
+
+    @Schema(description = "책 내부 characterId", example = "7")
     private Long characterId;
+
+    @Schema(description = "인물 이름", example = "셜록 홈즈")
     private String characterName;
+
+    @Schema(description = "해당 인물 시점의 챕터 요약")
     private String summaryText;
+
+    @Schema(description = "주요 인물 여부")
     private boolean isMainCharacter;
 }

--- a/src/main/java/com/kw/readwith/dto/book/ChapterPovSummaryResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/book/ChapterPovSummaryResponseDTO.java
@@ -1,5 +1,6 @@
 package com.kw.readwith.dto.book;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,9 +10,18 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "챕터 POV summary 조회 응답")
 public class ChapterPovSummaryResponseDTO {
+
+    @Schema(description = "도서 ID", example = "42")
     private Long bookId;
+
+    @Schema(description = "챕터 인덱스(1-based)", example = "3")
     private Integer chapterIdx;
+
+    @Schema(description = "챕터 제목")
     private String chapterTitle;
+
+    @Schema(description = "인물별 POV summary 목록")
     private List<ChapterPovSummaryDTO> povSummaries;
 }

--- a/src/main/java/com/kw/readwith/dto/bookmark/BookmarkResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/bookmark/BookmarkResponseDTO.java
@@ -1,6 +1,7 @@
 package com.kw.readwith.dto.bookmark;
 
 import com.kw.readwith.dto.common.LocatorDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,17 +9,42 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@Schema(description = "북마크 응답")
 public class BookmarkResponseDTO {
+
+    @Schema(description = "북마크 ID", example = "101")
     private Long id;
+
+    @Schema(description = "도서 ID", example = "42")
     private Long bookId;
+
+    @Schema(description = "북마크 시작 위치")
     private LocatorDTO startLocator;
+
+    @Schema(description = "범위 북마크 종료 위치", nullable = true)
     private LocatorDTO endLocator;
+
+    @Schema(description = "startLocator를 텍스트 오프셋으로 환산한 값", example = "1500")
     private Integer startTxtOffset;
+
+    @Schema(description = "endLocator를 텍스트 오프셋으로 환산한 값", nullable = true)
     private Integer endTxtOffset;
+
+    @Schema(description = "북마크 계산에 사용한 locator 버전", example = "v2")
     private String locatorVersion;
+
+    @Schema(description = "북마크 색상(HEX)", example = "#FFD700", nullable = true)
     private String color;
+
+    @Schema(description = "북마크 메모", nullable = true)
     private String memo;
-    private boolean isRangeBookmark; // 범위 선택 여부
+
+    @Schema(description = "범위 북마크 여부", example = "true")
+    private boolean isRangeBookmark;
+
+    @Schema(description = "생성 시각")
     private LocalDateTime createdAt;
+
+    @Schema(description = "수정 시각")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/kw/readwith/dto/bookmark/CreateBookmarkRequestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/bookmark/CreateBookmarkRequestDTO.java
@@ -1,6 +1,7 @@
 package com.kw.readwith.dto.bookmark;
 
 import com.kw.readwith.dto.common.LocatorDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -11,19 +12,25 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@Schema(description = "북마크 생성 요청")
 public class CreateBookmarkRequestDTO {
 
     @NotNull(message = "책 ID는 필수입니다.")
+    @Schema(description = "북마크를 생성할 도서 ID", example = "42")
     private Long bookId;
 
     @NotNull(message = "시작 locator는 필수입니다.")
+    @Schema(description = "북마크 시작 위치")
     private LocatorDTO startLocator;
 
+    @Schema(description = "범위 북마크일 때의 종료 위치. 단일 포인트 북마크면 생략합니다.", nullable = true)
     private LocatorDTO endLocator;
 
     @Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "색상은 유효한 HEX 코드여야 합니다. (예: #ffd700)")
+    @Schema(description = "북마크 색상(HEX)", example = "#FFD700", nullable = true)
     private String color;
 
     @Size(max = 1000, message = "메모는 1000자를 초과할 수 없습니다.")
+    @Schema(description = "북마크 메모", example = "여기서 사건이 본격적으로 시작됨", nullable = true)
     private String memo;
 }

--- a/src/main/java/com/kw/readwith/dto/bookmark/UpdateBookmarkRequestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/bookmark/UpdateBookmarkRequestDTO.java
@@ -1,5 +1,6 @@
 package com.kw.readwith.dto.bookmark;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -9,11 +10,14 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@Schema(description = "북마크 수정 요청")
 public class UpdateBookmarkRequestDTO {
 
     @Pattern(regexp = "^#[0-9A-Fa-f]{6}$", message = "색상은 유효한 HEX 코드여야 합니다. (예: #ffd700)")
+    @Schema(description = "수정할 북마크 색상(HEX)", example = "#4A90E2", nullable = true)
     private String color;
 
     @Size(max = 1000, message = "메모는 1000자를 초과할 수 없습니다.")
+    @Schema(description = "수정할 북마크 메모", example = "다시 읽을 부분", nullable = true)
     private String memo;
 }

--- a/src/main/java/com/kw/readwith/dto/common/LocatorDTO.java
+++ b/src/main/java/com/kw/readwith/dto/common/LocatorDTO.java
@@ -1,5 +1,6 @@
 package com.kw.readwith.dto.common;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,9 +10,15 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "정규화 본문 안의 읽기 위치를 나타내는 좌표입니다.")
 public class LocatorDTO {
 
+    @Schema(description = "1-based 챕터 인덱스", example = "3")
     private Integer chapterIndex;
+
+    @Schema(description = "챕터 안의 블록 인덱스", example = "12")
     private Integer blockIndex;
+
+    @Schema(description = "블록 내부 code point offset", example = "45")
     private Integer offset;
 }

--- a/src/main/java/com/kw/readwith/dto/graph/EventInfoDTO.java
+++ b/src/main/java/com/kw/readwith/dto/graph/EventInfoDTO.java
@@ -2,22 +2,34 @@ package com.kw.readwith.dto.graph;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.kw.readwith.dto.common.LocatorDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "그래프가 가리키는 이벤트 정보")
 public class EventInfoDTO {
+
+    @Schema(description = "챕터 인덱스", example = "3")
     private Integer chapterIdx;
-    
+
     @JsonProperty("event_id")
+    @Schema(description = "챕터 내부 이벤트 인덱스", example = "4")
     private Integer eventIdx;
 
+    @Schema(description = "이벤트 식별자", example = "ch3-e4")
     private String eventId;
-    
+
+    @Schema(description = "이벤트 시작 locator", nullable = true)
     private LocatorDTO startLocator;
+
+    @Schema(description = "이벤트 종료 locator", nullable = true)
     private LocatorDTO endLocator;
 
+    @Schema(description = "이벤트 시작 텍스트 오프셋", nullable = true)
     private Integer startTxtOffset;
+
+    @Schema(description = "이벤트 종료 텍스트 오프셋", nullable = true)
     private Integer endTxtOffset;
 }

--- a/src/main/java/com/kw/readwith/dto/graph/FineGraphEdgeDTO.java
+++ b/src/main/java/com/kw/readwith/dto/graph/FineGraphEdgeDTO.java
@@ -1,6 +1,7 @@
 package com.kw.readwith.dto.graph;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,19 +9,26 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "이벤트 단위 관계 edge")
 public class FineGraphEdgeDTO {
+
     @JsonProperty("id1")
+    @Schema(description = "출발 인물 characterId", example = "7")
     private Long from;
-    
+
     @JsonProperty("id2")
+    @Schema(description = "도착 인물 characterId", example = "9")
     private Long to;
-    
+
     @JsonProperty("positivity")
+    @Schema(description = "감정 점수", example = "0.75")
     private Double sentimentScore;
-    
+
     @JsonProperty("count")
+    @Schema(description = "상호작용 횟수", example = "3")
     private Integer interactionCount;
-    
+
     @JsonProperty("relation")
+    @Schema(description = "관계 라벨 목록")
     private List<String> relationTags;
 }

--- a/src/main/java/com/kw/readwith/dto/graph/FineGraphResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/graph/FineGraphResponseDTO.java
@@ -1,6 +1,7 @@
 package com.kw.readwith.dto.graph;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,13 +9,18 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "이벤트 단위 그래프 응답")
 public class FineGraphResponseDTO {
+
     @JsonProperty("characters")
+    @Schema(description = "이벤트 시점에 등장하는 인물 노드 목록")
     private List<GraphNodeDTO> nodes;
-    
+
     @JsonProperty("relations")
+    @Schema(description = "이벤트 시점의 관계 edge 목록")
     private List<FineGraphEdgeDTO> edges;
-    
+
     @JsonProperty("event")
+    @Schema(description = "현재 그래프가 가리키는 이벤트 정보", nullable = true)
     private EventInfoDTO eventInfo;
 }

--- a/src/main/java/com/kw/readwith/dto/graph/GraphNodeDTO.java
+++ b/src/main/java/com/kw/readwith/dto/graph/GraphNodeDTO.java
@@ -1,6 +1,7 @@
 package com.kw.readwith.dto.graph;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,26 +9,36 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "그래프의 인물 노드")
 public class GraphNodeDTO {
+
+    @Schema(description = "책 내부 characterId", example = "7")
     private Long id;
-    
+
     @JsonProperty("common_name")
+    @Schema(description = "대표 이름")
     private String label;
-    
+
     @JsonProperty("main_character")
+    @Schema(description = "주요 인물 여부")
     private Boolean isMainCharacter;
-    
+
+    @Schema(description = "프로필 이미지 URL", nullable = true)
     private String profileImage;
+
+    @Schema(description = "인물 설명", nullable = true)
     private String description;
-    
+
     @JsonProperty("portrait_prompt")
+    @Schema(description = "프로필/프롬프트 텍스트", nullable = true)
     private String portraitPrompt;
-    
+
+    @Schema(description = "이름/별칭 목록")
     private List<String> names;
-    
-    // 노드 중요도 (크기)
+
+    @Schema(description = "현재 이벤트 또는 누적 시점에서의 node weight", nullable = true)
     private Float weight;
-    
-    // 참고용 카운트
+
+    @Schema(description = "누적 그래프에서 등장 횟수", nullable = true)
     private Integer count;
 }

--- a/src/main/java/com/kw/readwith/dto/graph/MacroGraphEdgeDTO.java
+++ b/src/main/java/com/kw/readwith/dto/graph/MacroGraphEdgeDTO.java
@@ -1,6 +1,7 @@
 package com.kw.readwith.dto.graph;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,19 +9,26 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "누적 그래프 관계 edge")
 public class MacroGraphEdgeDTO {
+
     @JsonProperty("id1")
+    @Schema(description = "출발 인물 characterId", example = "7")
     private Long from;
-    
+
     @JsonProperty("id2")
+    @Schema(description = "도착 인물 characterId", example = "9")
     private Long to;
-    
+
     @JsonProperty("positivity")
+    @Schema(description = "감정 점수", example = "0.75")
     private Double sentimentScore;
-    
+
     @JsonProperty("count")
+    @Schema(description = "상호작용 횟수", example = "12")
     private Integer interactionCount;
-    
+
     @JsonProperty("relation")
+    @Schema(description = "관계 라벨 목록")
     private List<String> relationTags;
 }

--- a/src/main/java/com/kw/readwith/dto/graph/MacroGraphResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/graph/MacroGraphResponseDTO.java
@@ -1,6 +1,7 @@
 package com.kw.readwith.dto.graph;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,12 +9,17 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "누적 그래프 응답")
 public class MacroGraphResponseDTO {
+
     @JsonProperty("characters")
+    @Schema(description = "누적 시점까지 등장한 인물 노드 목록")
     private List<GraphNodeDTO> nodes;
-    
+
     @JsonProperty("relations")
+    @Schema(description = "누적 시점까지 계산된 관계 edge 목록")
     private List<MacroGraphEdgeDTO> edges;
-    
-    private Integer userCurrentChapter; // 사용자 현재 진도 챕터 (스포일러 방지용)
+
+    @Schema(description = "현재 누적 기준 챕터 인덱스", example = "3")
+    private Integer userCurrentChapter;
 }

--- a/src/main/java/com/kw/readwith/dto/manifest/BookManifestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/manifest/BookManifestDTO.java
@@ -1,44 +1,62 @@
 package com.kw.readwith.dto.manifest;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "매니페스트 안의 도서 메타데이터")
 public class BookManifestDTO {
 
-    /** 책 식별자 */
+    @Schema(description = "도서 ID", example = "42")
     private Long id;
-    /** 리더에 표시할 제목 */
+
+    @Schema(description = "도서 제목")
     private String title;
-    /** 리더에 표시할 저자 */
+
+    @Schema(description = "저자명")
     private String author;
-    /** 책 언어 코드 */
+
+    @Schema(description = "언어 코드", example = "en")
     private String language;
-    /** 기본 제공 책인지 여부 */
+
+    @Schema(description = "기본 제공 도서 여부")
     private Boolean isDefault;
-    /** 요약 자료 준비 여부 */
+
+    @Schema(description = "요약 준비 완료 여부")
     private Boolean summary;
-    /** 리더용 커버 이미지 */
+
+    @Schema(description = "표지 이미지 URL", nullable = true)
     private String coverImgUrl;
-    /** 책 전체 요약 경로 */
+
+    @Schema(description = "전체 요약 URL", nullable = true)
     private String summaryUrl;
-    /** 원본 EPUB 경로 */
+
+    @Schema(description = "원본 EPUB 저장 경로", nullable = true)
     private String epubPath;
-    /** 본문 읽기 가능 상태 */
+
+    @Schema(description = "정규화 상태", example = "READY")
     private String normalizationStatus;
-    /** AI 분석 자료 상태 */
+
+    @Schema(description = "분석 상태", example = "READY")
     private String analysisStatus;
-    /** 현재 활성 정규화 규칙 버전 */
+
+    @Schema(description = "정규화 규칙 버전", nullable = true)
     private String ruleVersion;
-    /** 현재 활성 locator 버전 */
+
+    @Schema(description = "locator 버전", nullable = true)
     private String locatorVersion;
-    /** 현재 활성 정규화 run id */
+
+    @Schema(description = "활성 정규화 run id", nullable = true)
     private String normalizationRunId;
-    /** 현재 엔진 기준 버전 상태 */
+
+    @Schema(description = "정규화 버전 비교 상태", nullable = true)
     private String normalizationVersionStatus;
-    /** 재정규화 필요 여부 */
+
+    @Schema(description = "재정규화 필요 여부")
     private Boolean needsRenormalization;
-    /** 활성 정규화 산출물 루트 경로 */
+
+    @Schema(description = "정규화 산출물 루트 경로", nullable = true)
     private String normalizedArtifactPath;
 }

--- a/src/main/java/com/kw/readwith/dto/manifest/ChapterLengthDTO.java
+++ b/src/main/java/com/kw/readwith/dto/manifest/ChapterLengthDTO.java
@@ -1,23 +1,21 @@
 package com.kw.readwith.dto.manifest;
 
-import lombok.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-/**
- * 챕터별 글자수 DTO
- */
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "한 챕터의 길이 정보")
 public class ChapterLengthDTO {
-    
-    /**
-     * 챕터 인덱스
-     */
+
+    @Schema(description = "챕터 인덱스", example = "3")
     private Integer chapterIdx;
-    
-    /**
-     * 해당 챕터의 글자수
-     */
+
+    @Schema(description = "해당 챕터 길이", example = "4210")
     private Integer length;
 }

--- a/src/main/java/com/kw/readwith/dto/manifest/ChapterManifestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/manifest/ChapterManifestDTO.java
@@ -1,5 +1,6 @@
 package com.kw.readwith.dto.manifest;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,75 +8,48 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "매니페스트 안의 챕터 정보")
 public class ChapterManifestDTO {
-    
-    /**
-     * 챕터 인덱스 (1-based)
-     */
+
+    @Schema(description = "챕터 인덱스(1-based)", example = "3")
     private Integer idx;
-    
-    /**
-     * 챕터 제목
-     */
+
+    @Schema(description = "챕터 제목")
     private String title;
 
-    /**
-     * EPUB spine href
-     */
+    @Schema(description = "EPUB spine href", nullable = true)
     private String spineHref;
 
-    /**
-     * 문단 수
-     */
+    @Schema(description = "문단 수", nullable = true)
     private Integer paragraphCount;
 
-    /**
-     * 문단 시작 오프셋 JSON
-     */
+    @Schema(description = "문단 시작 위치 배열(JSON 문자열)", nullable = true)
     private String paragraphStartsJson;
 
-    /**
-     * 문단 길이 JSON
-     */
+    @Schema(description = "문단 길이 배열(JSON 문자열)", nullable = true)
     private String paragraphLengthsJson;
 
-    /**
-     * 챕터 전체 code point 수
-     */
+    @Schema(description = "챕터 전체 code point 수", nullable = true)
     private Integer totalCodePoints;
-    
-    /**
-     * 시작 위치
-     */
+
+    @Schema(description = "본문 전체 기준 시작 위치", nullable = true)
     private Integer startPos;
-    
-    /**
-     * 종료 위치
-     */
+
+    @Schema(description = "본문 전체 기준 종료 위치", nullable = true)
     private Integer endPos;
-    
-    /**
-     * 원본 텍스트 (일부)
-     */
+
+    @Schema(description = "챕터 원문 일부", nullable = true)
     private String rawText;
-    
-    /**
-     * 챕터 요약
-     */
+
+    @Schema(description = "챕터 요약 텍스트", nullable = true)
     private String summaryText;
-    
-    /**
-     * 요약 업로드 URL
-     */
+
+    @Schema(description = "요약 업로드 URL", nullable = true)
     private String summaryUploadUrl;
-    
-    /**
-     * POV 요약 캐시 여부
-     */
+
+    @Schema(description = "POV summary 캐시 여부")
     private Boolean povSummariesCached;
-    
-    /**
-     * 이벤트 목록
-     */
+
+    @Schema(description = "챕터에 속한 이벤트 목록")
     private List<EventManifestDTO> events;
 }

--- a/src/main/java/com/kw/readwith/dto/manifest/CharacterManifestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/manifest/CharacterManifestDTO.java
@@ -1,49 +1,35 @@
 package com.kw.readwith.dto.manifest;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "매니페스트 안의 인물 정보")
 public class CharacterManifestDTO {
-    
-    /**
-     * 인물 ID (책 내 고유 ID)
-     */
+
+    @Schema(description = "책 내부 characterId", example = "7")
     private Long id;
-    
-    /**
-     * 인물 이름
-     */
+
+    @Schema(description = "대표 이름")
     private String name;
-    
-    /**
-     * 인물이 불리는 다른 이름들
-     */
+
+    @Schema(description = "이름/별칭 묶음 문자열", nullable = true)
     private String names;
-    
-    /**
-     * 프로필 이미지 URL
-     */
+
+    @Schema(description = "프로필 이미지 URL", nullable = true)
     private String profileImage;
-    
-    /**
-     * 주요 인물 여부
-     */
+
+    @Schema(description = "주요 인물 여부")
     private Boolean isMainCharacter;
-    
-    /**
-     * 첫 등장 챕터
-     */
+
+    @Schema(description = "처음 등장한 챕터 인덱스", nullable = true)
     private Integer firstChapterIdx;
-    
-    /**
-     * 성격/인물 설명
-     */
+
+    @Schema(description = "인물 설명", nullable = true)
     private String personalityText;
-    
-    /**
-     * 프로필 묘사
-     */
+
+    @Schema(description = "이미지 생성용 프롬프트 또는 프로필 텍스트", nullable = true)
     private String profileText;
 }

--- a/src/main/java/com/kw/readwith/dto/manifest/EventManifestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/manifest/EventManifestDTO.java
@@ -1,45 +1,33 @@
 package com.kw.readwith.dto.manifest;
 
 import com.kw.readwith.dto.common.LocatorDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "매니페스트 안의 이벤트 정보")
 public class EventManifestDTO {
-    
-    /**
-     * 이벤트 인덱스 (챕터 내)
-     */
+
+    @Schema(description = "챕터 내부 이벤트 인덱스", example = "4")
     private Integer idx;
 
-    /**
-     * 이벤트 표준 식별자
-     */
+    @Schema(description = "이벤트 식별자", example = "ch3-e4")
     private String eventId;
-    
-    /**
-     * 시작 locator
-     */
+
+    @Schema(description = "이벤트 시작 locator", nullable = true)
     private LocatorDTO startLocator;
-    
-    /**
-     * 종료 locator
-     */
+
+    @Schema(description = "이벤트 종료 locator", nullable = true)
     private LocatorDTO endLocator;
 
-    /**
-     * 시작 텍스트 오프셋
-     */
+    @Schema(description = "이벤트 시작 텍스트 오프셋", nullable = true)
     private Integer startTxtOffset;
 
-    /**
-     * 종료 텍스트 오프셋
-     */
+    @Schema(description = "이벤트 종료 텍스트 오프셋", nullable = true)
     private Integer endTxtOffset;
-    
-    /**
-     * 원본 텍스트
-     */
+
+    @Schema(description = "이벤트 원문 일부", nullable = true)
     private String rawText;
 }

--- a/src/main/java/com/kw/readwith/dto/manifest/ManifestResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/manifest/ManifestResponseDTO.java
@@ -1,5 +1,6 @@
 package com.kw.readwith.dto.manifest;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,30 +8,21 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "리더 초기 진입에 필요한 전체 매니페스트 응답")
 public class ManifestResponseDTO {
-    
-    /**
-     * 책 기본 정보
-     */
+
+    @Schema(description = "도서 기본 메타데이터")
     private BookManifestDTO book;
-    
-    /**
-     * 챕터 목록 (이벤트 포함)
-     */
+
+    @Schema(description = "챕터 목록과 각 챕터에 속한 이벤트 목록")
     private List<ChapterManifestDTO> chapters;
-    
-    /**
-     * 인물 목록
-     */
+
+    @Schema(description = "분석 완료 시 제공되는 인물 목록")
     private List<CharacterManifestDTO> characters;
 
-    /**
-     * 리더가 직접 참조하는 정규화 산출물
-     */
+    @Schema(description = "리더가 직접 참조하는 정규화 산출물 정보")
     private ReaderArtifactsDTO readerArtifacts;
-    
-    /**
-     * Progress API 메타데이터
-     */
+
+    @Schema(description = "진도 계산에 필요한 메타데이터")
     private ProgressMetadataDTO progressMetadata;
 }

--- a/src/main/java/com/kw/readwith/dto/manifest/ProgressMetadataDTO.java
+++ b/src/main/java/com/kw/readwith/dto/manifest/ProgressMetadataDTO.java
@@ -1,31 +1,26 @@
 package com.kw.readwith.dto.manifest;
 
-import lombok.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-/**
- * Progress API 메타데이터 DTO
- * Manifest API에서 Progress 계산에 필요한 메타데이터를 제공
- */
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "진도 계산에 필요한 챕터 길이 메타데이터")
 public class ProgressMetadataDTO {
-    
-    /**
-     * 최대 챕터 수
-     */
+
+    @Schema(description = "가장 마지막 챕터 인덱스", example = "30")
     private Integer maxChapter;
-    
-    /**
-     * 각 챕터별 글자수
-     */
+
+    @Schema(description = "챕터별 길이 목록")
     private List<ChapterLengthDTO> chapterLengths;
-    
-    /**
-     * 책 전체 글자수
-     */
+
+    @Schema(description = "도서 전체 길이", example = "125430")
     private Integer totalLength;
 }

--- a/src/main/java/com/kw/readwith/dto/manifest/ReaderArtifactsDTO.java
+++ b/src/main/java/com/kw/readwith/dto/manifest/ReaderArtifactsDTO.java
@@ -1,5 +1,6 @@
 package com.kw.readwith.dto.manifest;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,8 +8,12 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "리더가 직접 참조하는 정규화 산출물 정보")
 public class ReaderArtifactsDTO {
 
+    @Schema(description = "combined.xhtml 공개 경로", nullable = true)
     private String combinedXhtmlPath;
+
+    @Schema(description = "리더에서 사용할 data-* 속성 목록")
     private List<String> dataAttributes;
 }

--- a/src/main/java/com/kw/readwith/dto/progress/ProgressResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/progress/ProgressResponseDTO.java
@@ -2,6 +2,7 @@ package com.kw.readwith.dto.progress;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.kw.readwith.dto.common.LocatorDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,23 +14,32 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "독서 진도 응답")
 public class ProgressResponseDTO {
 
+    @Schema(description = "도서 ID", example = "42")
     private Long bookId;
 
+    @Schema(description = "현재 저장된 시작 위치")
     private LocatorDTO startLocator;
 
+    @Schema(description = "범위 진도를 지원할 때 사용할 종료 위치. 현재는 null입니다.", nullable = true)
     private LocatorDTO endLocator;
 
+    @Schema(description = "startLocator를 텍스트 오프셋으로 환산한 값", example = "1280", nullable = true)
     private Integer startTxtOffset;
 
+    @Schema(description = "endLocator를 텍스트 오프셋으로 환산한 값. 현재는 null입니다.", nullable = true)
     private Integer endTxtOffset;
 
+    @Schema(description = "현재 도서에 적용된 locator 버전", example = "v2")
     private String locatorVersion;
 
+    @Schema(description = "마지막 저장 시각")
     private LocalDateTime updatedAt;
 
     @JsonProperty("locator")
+    @Schema(description = "legacy 응답 필드 alias입니다. 값은 startLocator와 같습니다.", deprecated = true)
     public LocatorDTO getLocator() {
         return startLocator;
     }

--- a/src/main/java/com/kw/readwith/dto/progress/SaveProgressRequestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/progress/SaveProgressRequestDTO.java
@@ -2,6 +2,7 @@ package com.kw.readwith.dto.progress;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.kw.readwith.dto.common.LocatorDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,15 +13,19 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "독서 진도 저장 요청")
 public class SaveProgressRequestDTO {
 
     @NotNull(message = "bookId is required.")
+    @Schema(description = "진도를 저장할 도서 ID", example = "42")
     private Long bookId;
 
     @JsonAlias("locator")
     @NotNull(message = "startLocator is required.")
+    @Schema(description = "현재 읽기 위치. 신규 클라이언트는 startLocator를 사용합니다.")
     private LocatorDTO startLocator;
 
+    @Schema(name = "locator", description = "legacy 요청 필드 alias입니다. 신규 클라이언트는 startLocator를 사용하세요.", deprecated = true)
     public LocatorDTO getLocator() {
         return startLocator;
     }

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -332,13 +332,12 @@ public class AdminService {
                     throw new GeneralException(ErrorStatus.CHAPTER_ALREADY_SUMMARIZED, "Chapter summary already exists: " + chapterIdx);
                 }
 
-                if (uploadDTO.getItems() != null) {
-                    List<CharacterPovSummary> newSummariesFromFile = uploadDTO.getItems().stream()
-                            .map(this::validateSummaryItem)
-                            .map(item -> buildCharacterPovSummary(chapter, item))
-                            .collect(Collectors.toList());
-                    allNewSummaries.addAll(newSummariesFromFile);
-                }
+                List<SummaryItemDTO> summaryItems = requireSummaryItems(uploadDTO);
+                List<CharacterPovSummary> newSummariesFromFile = summaryItems.stream()
+                        .map(this::validateSummaryItem)
+                        .map(item -> buildCharacterPovSummary(chapter, item))
+                        .collect(Collectors.toList());
+                allNewSummaries.addAll(newSummariesFromFile);
 
                 chapter.markAsSummarized();
             }
@@ -435,6 +434,13 @@ public class AdminService {
         requireText(item.getCharacterId(), "summary.characterId");
         requireText(item.getSummary(), "summary.summary");
         return item;
+    }
+
+    private List<SummaryItemDTO> requireSummaryItems(SummaryUploadDTO uploadDTO) {
+        if (uploadDTO.getItems() == null || uploadDTO.getItems().isEmpty()) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "summary.items must contain at least one item.");
+        }
+        return uploadDTO.getItems();
     }
 
     private CharacterPovSummary buildCharacterPovSummary(Chapter chapter, SummaryItemDTO item) {

--- a/src/main/java/com/kw/readwith/service/BookAnalysisStatusService.java
+++ b/src/main/java/com/kw/readwith/service/BookAnalysisStatusService.java
@@ -5,6 +5,7 @@ import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.repository.BookRepository;
 import com.kw.readwith.repository.ChapterRepository;
 import com.kw.readwith.repository.CharacterRepository;
+import com.kw.readwith.repository.CharacterPovSummaryRepository;
 import com.kw.readwith.repository.EventCharacterStatRepository;
 import com.kw.readwith.repository.EventRelationshipEdgeRepository;
 import com.kw.readwith.repository.EventRepository;
@@ -22,6 +23,7 @@ public class BookAnalysisStatusService {
     private final BookRepository bookRepository;
     private final ChapterRepository chapterRepository;
     private final CharacterRepository characterRepository;
+    private final CharacterPovSummaryRepository characterPovSummaryRepository;
     private final EventRepository eventRepository;
     private final EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
     private final EventCharacterStatRepository eventCharacterStatRepository;
@@ -70,7 +72,8 @@ public class BookAnalysisStatusService {
         if (chapters.isEmpty()) {
             return false;
         }
-        if (chapters.stream().anyMatch(chapter -> !chapter.isPovSummariesCached())) {
+        if (chapters.stream().anyMatch(chapter -> !chapter.isPovSummariesCached()
+                || !characterPovSummaryRepository.existsByChapter(chapter))) {
             return false;
         }
 

--- a/src/main/java/com/kw/readwith/service/CharacterPovSummaryService.java
+++ b/src/main/java/com/kw/readwith/service/CharacterPovSummaryService.java
@@ -56,7 +56,7 @@ public class CharacterPovSummaryService {
                 .map(summary -> new CharacterPovSummaryDTO(
                         summary.getId(),
                         summary.getChapter().getId(),
-                        summary.getCharacter().getId(),
+                        summary.getCharacter().getCharacterId(),
                         summary.getSummaryText()))
                 .toList();
     }
@@ -75,7 +75,7 @@ public class CharacterPovSummaryService {
 
         List<ChapterPovSummaryDTO> povSummaryDTOs = characterPovSummaryRepository.findByBookIdAndChapterIdx(bookId, chapterIdx).stream()
                 .map(summary -> new ChapterPovSummaryDTO(
-                        summary.getCharacter().getId(),
+                        summary.getCharacter().getCharacterId(),
                         summary.getCharacter().getName(),
                         summary.getSummaryText(),
                         summary.getCharacter().isMainCharacter()

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -6,9 +6,16 @@ import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.service.AdminService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -16,90 +23,103 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping({"/api/admin", "/api/v2/admin"})
+@Tag(name = "관리자 업로드", description = "AI/관리자 산출물을 책에 적재하는 업로드 API입니다.")
 public class AdminController {
 
     private final AdminService adminService;
 
-    @Operation(summary = "인물 정보 업로드 API", description = "특정 책에 대한 인물 정보가 담긴 JSON 파일을 업로드합니다.")
+    @Operation(
+            summary = "인물 업로드",
+            description = "`book_characters.json` 파일을 업로드합니다. payload 루트는 `items`이며, 각 인물은 책 내부 `characterId`를 가져야 합니다."
+    )
     @PostMapping(value = "/books/{bookId}/characters", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadCharacters(
-            @Parameter(description = "인물 정보를 추가할 책의 ID") @PathVariable Long bookId,
-            @Parameter(description = "인물 정보가 담긴 JSON 파일") @RequestParam("file") MultipartFile file) {
+            @Parameter(description = "업로드 대상 도서 ID", required = true) @PathVariable Long bookId,
+            @Parameter(description = "인물 JSON 파일", required = true) @RequestParam("file") MultipartFile file) {
         adminService.uploadCharacters(bookId, file);
         return ApiResponse.onSuccess("Characters have been successfully uploaded.");
     }
 
-    @Operation(summary = "인물 정보 삭제 API", description = "특정 책에 대한 모든 인물 정보를 삭제합니다.")
+    @Operation(summary = "인물 전체 삭제", description = "특정 책에 적재된 인물 정보를 모두 삭제합니다.")
     @DeleteMapping("/books/{bookId}/characters")
     public ApiResponse<String> deleteCharacters(
-            @Parameter(description = "인물 정보를 삭제할 책의 ID") @PathVariable Long bookId) {
+            @Parameter(description = "삭제 대상 도서 ID", required = true) @PathVariable Long bookId) {
         adminService.deleteCharacters(bookId);
         return ApiResponse.onSuccess("Characters for the book have been successfully deleted.");
     }
 
-    @Operation(summary = "이벤트 정보 다중 업로드 API", description = "특정 책에 대한 챕터별 이벤트 정보가 담긴 JSON 파일들을 업로드합니다.")
+    @Operation(
+            summary = "이벤트 업로드",
+            description = "`chapter_{n}_events.json` 파일들을 업로드합니다. `chapterIndex`, `items`, `eventId`, `startTxtOffset`, `endTxtOffset`, `eventText` 구조를 사용합니다."
+    )
     @PostMapping(value = "/books/{bookId}/events", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadEvents(
-            @Parameter(description = "이벤트를 추가할 책의 ID") @PathVariable Long bookId,
-            @Parameter(description = "챕터별 이벤트 정보 파일 목록 (파일명: chapter<번호>_events.json)") @RequestParam("files") List<MultipartFile> files) {
+            @Parameter(description = "업로드 대상 도서 ID", required = true) @PathVariable Long bookId,
+            @Parameter(description = "이벤트 JSON 파일 목록", required = true) @RequestParam("files") List<MultipartFile> files) {
         adminService.uploadEvents(bookId, files);
         return ApiResponse.onSuccess("Events have been successfully uploaded.");
     }
 
-    @Operation(summary = "이벤트 정보 삭제 API", description = "특정 챕터에 대한 모든 이벤트 정보를 삭제합니다.")
+    @Operation(summary = "챕터 이벤트 전체 삭제", description = "특정 챕터에 적재된 이벤트를 모두 삭제합니다.")
     @DeleteMapping("/books/{bookId}/chapters/{chapterIdx}/events")
     public ApiResponse<String> deleteEvents(
-            @Parameter(description = "이벤트 정보를 삭제할 책의 ID") @PathVariable Long bookId,
-            @Parameter(description = "이벤트 정보를 삭제할 챕터의 순서(index)") @PathVariable Integer chapterIdx) {
+            @Parameter(description = "삭제 대상 도서 ID", required = true) @PathVariable Long bookId,
+            @Parameter(description = "삭제할 챕터 인덱스(1-based)", required = true) @PathVariable Integer chapterIdx) {
         adminService.deleteEvents(bookId, chapterIdx);
         return ApiResponse.onSuccess("Events for the chapter have been successfully deleted.");
     }
 
-    @Operation(summary = "관계 정보 다중 업로드 API", description = "특정 책에 대한 관계 정보(JSON) 파일들을 업로드합니다. 파일명 규칙: chapter<번호>_relationships_<언어>_event_<번호>.json")
+    @Operation(
+            summary = "관계 업로드",
+            description = "`chapter_{n}_relationships_event_{m}.json` 파일들을 업로드합니다. payload 루트는 `chapterIndex`, `eventId`, `items`, `nodeWeights`를 사용합니다."
+    )
     @PostMapping(value = "/books/{bookId}/relationships", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadRelationships(
-            @Parameter(description = "관계 정보를 추가할 책의 ID") @PathVariable Long bookId,
-            @Parameter(description = "관계 정보가 담긴 JSON 파일 목록") @RequestParam("files") List<MultipartFile> files) {
+            @Parameter(description = "업로드 대상 도서 ID", required = true) @PathVariable Long bookId,
+            @Parameter(description = "관계 JSON 파일 목록", required = true) @RequestParam("files") List<MultipartFile> files) {
         adminService.uploadRelationships(bookId, files);
         return ApiResponse.onSuccess("Relationships for the book have been successfully uploaded.");
     }
 
-    @Operation(summary = "관계 정보 삭제 API", description = "특정 이벤트에 대한 모든 관계 정보(엣지)를 삭제합니다.")
+    @Operation(summary = "이벤트 관계 삭제", description = "특정 이벤트에 적재된 관계 edge와 node weight를 함께 삭제합니다.")
     @DeleteMapping("/books/{bookId}/chapters/{chapterIdx}/events/{eventIdx}/relationships")
     public ApiResponse<String> deleteRelationships(
-            @Parameter(description = "관계 정보를 삭제할 책의 ID") @PathVariable Long bookId,
-            @Parameter(description = "관계 정보를 삭제할 챕터의 순서(index)") @PathVariable Integer chapterIdx,
-            @Parameter(description = "관계 정보를 삭제할 이벤트의 순서(index)") @PathVariable Integer eventIdx) {
+            @Parameter(description = "삭제 대상 도서 ID", required = true) @PathVariable Long bookId,
+            @Parameter(description = "이벤트가 속한 챕터 인덱스(1-based)", required = true) @PathVariable Integer chapterIdx,
+            @Parameter(description = "삭제할 이벤트 인덱스", required = true) @PathVariable Integer eventIdx) {
         adminService.deleteRelationships(bookId, chapterIdx, eventIdx);
         return ApiResponse.onSuccess("Relationships have been successfully deleted.");
     }
 
-    @Operation(summary = "챕터 요약본 다중 업로드 API", description = "특정 책에 대한 챕터별 요약 정보가 담긴 JSON 파일들을 업로드합니다.")
+    @Operation(
+            summary = "챕터 요약 업로드",
+            description = "`chapter_{n}_summaries_Ko.json` 파일들을 업로드합니다. 현재는 `language=ko` 요약만 공식 입력으로 받습니다."
+    )
     @PostMapping(value = "/books/{bookId}/summary", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadChapterSummaries(
-            @Parameter(description = "요약본을 추가할 책의 ID") @PathVariable Long bookId,
-            @Parameter(description = "인물별 요약 정보 파일 목록 (파일명: chapter<번호>_perspective_summaries.json)") @RequestParam("files") List<MultipartFile> files) {
+            @Parameter(description = "업로드 대상 도서 ID", required = true) @PathVariable Long bookId,
+            @Parameter(description = "챕터 요약 JSON 파일 목록", required = true) @RequestParam("files") List<MultipartFile> files) {
         adminService.uploadChapterSummaries(bookId, files);
         return ApiResponse.onSuccess("Chapter summaries have been successfully uploaded.");
     }
 
-    @Operation(summary = "챕터 요약본 삭제 API", description = "특정 챕터에 대한 요약본 정보를 삭제합니다.")
+    @Operation(summary = "챕터 요약 삭제", description = "특정 챕터에 적재된 POV summary를 삭제합니다.")
     @DeleteMapping("/books/{bookId}/chapters/{chapterIdx}/summary")
     public ApiResponse<String> deleteChapterSummary(
-            @Parameter(description = "요약본을 삭제할 책의 ID") @PathVariable Long bookId,
-            @Parameter(description = "요약본을 삭제할 챕터의 순서(index)") @PathVariable Integer chapterIdx) {
+            @Parameter(description = "삭제 대상 도서 ID", required = true) @PathVariable Long bookId,
+            @Parameter(description = "삭제할 챕터 인덱스(1-based)", required = true) @PathVariable Integer chapterIdx) {
         adminService.deleteChapterSummary(bookId, chapterIdx);
         return ApiResponse.onSuccess("Chapter summary has been successfully deleted.");
     }
 
-    @Operation(summary = "미요약 도서 목록 조회 API", description = "전체 책 중에서 요약이 완료되지 않은 책들의 목록을 조회합니다.")
+    @Operation(summary = "미요약 도서 목록 조회", description = "legacy summary 플래그 기준으로 아직 요약이 완료되지 않은 책을 조회합니다.")
     @GetMapping("/books/unsummarized")
     public ApiResponse<List<BookSummaryDTO>> getUnsummarizedBooks() {
         List<BookSummaryDTO> response = adminService.getUnsummarizedBooks();
         return ApiResponse.onSuccess(response);
     }
 
-    @Operation(summary = "미요약 챕터 목록 조회 API", description = "전체 챕터 중에서 요약이 필요한 챕터들의 목록을 조회합니다.")
+    @Operation(summary = "미요약 챕터 목록 조회", description = "POV summary가 아직 캐시되지 않은 챕터 목록을 조회합니다.")
     @GetMapping("/chapters/unsummarized")
     public ApiResponse<List<UnsummarizedItemDTO>> getUnsummarizedChapters() {
         List<UnsummarizedItemDTO> response = adminService.getUnsummarizedChapters();
@@ -107,16 +127,16 @@ public class AdminController {
     }
 
     @Operation(
-        summary = "캐릭터 이미지 재생성 API", 
-        description = "특정 캐릭터의 프로필 이미지를 재생성합니다. 이미지 생성에 실패했거나 품질이 좋지 않은 경우 사용합니다.",
-        security = {}
+            summary = "캐릭터 이미지 재생성",
+            description = "특정 캐릭터의 프로필 이미지를 다시 생성합니다. 기존 이미지 품질이 낮거나 생성에 실패했을 때 사용합니다.",
+            security = {}
     )
     @PostMapping(
-        value = "/characters/{characterId}/regenerate-image",
-        consumes = MediaType.ALL_VALUE  // body 없는 POST 요청 허용
+            value = "/characters/{characterId}/regenerate-image",
+            consumes = MediaType.ALL_VALUE
     )
     public ApiResponse<String> regenerateCharacterImage(
-            @Parameter(description = "이미지를 재생성할 캐릭터의 ID") @PathVariable Long characterId) {
+            @Parameter(description = "이미지를 다시 생성할 캐릭터 DB ID", required = true) @PathVariable Long characterId) {
         adminService.regenerateCharacterImage(characterId);
         return ApiResponse.onSuccess("Character image regeneration has been started.");
     }

--- a/src/main/java/com/kw/readwith/web/controller/AuthController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AuthController.java
@@ -10,29 +10,34 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-@Tag(name = "Authentication", description = "인증 관련 API")
+@Tag(name = "인증", description = "토큰 관리와 현재 사용자 계정 정보를 다루는 API입니다.")
 @Slf4j
 public class AuthController {
 
     private final AuthService authService;
 
     @PostMapping("/refresh")
-    @Operation(summary = "토큰 갱신", description = "Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.")
+    @Operation(summary = "액세스 토큰 재발급", description = "Refresh Token으로 새로운 Access Token을 발급합니다.")
     public ApiResponse<TokenResponseDTO> refreshToken(
-            @Parameter(description = "Refresh Token", required = true)
+            @Parameter(description = "요청 헤더 `Refresh-Token`에 넣어 보낼 refresh token", required = true)
             @RequestHeader("Refresh-Token") String refreshToken) {
-        
+
         TokenResponseDTO response = authService.refreshToken(refreshToken);
         return ApiResponse.onSuccess(response);
     }
 
     @PostMapping("/logout")
-    @Operation(summary = "로그아웃", description = "사용자를 로그아웃하고 Refresh Token을 무효화합니다.")
+    @Operation(summary = "로그아웃", description = "현재 사용자의 refresh token을 무효화합니다.")
     public ApiResponse<String> logout(Authentication authentication) {
         Long userId = (Long) authentication.getPrincipal();
         authService.logout(userId);
@@ -40,7 +45,7 @@ public class AuthController {
     }
 
     @GetMapping("/me")
-    @Operation(summary = "사용자 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.")
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.")
     public ApiResponse<UserInfoResponseDTO> getUserInfo(Authentication authentication) {
         Long userId = (Long) authentication.getPrincipal();
         UserInfoResponseDTO response = authService.getUserInfo(userId);
@@ -48,7 +53,7 @@ public class AuthController {
     }
 
     @DeleteMapping("/account")
-    @Operation(summary = "회원 탈퇴", description = "사용자 계정을 삭제합니다.")
+    @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자의 계정을 삭제합니다.")
     public ApiResponse<String> deleteAccount(Authentication authentication) {
         Long userId = (Long) authentication.getPrincipal();
         authService.deleteAccount(userId);
@@ -56,7 +61,7 @@ public class AuthController {
     }
 
     @GetMapping("/status")
-    @Operation(summary = "인증 상태 확인", description = "현재 사용자의 인증 상태를 확인합니다.")
+    @Operation(summary = "인증 상태 확인", description = "현재 요청의 인증 여부를 간단히 확인합니다.")
     public ApiResponse<String> checkAuthStatus(Authentication authentication) {
         if (authentication != null && authentication.isAuthenticated()) {
             Long userId = (Long) authentication.getPrincipal();

--- a/src/main/java/com/kw/readwith/web/controller/BookController.java
+++ b/src/main/java/com/kw/readwith/web/controller/BookController.java
@@ -6,21 +6,28 @@ import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.dto.book.BookDetailDTO;
 import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.service.BookService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping({"/api/books", "/api/v2/books"})
 @RequiredArgsConstructor
-@Tag(name = "Books", description = "도서 관련 API")
+@Tag(name = "도서", description = "도서 목록 조회, 상세 조회, EPUB 업로드 API입니다.")
 public class BookController {
 
     private final BookService bookService;
@@ -47,13 +54,19 @@ public class BookController {
         throw new GeneralException(ErrorStatus._UNAUTHORIZED);
     }
 
-    // 도서 목록 조회
     @GetMapping
-    @Operation(summary = "도서 목록 조회", description = "검색/필터/정렬 파라미터를 이용해 도서 목록을 반환합니다.")
+    @Operation(
+            summary = "도서 목록 조회",
+            description = "현재 노출 가능한 도서 목록을 조회합니다. 정규화가 완료된 도서만 반환합니다."
+    )
     public ApiResponse<List<BookSummaryDTO>> getBooks(
+            @Parameter(description = "도서 제목 또는 저자 검색어", example = "셜록")
             @RequestParam(required = false) String q,
+            @Parameter(description = "언어 코드 필터", example = "ko")
             @RequestParam(required = false) String language,
+            @Parameter(description = "정렬 기준. `updatedAt` 또는 `title`을 사용합니다.", example = "updatedAt")
             @RequestParam(defaultValue = "updatedAt") String sort,
+            @Parameter(description = "true이면 즐겨찾기한 도서만 반환합니다.", example = "false")
             @RequestParam(required = false) Boolean favorite
     ) {
         Long userId = getCurrentUserIdOrNull();
@@ -61,22 +74,33 @@ public class BookController {
         return ApiResponse.onSuccess(response);
     }
 
-    // 단일 도서 조회
     @GetMapping("/{bookId}")
-    @Operation(summary = "단일 도서 조회", description = "도서 ID로 단일 도서를 조회합니다.")
-    public ApiResponse<BookDetailDTO> getBook(@PathVariable Long bookId) {
+    @Operation(
+            summary = "도서 상세 조회",
+            description = "도서 상세 메타데이터를 조회합니다. 정규화가 완료된 도서만 조회할 수 있습니다."
+    )
+    public ApiResponse<BookDetailDTO> getBook(
+            @Parameter(description = "조회할 도서 ID", required = true, example = "42")
+            @PathVariable Long bookId) {
         Long userId = getCurrentUserIdOrNull();
         BookDetailDTO response = bookService.getBook(bookId, userId);
         return ApiResponse.onSuccess(response);
     }
 
-    // 도서 업로드
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "도서 업로드", description = "EPUB 파일을 업로드하여 도서를 등록합니다.")
-    public ApiResponse<BookDetailDTO> uploadBook(@RequestPart("file") MultipartFile file,
-                                                    @RequestPart(value = "title", required = false) String title,
-                                                    @RequestPart(value = "author", required = false) String author,
-                                                    @RequestPart(value = "language", required = false) String language) {
+    @Operation(
+            summary = "EPUB 도서 업로드",
+            description = "EPUB 파일을 업로드해 도서를 등록합니다. 제목과 저자는 EPUB 메타데이터를 기준으로 저장하며, 업로드 후 비동기 정규화 작업이 시작됩니다."
+    )
+    public ApiResponse<BookDetailDTO> uploadBook(
+            @Parameter(description = "업로드할 EPUB 파일", required = true)
+            @RequestPart("file") MultipartFile file,
+            @Parameter(description = "예비 제목 값입니다. EPUB 메타데이터에 제목이 없을 때만 사용합니다.", example = "테스트 책")
+            @RequestPart(value = "title", required = false) String title,
+            @Parameter(description = "예비 저자 값입니다. EPUB 메타데이터에 저자가 없을 때만 사용합니다.", example = "Arthur Conan Doyle")
+            @RequestPart(value = "author", required = false) String author,
+            @Parameter(description = "예비 언어 코드입니다. EPUB 메타데이터에 언어가 없을 때만 사용합니다.", example = "en")
+            @RequestPart(value = "language", required = false) String language) {
         Long userId = requireCurrentUserId();
         BookDetailDTO response = bookService.uploadBook(userId, file, title, author, language);
         return ApiResponse.onSuccess(response);

--- a/src/main/java/com/kw/readwith/web/controller/BookController.java
+++ b/src/main/java/com/kw/readwith/web/controller/BookController.java
@@ -18,7 +18,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
-@RequestMapping("/api/books")
+@RequestMapping({"/api/books", "/api/v2/books"})
 @RequiredArgsConstructor
 @Tag(name = "Books", description = "도서 관련 API")
 public class BookController {

--- a/src/main/java/com/kw/readwith/web/controller/BookmarkController.java
+++ b/src/main/java/com/kw/readwith/web/controller/BookmarkController.java
@@ -14,14 +14,22 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
 @RequestMapping({"/api/bookmarks", "/api/v2/bookmarks"})
 @RequiredArgsConstructor
-@Tag(name = "Bookmarks", description = "북마크 관련 API")
+@Tag(name = "북마크", description = "사용자별 북마크 관리 API입니다.")
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;
@@ -34,59 +42,50 @@ public class BookmarkController {
         throw new GeneralException(ErrorStatus._UNAUTHORIZED);
     }
 
-    /**
-     * 북마크 목록 조회
-     */
     @GetMapping
-    @Operation(summary = "북마크 목록 조회", description = "특정 책에 대한 사용자의 북마크 목록을 조회합니다.")
+    @Operation(summary = "북마크 목록 조회", description = "특정 책에 대해 저장한 북마크 목록을 조회합니다.")
     public ApiResponse<List<BookmarkResponseDTO>> getBookmarks(
-            @Parameter(description = "책 ID", required = true)
+            @Parameter(description = "조회할 도서 ID", required = true, example = "42")
             @RequestParam Long bookId,
-            @Parameter(description = "정렬 방식 (time_desc: 최신순, time_asc: 오래된순)", example = "time_desc")
+            @Parameter(description = "정렬 방식. `time_desc` 또는 `time_asc`를 사용합니다.", example = "time_desc")
             @RequestParam(defaultValue = "time_desc") String sort) {
-        
+
         Long userId = getCurrentUserId();
         List<BookmarkResponseDTO> bookmarks = bookmarkService.getBookmarks(userId, bookId, sort);
         return ApiResponse.onSuccess(bookmarks);
     }
 
-    /**
-     * 북마크 생성
-     */
     @PostMapping
-    @Operation(summary = "북마크 생성", description = "새로운 북마크를 생성합니다. startLocator는 필수이며, endLocator는 범위 선택 시에만 제공합니다.")
+    @Operation(
+            summary = "북마크 생성",
+            description = "새 북마크를 생성합니다. `startLocator`는 필수이고, `endLocator`를 함께 보내면 범위 북마크로 저장합니다."
+    )
     public ApiResponse<BookmarkResponseDTO> createBookmark(
             @Valid @RequestBody CreateBookmarkRequestDTO requestDTO) {
-        
+
         Long userId = getCurrentUserId();
         BookmarkResponseDTO bookmark = bookmarkService.createBookmark(userId, requestDTO);
         return ApiResponse.onSuccess(bookmark);
     }
 
-    /**
-     * 북마크 수정
-     */
     @PatchMapping("/{bookmarkId}")
-    @Operation(summary = "북마크 수정", description = "기존 북마크의 색상이나 메모를 수정합니다.")
+    @Operation(summary = "북마크 수정", description = "기존 북마크의 색상과 메모를 수정합니다.")
     public ApiResponse<BookmarkResponseDTO> updateBookmark(
-            @Parameter(description = "북마크 ID", required = true)
+            @Parameter(description = "수정할 북마크 ID", required = true, example = "101")
             @PathVariable Long bookmarkId,
             @Valid @RequestBody UpdateBookmarkRequestDTO requestDTO) {
-        
+
         Long userId = getCurrentUserId();
         BookmarkResponseDTO bookmark = bookmarkService.updateBookmark(userId, bookmarkId, requestDTO);
         return ApiResponse.onSuccess(bookmark);
     }
 
-    /**
-     * 북마크 삭제
-     */
     @DeleteMapping("/{bookmarkId}")
-    @Operation(summary = "북마크 삭제", description = "기존 북마크를 삭제합니다.")
+    @Operation(summary = "북마크 삭제", description = "북마크를 삭제합니다.")
     public ApiResponse<Void> deleteBookmark(
-            @Parameter(description = "북마크 ID", required = true)
+            @Parameter(description = "삭제할 북마크 ID", required = true, example = "101")
             @PathVariable Long bookmarkId) {
-        
+
         Long userId = getCurrentUserId();
         bookmarkService.deleteBookmark(userId, bookmarkId);
         return ApiResponse.onSuccess(null);

--- a/src/main/java/com/kw/readwith/web/controller/ChapterController.java
+++ b/src/main/java/com/kw/readwith/web/controller/ChapterController.java
@@ -14,7 +14,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/books")
+@RequestMapping({"/api/books", "/api/v2/books"})
 @RequiredArgsConstructor
 @Tag(name = "Chapter", description = "챕터 관련 API")
 public class ChapterController {

--- a/src/main/java/com/kw/readwith/web/controller/ChapterController.java
+++ b/src/main/java/com/kw/readwith/web/controller/ChapterController.java
@@ -11,12 +11,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping({"/api/books", "/api/v2/books"})
 @RequiredArgsConstructor
-@Tag(name = "Chapter", description = "챕터 관련 API")
+@Tag(name = "챕터 POV 요약", description = "챕터별 인물 시점 요약 조회 API입니다.")
 public class ChapterController {
 
     private final CharacterPovSummaryService characterPovSummaryService;
@@ -29,16 +32,17 @@ public class ChapterController {
         throw new GeneralException(ErrorStatus._UNAUTHORIZED);
     }
 
-    // 챕터당 각 인물별 시점요약 조회
     @GetMapping("/{bookId}/chapters/{chapterIdx}/pov-summaries")
-    @Operation(summary = "챕터당 각 인물별 시점요약 조회", 
-               description = "특정 챕터에서 등장하는 각 인물의 시점에서 바라본 해당 챕터의 요약 정보를 조회합니다.")
+    @Operation(
+            summary = "챕터 POV 요약 조회",
+            description = "특정 챕터의 인물별 시점 요약을 조회합니다. 분석이 아직 완료되지 않았으면 빈 목록을 반환할 수 있습니다."
+    )
     public ApiResponse<ChapterPovSummaryResponseDTO> getChapterPovSummaries(
-            @Parameter(description = "책 ID", required = true)
+            @Parameter(description = "조회할 도서 ID", required = true, example = "42")
             @PathVariable Long bookId,
-            @Parameter(description = "챕터 인덱스 (1-based)", required = true)
+            @Parameter(description = "조회할 챕터 인덱스(1-based)", required = true, example = "3")
             @PathVariable Integer chapterIdx) {
-        
+
         Long userId = getCurrentUserId();
         ChapterPovSummaryResponseDTO response = characterPovSummaryService.getChapterPovSummaries(bookId, chapterIdx, userId);
         return ApiResponse.onSuccess(response);

--- a/src/main/java/com/kw/readwith/web/controller/FavoriteController.java
+++ b/src/main/java/com/kw/readwith/web/controller/FavoriteController.java
@@ -15,7 +15,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
-@RequestMapping("/api/favorites")
+@RequestMapping({"/api/favorites", "/api/v2/favorites"})
 @RequiredArgsConstructor
 @Tag(name = "Favorites", description = "즐겨찾기 관련 API")
 public class FavoriteController {

--- a/src/main/java/com/kw/readwith/web/controller/FavoriteController.java
+++ b/src/main/java/com/kw/readwith/web/controller/FavoriteController.java
@@ -5,19 +5,25 @@ import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.service.FavoriteService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping({"/api/favorites", "/api/v2/favorites"})
 @RequiredArgsConstructor
-@Tag(name = "Favorites", description = "즐겨찾기 관련 API")
+@Tag(name = "즐겨찾기", description = "사용자별 즐겨찾기 도서 관리 API입니다.")
 public class FavoriteController {
 
     private final FavoriteService favoriteService;
@@ -30,30 +36,31 @@ public class FavoriteController {
         throw new GeneralException(ErrorStatus._UNAUTHORIZED);
     }
 
-    // 즐겨찾기 추가
     @PostMapping("/{bookId}")
-    @Operation(summary = "즐겨찾기 추가", description = "도서를 즐겨찾기 목록에 추가합니다.")
-    public ApiResponse<Void> addFavorite(@PathVariable Long bookId) {
+    @Operation(summary = "즐겨찾기 추가", description = "특정 도서를 현재 사용자의 즐겨찾기 목록에 추가합니다.")
+    public ApiResponse<Void> addFavorite(
+            @Parameter(description = "즐겨찾기에 추가할 도서 ID", required = true)
+            @PathVariable Long bookId) {
         Long userId = getCurrentUserId();
         favoriteService.addFavorite(userId, bookId);
         return ApiResponse.onSuccess(null);
     }
 
-    // 즐겨찾기 삭제
     @DeleteMapping("/{bookId}")
-    @Operation(summary = "즐겨찾기 삭제", description = "즐겨찾기 목록에서 도서를 제거합니다.")
-    public ApiResponse<Void> removeFavorite(@PathVariable Long bookId) {
+    @Operation(summary = "즐겨찾기 삭제", description = "특정 도서를 현재 사용자의 즐겨찾기 목록에서 제거합니다.")
+    public ApiResponse<Void> removeFavorite(
+            @Parameter(description = "즐겨찾기에서 제거할 도서 ID", required = true)
+            @PathVariable Long bookId) {
         Long userId = getCurrentUserId();
         favoriteService.removeFavorite(userId, bookId);
         return ApiResponse.onSuccess(null);
     }
 
-    // 즐겨찾기 목록 조회
     @GetMapping
-    @Operation(summary = "즐겨찾기 목록 조회", description = "사용자의 즐겨찾기 도서 목록을 조회합니다.")
+    @Operation(summary = "즐겨찾기 목록 조회", description = "현재 사용자가 즐겨찾기한 도서 목록을 조회합니다.")
     public ApiResponse<List<BookSummaryDTO>> getFavorites() {
         Long userId = getCurrentUserId();
         List<BookSummaryDTO> response = favoriteService.getFavoriteBooks(userId);
         return ApiResponse.onSuccess(response);
     }
-} 
+}

--- a/src/main/java/com/kw/readwith/web/controller/GoogleAuthController.java
+++ b/src/main/java/com/kw/readwith/web/controller/GoogleAuthController.java
@@ -14,14 +14,18 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
 @RestController
 @RequestMapping("/api/auth/google")
 @RequiredArgsConstructor
-@Tag(name = "Google Authentication", description = "Google OAuth2 인증 관련 API")
+@Tag(name = "구글 로그인", description = "Google OAuth2 로그인 API입니다.")
 @Slf4j
 public class GoogleAuthController {
 
@@ -30,60 +34,56 @@ public class GoogleAuthController {
 
     @PostMapping
     @Operation(
-        summary = "Google OAuth2 로그인", 
-        description = "Google OAuth2 인증 코드를 사용하여 로그인합니다."
+            summary = "Google OAuth2 로그인",
+            description = "프론트엔드에서 받은 Google authorization code와 redirect URI를 사용해 로그인합니다."
     )
     @ApiResponses(value = {
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200", 
-            description = "로그인 성공",
-            content = @Content(schema = @Schema(implementation = TokenResponseDTO.class))
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "400", 
-            description = "잘못된 요청 (인증 코드 누락 또는 유효하지 않음)"
-        ),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "401", 
-            description = "Google 인증 실패"
-        )
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = TokenResponseDTO.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청입니다. authorization code 또는 redirect URI가 올바르지 않습니다."
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "Google 인증에 실패했습니다."
+            )
     })
     public ApiResponse<TokenResponseDTO> googleLogin(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                description = "Google OAuth2 인증 코드",
-                required = true,
-                content = @Content(schema = @Schema(implementation = GoogleLoginRequestDTO.class))
+                    description = "Google OAuth2 로그인 요청 바디",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = GoogleLoginRequestDTO.class))
             )
             @RequestBody GoogleLoginRequestDTO request) {
-        
+
         try {
             String authorizationCode = request.getCode();
             String redirectUri = request.getRedirectUri();
-            
+
             if (authorizationCode == null || authorizationCode.isBlank()) {
                 return ApiResponse.onFailure("AUTH4001", "인증 코드가 필요합니다.", null);
             }
-            
+
             if (redirectUri == null || redirectUri.isBlank()) {
-                return ApiResponse.onFailure("AUTH4001", "리다이렉트 URI가 필요합니다.", null);
+                return ApiResponse.onFailure("AUTH4001", "redirect URI가 필요합니다.", null);
             }
 
-            // Google OAuth2 서비스에서 사용자 정보 가져오기 및 사용자 생성/업데이트
             User user = googleOAuth2Service.authenticateWithGoogle(authorizationCode, redirectUri);
 
-            // JWT 토큰 생성
             String accessToken = jwtUtil.generateAccessToken(user.getId(), user.getEmail());
             String refreshToken = jwtUtil.generateRefreshToken(user.getId());
 
-            // Refresh Token을 DB에 저장
             user.updateJwtRefreshToken(refreshToken);
 
-            // 응답 생성
             TokenResponseDTO tokenResponse = TokenResponseDTO.builder()
                     .accessToken(accessToken)
                     .refreshToken(refreshToken)
                     .tokenType("Bearer")
-                    .expiresIn(3600L) // 1시간
+                    .expiresIn(3600L)
                     .user(UserInfoResponseDTO.from(user))
                     .build();
 
@@ -98,9 +98,8 @@ public class GoogleAuthController {
     }
 
     @GetMapping("/url")
-    @Operation(summary = "Google OAuth2 인증 URL 생성", description = "Google OAuth2 인증을 위한 URL을 생성합니다.")
+    @Operation(summary = "Google OAuth2 URL 조회", description = "Google 로그인에 사용할 기본 인증 URL 정보를 반환합니다.")
     public ApiResponse<Map<String, String>> getGoogleAuthUrl() {
-        // Google OAuth2 인증 URL 생성
         String authUrl = "https://accounts.google.com/o/oauth2/v2/auth" +
                 "?client_id=${GOOGLE_CLIENT_ID}" +
                 "&redirect_uri=${GOOGLE_REDIRECT_URI}" +
@@ -111,7 +110,7 @@ public class GoogleAuthController {
 
         return ApiResponse.onSuccess(Map.of(
                 "authUrl", authUrl,
-                "message", "클라이언트에서 환경변수를 사용하여 실제 URL을 구성하세요."
+                "message", "클라이언트에서 환경변수를 사용해 실제 URL을 구성하세요."
         ));
     }
 }

--- a/src/main/java/com/kw/readwith/web/controller/GraphController.java
+++ b/src/main/java/com/kw/readwith/web/controller/GraphController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping({"/api/graph", "/api/v2/graph"})
 @RequiredArgsConstructor
-@Tag(name = "Graph", description = "?몃Ъ 愿怨?洹몃옒??API")
+@Tag(name = "관계 그래프", description = "인물 관계 그래프 조회 API입니다.")
 public class GraphController {
 
     private final FineGraphService fineGraphService;
@@ -38,21 +38,21 @@ public class GraphController {
 
     @GetMapping("/fine")
     @Operation(
-            summary = "?몃?(?대깽?? 洹몃옒??議고쉶",
-            description = "locator ? chapterIdx/eventIdx 湲곕컲?쇰줈 ?대깽??洹몃옒?꾨? 議고쉶?⑸땲??"
+            summary = "이벤트 단위 그래프 조회",
+            description = "특정 이벤트 시점의 관계 그래프를 조회합니다. `locator` 또는 legacy `chapterIdx/eventIdx` 조합 중 하나를 사용합니다."
     )
     public ApiResponse<FineGraphResponseDTO> getFineGraph(
-            @Parameter(description = "梨?ID", required = true, example = "1")
+            @Parameter(description = "조회할 도서 ID", required = true, example = "1")
             @RequestParam Long bookId,
-            @Parameter(description = "legacy chapter index", example = "1")
+            @Parameter(description = "legacy 챕터 인덱스. locator를 쓰지 않을 때만 사용합니다.", example = "1")
             @RequestParam(required = false) Integer chapterIdx,
-            @Parameter(description = "legacy event index", example = "3")
+            @Parameter(description = "legacy 이벤트 인덱스. locator를 쓰지 않을 때만 사용합니다.", example = "3")
             @RequestParam(required = false) Integer eventIdx,
-            @Parameter(description = "locator chapter index", example = "1")
+            @Parameter(description = "locator의 챕터 인덱스", example = "1")
             @RequestParam(required = false) Integer chapterIndex,
-            @Parameter(description = "locator block index", example = "2")
+            @Parameter(description = "locator의 블록 인덱스", example = "2")
             @RequestParam(required = false) Integer blockIndex,
-            @Parameter(description = "locator offset", example = "5")
+            @Parameter(description = "locator의 블록 내부 offset", example = "5")
             @RequestParam(required = false) Integer offset) {
 
         Long userId = getCurrentUserId();
@@ -63,19 +63,19 @@ public class GraphController {
 
     @GetMapping("/macro")
     @Operation(
-            summary = "嫄곗떆(梨뺥꽣 ?꾩쟻) 洹몃옒??議고쉶",
-            description = "uptoLocator ? uptoChapter 湲곕컲?쇰줈 ?꾩쟻 愿怨?洹몃옒?꾨? 議고쉶?⑸땲??"
+            summary = "누적 그래프 조회",
+            description = "사용자가 특정 위치까지 읽었을 때의 누적 관계 그래프를 조회합니다. `uptoLocator` 또는 legacy `uptoChapter`를 사용할 수 있습니다."
     )
     public ApiResponse<MacroGraphResponseDTO> getMacroGraph(
-            @Parameter(description = "梨?ID", required = true, example = "1")
+            @Parameter(description = "조회할 도서 ID", required = true, example = "1")
             @RequestParam Long bookId,
-            @Parameter(description = "legacy upto chapter", example = "3")
+            @Parameter(description = "legacy 누적 기준 챕터. locator를 쓰지 않을 때만 사용합니다.", example = "3")
             @RequestParam(required = false) Integer uptoChapter,
-            @Parameter(description = "locator chapter index", example = "3")
+            @Parameter(description = "locator의 챕터 인덱스", example = "3")
             @RequestParam(required = false) Integer chapterIndex,
-            @Parameter(description = "locator block index", example = "2")
+            @Parameter(description = "locator의 블록 인덱스", example = "2")
             @RequestParam(required = false) Integer blockIndex,
-            @Parameter(description = "locator offset", example = "5")
+            @Parameter(description = "locator의 블록 내부 offset", example = "5")
             @RequestParam(required = false) Integer offset) {
 
         Long userId = getCurrentUserId();

--- a/src/main/java/com/kw/readwith/web/controller/ManifestController.java
+++ b/src/main/java/com/kw/readwith/web/controller/ManifestController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "Manifest", description = "Book manifest API")
+@Tag(name = "매니페스트", description = "리더 초기 진입에 필요한 도서 메타데이터 조회 API입니다.")
 public class ManifestController {
 
     private final ManifestService manifestService;
@@ -48,25 +48,25 @@ public class ManifestController {
 
     @GetMapping({"/api/books/{bookId}/manifest", "/api/v2/books/{bookId}/manifest"})
     @Operation(
-            summary = "Get book manifest",
-            description = "Returns the shared manifest payload used to bootstrap the reader."
+            summary = "도서 매니페스트 조회",
+            description = "리더 화면을 시작할 때 필요한 도서, 챕터, 이벤트, 인물, reader artifact 정보를 한 번에 조회합니다."
     )
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "200",
-                    description = "Manifest returned successfully"
+                    description = "매니페스트 조회 성공"
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "404",
-                    description = "Book not found or not accessible"
+                    description = "도서를 찾을 수 없거나 아직 노출 가능한 상태가 아닙니다."
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
-                    description = "Invalid request"
+                    description = "잘못된 요청입니다."
             )
     })
     public ApiResponse<ManifestResponseDTO> getBookManifest(
-            @Parameter(description = "Book ID", required = true, example = "42")
+            @Parameter(description = "조회할 도서 ID", required = true, example = "42")
             @PathVariable Long bookId) {
 
         Long userId = getCurrentUserId();

--- a/src/main/java/com/kw/readwith/web/controller/ProgressController.java
+++ b/src/main/java/com/kw/readwith/web/controller/ProgressController.java
@@ -4,56 +4,68 @@ import com.kw.readwith.apiPayload.ApiResponse;
 import com.kw.readwith.dto.progress.ProgressResponseDTO;
 import com.kw.readwith.dto.progress.SaveProgressRequestDTO;
 import com.kw.readwith.service.UserReadStateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
 @RequestMapping({"/api/progress", "/api/v2/progress"})
 @RequiredArgsConstructor
-@Tag(name = "Progress", description = "독서 진도 관련 API")
+@Tag(name = "독서 진도", description = "사용자별 현재 읽기 위치를 저장하고 조회하는 API입니다.")
 public class ProgressController {
 
     private final UserReadStateService userReadStateService;
 
-    // 진도 저장/업데이트
     @PostMapping
-    @Operation(summary = "독서 진도 저장/업데이트", description = "사용자의 독서 진도를 저장하거나 업데이트합니다.")
+    @Operation(
+            summary = "독서 진도 저장",
+            description = "`startLocator` 기준으로 현재 읽기 위치를 저장합니다. legacy 필드 `locator`도 함께 허용합니다."
+    )
     public ApiResponse<ProgressResponseDTO> saveProgress(@Valid @RequestBody SaveProgressRequestDTO requestDTO, Authentication authentication) {
         Long userId = (Long) authentication.getPrincipal();
         ProgressResponseDTO response = userReadStateService.saveProgress(userId, requestDTO);
         return ApiResponse.onSuccess(response);
     }
 
-    // 특정 책의 진도 조회
     @GetMapping("/{bookId}")
-    @Operation(summary = "특정 책의 독서 진도 조회", description = "사용자의 특정 책에 대한 독서 진도를 조회합니다.")
-    public ApiResponse<ProgressResponseDTO> getProgress(@PathVariable Long bookId, Authentication authentication) {
+    @Operation(summary = "도서별 진도 조회", description = "특정 도서에 대한 현재 사용자의 읽기 위치를 조회합니다.")
+    public ApiResponse<ProgressResponseDTO> getProgress(
+            @Parameter(description = "조회할 도서 ID", required = true, example = "42")
+            @PathVariable Long bookId,
+            Authentication authentication) {
         Long userId = (Long) authentication.getPrincipal();
         ProgressResponseDTO response = userReadStateService.getProgress(userId, bookId);
         return ApiResponse.onSuccess(response);
     }
 
-    // 사용자의 모든 진도 조회
     @GetMapping
-    @Operation(summary = "사용자의 모든 독서 진도 조회", description = "사용자가 읽고 있는 모든 책의 독서 진도를 조회합니다.")
+    @Operation(summary = "전체 진도 조회", description = "현재 사용자가 저장한 모든 도서의 진도를 조회합니다.")
     public ApiResponse<List<ProgressResponseDTO>> getAllProgress(Authentication authentication) {
         Long userId = (Long) authentication.getPrincipal();
         List<ProgressResponseDTO> response = userReadStateService.getAllProgress(userId);
         return ApiResponse.onSuccess(response);
     }
 
-    // 진도 삭제
     @DeleteMapping("/{bookId}")
-    @Operation(summary = "독서 진도 삭제", description = "사용자의 특정 책에 대한 독서 진도를 삭제합니다.")
-    public ApiResponse<Void> deleteProgress(@PathVariable Long bookId, Authentication authentication) {
+    @Operation(summary = "진도 삭제", description = "특정 도서에 저장된 현재 사용자의 진도를 삭제합니다.")
+    public ApiResponse<Void> deleteProgress(
+            @Parameter(description = "진도를 삭제할 도서 ID", required = true, example = "42")
+            @PathVariable Long bookId,
+            Authentication authentication) {
         Long userId = (Long) authentication.getPrincipal();
         userReadStateService.deleteProgress(userId, bookId);
         return ApiResponse.onSuccess(null);
     }
-} 
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,7 +85,9 @@ locator:
 
 api:
   contract:
-    mode: ${API_CONTRACT_MODE:prepare}
+    # v2로 완전히 대체된 manifest/progress/bookmark/graph/admin legacy 경로는 기본 차단한다.
+    # books/favorites/pov-summaries 계열은 아직 일부 클라이언트 전환 확인 전이라 인터셉터에서 제외되어 있다.
+    mode: ${API_CONTRACT_MODE:v2_only}
 
 # JWT 설정
 jwt:

--- a/src/test/java/com/kw/readwith/config/V2ApiContractInterceptorTest.java
+++ b/src/test/java/com/kw/readwith/config/V2ApiContractInterceptorTest.java
@@ -1,0 +1,86 @@
+package com.kw.readwith.config;
+
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.method.HandlerMethod;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class V2ApiContractInterceptorTest {
+
+    private final ApiContractProperties apiContractProperties = new ApiContractProperties();
+    private final V2ApiContractInterceptor interceptor = new V2ApiContractInterceptor(apiContractProperties);
+    private final HandlerMethod handlerMethod = buildHandlerMethod();
+
+    @Test
+    @DisplayName("v2_only에서는 manifest/progress/bookmark/graph/admin legacy 경로를 차단한다")
+    void blocksSafeLegacyRoutesWhenV2Only() {
+        apiContractProperties.setMode("v2_only");
+
+        assertBlocked("/api/books/1/manifest");
+        assertBlocked("/api/progress/1");
+        assertBlocked("/api/bookmarks");
+        assertBlocked("/api/graph/fine");
+        assertBlocked("/api/admin/books/1/events");
+    }
+
+    @Test
+    @DisplayName("아직 전환 확인이 필요한 legacy books/favorites/pov-summary 경로는 열어둔다")
+    void leavesTransitionalLegacyRoutesOpen() {
+        apiContractProperties.setMode("v2_only");
+
+        assertAllowed("/api/books");
+        assertAllowed("/api/books/1");
+        assertAllowed("/api/favorites");
+        assertAllowed("/api/books/1/chapters/2/pov-summaries");
+    }
+
+    @Test
+    @DisplayName("prepare 모드에서는 legacy 경로를 차단하지 않는다")
+    void doesNotBlockLegacyRoutesInPrepareMode() {
+        apiContractProperties.setMode("prepare");
+
+        assertAllowed("/api/books/1/manifest");
+        assertAllowed("/api/progress/1");
+    }
+
+    private void assertBlocked(String requestUri) {
+        GeneralException exception = assertThrows(
+                GeneralException.class,
+                () -> interceptor.preHandle(request(requestUri), new MockHttpServletResponse(), handlerMethod)
+        );
+        assertThat(exception.getErrorReason().getMessage()).contains("/api/v2");
+    }
+
+    private void assertAllowed(String requestUri) {
+        assertDoesNotThrow(() -> interceptor.preHandle(request(requestUri), new MockHttpServletResponse(), handlerMethod));
+    }
+
+    private MockHttpServletRequest request(String requestUri) {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", requestUri);
+        request.setRequestURI(requestUri);
+        return request;
+    }
+
+    private HandlerMethod buildHandlerMethod() {
+        try {
+            Method method = DummyHandler.class.getDeclaredMethod("handle");
+            return new HandlerMethod(new DummyHandler(), method);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static class DummyHandler {
+        @SuppressWarnings("unused")
+        public void handle() {
+        }
+    }
+}

--- a/src/test/java/com/kw/readwith/controller/ApiRouteAliasMappingTest.java
+++ b/src/test/java/com/kw/readwith/controller/ApiRouteAliasMappingTest.java
@@ -1,0 +1,51 @@
+package com.kw.readwith.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+        "cloud.aws.credentials.accessKey=test",
+        "cloud.aws.credentials.secretKey=test",
+        "cloud.aws.region.static=ap-northeast-2",
+        "cloud.aws.s3.bucket=test-bucket",
+        "cloud.aws.path.original=original",
+        "cloud.aws.path.metadata=metadata",
+        "spring.jpa.properties.hibernate.hbm2ddl.auto=create-drop",
+        "spring.security.oauth2.client.registration.google.client-id=test",
+        "spring.security.oauth2.client.registration.google.client-secret=test",
+        "spring.ai.openai.api-key=test"
+})
+class ApiRouteAliasMappingTest {
+
+    @Autowired
+    private RequestMappingHandlerMapping handlerMapping;
+
+    @Test
+    void exposesV2AliasesForBookFavoriteAndPovSummaryApis() {
+        Set<String> paths = handlerMapping.getHandlerMethods().keySet().stream()
+                .flatMap(info -> info.getPatternValues().stream())
+                .collect(Collectors.toSet());
+
+        assertThat(paths).contains("/api/books");
+        assertThat(paths).contains("/api/v2/books");
+        assertThat(paths).contains("/api/books/{bookId}");
+        assertThat(paths).contains("/api/v2/books/{bookId}");
+        assertThat(paths).contains("/api/books/{bookId}/chapters/{chapterIdx}/pov-summaries");
+        assertThat(paths).contains("/api/v2/books/{bookId}/chapters/{chapterIdx}/pov-summaries");
+        assertThat(paths).contains("/api/favorites");
+        assertThat(paths).contains("/api/v2/favorites");
+        assertThat(paths).contains("/api/favorites/{bookId}");
+        assertThat(paths).contains("/api/v2/favorites/{bookId}");
+    }
+}

--- a/src/test/java/com/kw/readwith/service/AdminSummaryUploadValidationTest.java
+++ b/src/test/java/com/kw/readwith/service/AdminSummaryUploadValidationTest.java
@@ -1,0 +1,108 @@
+package com.kw.readwith.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.config.V2TransitionGuard;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Chapter;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import com.kw.readwith.repository.CharacterPovSummaryRepository;
+import com.kw.readwith.repository.CharacterRepository;
+import com.kw.readwith.repository.EventCharacterStatRepository;
+import com.kw.readwith.repository.EventRelationshipEdgeRepository;
+import com.kw.readwith.repository.EventRepository;
+import com.kw.readwith.service.normalization.NormalizationVersionService;
+import com.kw.readwith.util.LocatorSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminSummaryUploadValidationTest {
+
+    @InjectMocks
+    private AdminService adminService;
+
+    @Mock
+    private BookRepository bookRepository;
+    @Mock
+    private CharacterRepository characterRepository;
+    @Mock
+    private ChapterRepository chapterRepository;
+    @Mock
+    private EventRepository eventRepository;
+    @Mock
+    private EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
+    @Mock
+    private CharacterPovSummaryRepository characterPovSummaryRepository;
+    @Mock
+    private EventCharacterStatRepository statRepository;
+    @Mock
+    private CharacterImageService characterImageService;
+    @Mock
+    private BookAnalysisStatusService bookAnalysisStatusService;
+    @Mock
+    private LocatorSupport locatorSupport;
+    @Mock
+    private V2TransitionGuard transitionGuard;
+    @Mock
+    private NormalizationVersionService normalizationVersionService;
+
+    @Spy
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("ko summary 업로드는 빈 items payload를 요약 완료로 처리하지 않는다")
+    void uploadChapterSummariesRejectsEmptyKoItems() {
+        Long bookId = 1L;
+        Chapter chapter = Chapter.builder()
+                .id(10L)
+                .idx(1)
+                .build();
+        Book book = Book.builder()
+                .id(bookId)
+                .build();
+        String jsonContent = """
+                {
+                  "chapterIndex": 1,
+                  "language": "ko",
+                  "items": []
+                }
+                """;
+        MockMultipartFile file = new MockMultipartFile(
+                "files",
+                "chapter_001_summaries_Ko.json",
+                "application/json",
+                jsonContent.getBytes()
+        );
+
+        when(bookRepository.findById(bookId)).thenReturn(Optional.of(book));
+        when(chapterRepository.findByBookIdAndIdx(bookId, 1)).thenReturn(Optional.of(chapter));
+        when(characterPovSummaryRepository.existsByChapter(chapter)).thenReturn(false);
+
+        GeneralException exception = assertThrows(
+                GeneralException.class,
+                () -> adminService.uploadChapterSummaries(bookId, java.util.List.of(file))
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus._BAD_REQUEST);
+        assertThat(chapter.isPovSummariesCached()).isFalse();
+        verify(characterPovSummaryRepository, never()).saveAll(org.mockito.ArgumentMatchers.anyList());
+        verify(bookAnalysisStatusService).markRejectedIfPending(bookId);
+    }
+}

--- a/src/test/java/com/kw/readwith/service/BookAnalysisStatusServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/BookAnalysisStatusServiceTest.java
@@ -7,6 +7,7 @@ import com.kw.readwith.domain.enums.NormalizationStatus;
 import com.kw.readwith.repository.BookRepository;
 import com.kw.readwith.repository.ChapterRepository;
 import com.kw.readwith.repository.CharacterRepository;
+import com.kw.readwith.repository.CharacterPovSummaryRepository;
 import com.kw.readwith.repository.EventCharacterStatRepository;
 import com.kw.readwith.repository.EventRelationshipEdgeRepository;
 import com.kw.readwith.repository.EventRepository;
@@ -36,6 +37,9 @@ class BookAnalysisStatusServiceTest {
     private CharacterRepository characterRepository;
 
     @Mock
+    private CharacterPovSummaryRepository characterPovSummaryRepository;
+
+    @Mock
     private EventRepository eventRepository;
 
     @Mock
@@ -59,10 +63,11 @@ class BookAnalysisStatusServiceTest {
         when(bookRepository.findById(1L)).thenReturn(Optional.of(book));
         when(characterRepository.existsByBook(book)).thenReturn(true);
         when(eventRepository.existsByBook(book)).thenReturn(true);
-        when(chapterRepository.findByBookId(1L)).thenReturn(List.of(
-                Chapter.builder().idx(1).povSummariesCached(true).build(),
-                Chapter.builder().idx(2).povSummariesCached(true).build()
-        ));
+        Chapter chapter1 = Chapter.builder().idx(1).povSummariesCached(true).build();
+        Chapter chapter2 = Chapter.builder().idx(2).povSummariesCached(true).build();
+        when(chapterRepository.findByBookId(1L)).thenReturn(List.of(chapter1, chapter2));
+        when(characterPovSummaryRepository.existsByChapter(chapter1)).thenReturn(true);
+        when(characterPovSummaryRepository.existsByChapter(chapter2)).thenReturn(true);
         when(eventRelationshipEdgeRepository.existsByBook(book)).thenReturn(false);
         when(eventCharacterStatRepository.existsByBook(book)).thenReturn(true);
 
@@ -85,10 +90,10 @@ class BookAnalysisStatusServiceTest {
         when(bookRepository.findById(1L)).thenReturn(Optional.of(book));
         when(characterRepository.existsByBook(book)).thenReturn(true);
         when(eventRepository.existsByBook(book)).thenReturn(true);
-        when(chapterRepository.findByBookId(1L)).thenReturn(List.of(
-                Chapter.builder().idx(1).povSummariesCached(true).build(),
-                Chapter.builder().idx(2).povSummariesCached(false).build()
-        ));
+        Chapter chapter1 = Chapter.builder().idx(1).povSummariesCached(true).build();
+        Chapter chapter2 = Chapter.builder().idx(2).povSummariesCached(false).build();
+        when(chapterRepository.findByBookId(1L)).thenReturn(List.of(chapter1, chapter2));
+        when(characterPovSummaryRepository.existsByChapter(chapter1)).thenReturn(true);
 
         bookAnalysisStatusService.refreshStatus(1L);
 
@@ -127,5 +132,30 @@ class BookAnalysisStatusServiceTest {
 
         assertThat(book.getAnalysisStatus()).isEqualTo(AnalysisStatus.READY);
         assertThat(book.isSummary()).isTrue();
+    }
+
+    @Test
+    @DisplayName("chapter 요약 플래그가 올라가 있어도 실제 summary row가 없으면 READY로 올리지 않는다")
+    void refreshStatusResetsToNoneWhenSummaryRowsAreMissing() {
+        Book book = Book.builder()
+                .id(1L)
+                .normalizationStatus(NormalizationStatus.READY)
+                .analysisStatus(AnalysisStatus.NONE)
+                .build();
+        Chapter chapter = Chapter.builder()
+                .idx(1)
+                .povSummariesCached(true)
+                .build();
+
+        when(bookRepository.findById(1L)).thenReturn(Optional.of(book));
+        when(characterRepository.existsByBook(book)).thenReturn(true);
+        when(eventRepository.existsByBook(book)).thenReturn(true);
+        when(chapterRepository.findByBookId(1L)).thenReturn(List.of(chapter));
+        when(characterPovSummaryRepository.existsByChapter(chapter)).thenReturn(false);
+
+        bookAnalysisStatusService.refreshStatus(1L);
+
+        assertThat(book.getAnalysisStatus()).isEqualTo(AnalysisStatus.NONE);
+        assertThat(book.isSummary()).isFalse();
     }
 }

--- a/src/test/java/com/kw/readwith/service/CharacterPovSummaryServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/CharacterPovSummaryServiceTest.java
@@ -1,0 +1,115 @@
+package com.kw.readwith.service;
+
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Chapter;
+import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.enums.AnalysisStatus;
+import com.kw.readwith.dto.admin.CharacterPovSummaryDTO;
+import com.kw.readwith.dto.book.ChapterPovSummaryResponseDTO;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import com.kw.readwith.repository.CharacterPovSummaryRepository;
+import com.kw.readwith.repository.CharacterRepository;
+import com.kw.readwith.domain.mapping.CharacterPovSummary;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CharacterPovSummaryServiceTest {
+
+    @Mock
+    private CharacterPovSummaryRepository characterPovSummaryRepository;
+
+    @Mock
+    private ChapterRepository chapterRepository;
+
+    @Mock
+    private CharacterRepository characterRepository;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private BookAccessPolicy bookAccessPolicy;
+
+    @InjectMocks
+    private CharacterPovSummaryService characterPovSummaryService;
+
+    @Test
+    @DisplayName("POV summary 조회는 DB PK가 아니라 책 내부 characterId를 반환한다")
+    void getChapterPovSummariesUsesLogicalCharacterId() {
+        Book book = Book.builder()
+                .id(1L)
+                .analysisStatus(AnalysisStatus.READY)
+                .build();
+        Chapter chapter = Chapter.builder()
+                .id(10L)
+                .book(book)
+                .idx(2)
+                .title("chapter 2")
+                .build();
+        Character character = Character.builder()
+                .id(99L)
+                .book(book)
+                .characterId(7L)
+                .name("Alice")
+                .isMainCharacter(true)
+                .build();
+        CharacterPovSummary summary = CharacterPovSummary.builder()
+                .id(100L)
+                .book(book)
+                .chapter(chapter)
+                .character(character)
+                .summaryText("summary")
+                .build();
+
+        when(bookRepository.findById(1L)).thenReturn(Optional.of(book));
+        when(chapterRepository.findByBookIdAndIdx(1L, 2)).thenReturn(Optional.of(chapter));
+        when(characterPovSummaryRepository.findByBookIdAndChapterIdx(1L, 2)).thenReturn(List.of(summary));
+        doNothing().when(bookAccessPolicy).ensureReadable(book, 55L);
+
+        ChapterPovSummaryResponseDTO response = characterPovSummaryService.getChapterPovSummaries(1L, 2, 55L);
+
+        assertThat(response.getPovSummaries()).hasSize(1);
+        assertThat(response.getPovSummaries().get(0).getCharacterId()).isEqualTo(7L);
+    }
+
+    @Test
+    @DisplayName("관리자 POV summary 조회도 책 내부 characterId를 반환한다")
+    void getCharacterPovSummariesByChapterUsesLogicalCharacterId() {
+        Book book = Book.builder().id(1L).build();
+        Chapter chapter = Chapter.builder().id(10L).book(book).idx(1).build();
+        Character character = Character.builder()
+                .id(42L)
+                .book(book)
+                .characterId(5L)
+                .name("Bob")
+                .build();
+        CharacterPovSummary summary = CharacterPovSummary.builder()
+                .id(77L)
+                .book(book)
+                .chapter(chapter)
+                .character(character)
+                .summaryText("admin summary")
+                .build();
+
+        when(chapterRepository.existsById(10L)).thenReturn(true);
+        when(characterPovSummaryRepository.findByChapterId(10L)).thenReturn(List.of(summary));
+
+        List<CharacterPovSummaryDTO> response = characterPovSummaryService.getCharacterPovSummariesByChapter(10L);
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).getCharacterId()).isEqualTo(5L);
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
M3 병합 이후 실제 호출 기준으로 깨질 가능성이 있던 API들을 안정화하고, 프론트가 Swagger만 보고도 이해할 수 있도록 문서를 보강한 PR입니다.

이번 PR에서는 크게 3가지를 정리했습니다.
- v2로 완전히 대체된 legacy `/api` 경로 기본 차단
- POV summary / summary 업로드 상태 판정 / v2 alias 등 M3 후속 안정화
- Swagger 설명을 한국어 기준으로 통일하고 요청/응답 DTO 스키마 설명 보강

즉, 이번 PR은 새로운 기능 추가보다
`M3에서 붙인 API를 실제 운영/프론트 사용 기준으로 다듬고 문서화하는 안정화 작업`
에 가깝습니다.

## 📋 변경 사항
- API 안정화
  - `/api/v2/books`, `/api/v2/favorites`, `/api/v2/books/{bookId}/chapters/{chapterIdx}/pov-summaries` alias 정리
  - POV summary 응답의 `characterId`를 DB PK가 아니라 책 내부 `characterId`로 통일
  - summary 업로드 시 `items`가 비어 있으면 400으로 거부
  - `analysisStatus=READY` 판정 시 chapter summary 캐시 플래그뿐 아니라 실제 summary row 존재 여부도 같이 확인

- legacy v1 차단
  - 기본 `api.contract.mode`를 `v2_only`로 상향
  - 아래 legacy 경로는 기본 차단
    - `/api/books/{bookId}/manifest`
    - `/api/progress/**`
    - `/api/bookmarks/**`
    - `/api/graph/**`
    - `/api/admin/**`
  - 아직 클라이언트 전환 확인이 필요한 경로는 주석으로 이유를 남기고 제외
    - `/api/books`
    - `/api/books/{bookId}`
    - `POST /api/books`
    - `/api/favorites/**`
    - `/api/books/{bookId}/chapters/{chapterIdx}/pov-summaries`

- Swagger 문서 정리
  - OpenAPI 제목/설명 한국어 기준으로 정리
  - controller `@Tag`, `@Operation`, `@Parameter` 설명 정리
  - 핵심 DTO에 `@Schema` 추가
    - locator
    - progress
    - bookmark
    - manifest
    - graph
    - admin upload payload
    - book / pov summary 응답

## 🔍 Code Review
주요 확인 포인트는 아래입니다.
- `v2_only` 기본 적용이 현재 프론트 호출 경로와 충돌하지 않는지
- 아직 열어둔 legacy 경로(`books`, `favorites`, `pov-summaries`) 범위가 적절한지
- POV summary의 `characterId`가 manifest/graph와 같은 식별 체계로 내려가는지
- summary 업로드 빈 payload를 막는 현재 정책이 AI 산출물 흐름과 맞는지
- Swagger 문구가 실제 현재 계약과 어긋나는 부분 없이 정리됐는지

검증한 항목
- `compileJava`
- `compileTestJava`
- `ApiRouteAliasMappingTest`
- `CharacterPovSummaryServiceTest`
- `BookAnalysisStatusServiceTest`
- `AdminSummaryUploadValidationTest`
- `V2ApiContractInterceptorTest`

참고
- 전체 테스트 스위트는 이번 PR에서 다시 전부 돌리지는 않았습니다.
- 로컬 보관용 `docs/`, `src/main/resources/static/upload/`는 이번 PR에 포함하지 않았습니다.

## 📸 ScreenShot
- 백엔드/문서화 작업으로 별도 스크린샷 없음