### PR TITLE
feat: [M3] AI 입력용 정규화 산출물 presigned URL 제공

### DIFF
--- a/src/main/java/com/kw/readwith/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/kw/readwith/aws/s3/AmazonS3Manager.java
@@ -1,6 +1,8 @@
 package com.kw.readwith.aws.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.kw.readwith.config.AmazonConfig;
@@ -12,7 +14,9 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.Base64;
+import java.util.Date;
 import java.util.UUID;
 
 @Slf4j
@@ -56,6 +60,18 @@ public class AmazonS3Manager {
 
     public String getObjectUrl(String keyName) {
         return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+    }
+
+    public String generatePresignedGetUrl(String keyName, Duration ttl) {
+        if (ttl == null || ttl.isZero() || ttl.isNegative()) {
+            throw new IllegalArgumentException("Presigned URL TTL must be positive.");
+        }
+
+        Date expiration = new Date(System.currentTimeMillis() + ttl.toMillis());
+        GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(amazonConfig.getBucket(), keyName)
+                .withMethod(HttpMethod.GET)
+                .withExpiration(expiration);
+        return amazonS3.generatePresignedUrl(request).toString();
     }
 
     public String uploadFileFromBase64(String keyName, String base64Data, String contentType) {

--- a/src/main/java/com/kw/readwith/config/ArtifactStorageProperties.java
+++ b/src/main/java/com/kw/readwith/config/ArtifactStorageProperties.java
@@ -5,6 +5,8 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+
 @Component
 @ConfigurationProperties(prefix = "artifact.storage")
 @Getter
@@ -14,4 +16,5 @@ public class ArtifactStorageProperties {
     private String publicPrefix = "public";
     private String privatePrefix = "private";
     private String cloudFrontBaseUrl = "";
+    private Duration privateUrlTtl = Duration.ofHours(1);
 }

--- a/src/main/java/com/kw/readwith/dto/admin/AnalysisInputChapterDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/AnalysisInputChapterDTO.java
@@ -1,0 +1,20 @@
+package com.kw.readwith.dto.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "AI 입력으로 전달할 챕터별 정규화 본문 정보")
+public class AnalysisInputChapterDTO {
+
+    @Schema(description = "챕터 인덱스(1-based)", example = "3")
+    private Integer chapterIndex;
+
+    @Schema(description = "챕터 제목", nullable = true)
+    private String title;
+
+    @Schema(description = "정규화된 챕터 원문 txt 다운로드용 presigned URL")
+    private String txtUrl;
+}

--- a/src/main/java/com/kw/readwith/dto/admin/AnalysisInputResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/AnalysisInputResponseDTO.java
@@ -1,0 +1,47 @@
+package com.kw.readwith.dto.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "AI 분석 서버가 내려받을 정규화 산출물 export 응답")
+public class AnalysisInputResponseDTO {
+
+    @Schema(description = "도서 ID", example = "42")
+    private Long bookId;
+
+    @Schema(description = "도서 제목")
+    private String title;
+
+    @Schema(description = "저자명")
+    private String author;
+
+    @Schema(description = "언어 코드", example = "en")
+    private String language;
+
+    @Schema(description = "활성 정규화 run id", nullable = true)
+    private String normalizationRunId;
+
+    @Schema(description = "정규화 산출물 루트 경로", nullable = true)
+    private String normalizedArtifactPath;
+
+    @Schema(description = "정규화 규칙 버전", nullable = true)
+    private String ruleVersion;
+
+    @Schema(description = "locator 버전", nullable = true)
+    private String locatorVersion;
+
+    @Schema(description = "meta.json 다운로드용 presigned URL")
+    private String metaUrl;
+
+    @Schema(description = "URL 만료 시각", example = "2026-04-02T15:30:00+09:00")
+    private OffsetDateTime expiresAt;
+
+    @Schema(description = "챕터별 txt 다운로드 정보")
+    private List<AnalysisInputChapterDTO> chapters;
+}

--- a/src/main/java/com/kw/readwith/service/AnalysisInputExportService.java
+++ b/src/main/java/com/kw/readwith/service/AnalysisInputExportService.java
@@ -1,0 +1,79 @@
+package com.kw.readwith.service;
+
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.aws.s3.AmazonS3Manager;
+import com.kw.readwith.config.ArtifactStorageProperties;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Chapter;
+import com.kw.readwith.dto.admin.AnalysisInputChapterDTO;
+import com.kw.readwith.dto.admin.AnalysisInputResponseDTO;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnalysisInputExportService {
+
+    private final BookRepository bookRepository;
+    private final ChapterRepository chapterRepository;
+    private final AmazonS3Manager amazonS3Manager;
+    private final ArtifactStorageProperties artifactStorageProperties;
+
+    public AnalysisInputResponseDTO getAnalysisInput(Long bookId) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+
+        if (!book.isNormalizationReady() || book.getNormalizedArtifactPath() == null || book.getNormalizedArtifactPath().isBlank()) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "정규화가 완료된 도서만 analysis input을 조회할 수 있습니다.");
+        }
+
+        List<Chapter> chapters = chapterRepository.findByBookId(bookId).stream()
+                .sorted(Comparator.comparingInt(Chapter::getIdx))
+                .toList();
+        if (chapters.isEmpty()) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "정규화 챕터 산출물이 아직 준비되지 않았습니다.");
+        }
+
+        Duration ttl = artifactStorageProperties.getPrivateUrlTtl();
+        OffsetDateTime expiresAt = OffsetDateTime.now().plus(ttl);
+        String artifactRoot = book.getNormalizedArtifactPath();
+
+        return AnalysisInputResponseDTO.builder()
+                .bookId(book.getId())
+                .title(book.getTitle())
+                .author(book.getAuthor())
+                .language(book.getLanguage())
+                .normalizationRunId(book.getNormalizationRunId())
+                .normalizedArtifactPath(artifactRoot)
+                .ruleVersion(book.getRuleVersion())
+                .locatorVersion(book.getLocatorVersion())
+                .metaUrl(presignPrivateObject(artifactRoot + "/meta.json", ttl))
+                .expiresAt(expiresAt)
+                .chapters(chapters.stream()
+                        .map(chapter -> AnalysisInputChapterDTO.builder()
+                                .chapterIndex(chapter.getIdx())
+                                .title(chapter.getTitle())
+                                .txtUrl(presignPrivateObject(
+                                        artifactRoot + "/text/" + String.format("chapter_%03d.txt", chapter.getIdx()),
+                                        ttl
+                                ))
+                                .build())
+                        .toList())
+                .build();
+    }
+
+    private String presignPrivateObject(String relativePath, Duration ttl) {
+        String key = artifactStorageProperties.getPrivatePrefix() + "/" + relativePath;
+        return amazonS3Manager.generatePresignedGetUrl(key, ttl);
+    }
+}

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -1,9 +1,11 @@
 package com.kw.readwith.web.controller;
 
 import com.kw.readwith.apiPayload.ApiResponse;
+import com.kw.readwith.dto.admin.AnalysisInputResponseDTO;
 import com.kw.readwith.dto.admin.UnsummarizedItemDTO;
 import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.service.AdminService;
+import com.kw.readwith.service.AnalysisInputExportService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,10 +25,11 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping({"/api/admin", "/api/v2/admin"})
-@Tag(name = "관리자 업로드", description = "AI/관리자 산출물을 책에 적재하는 업로드 API입니다.")
+@Tag(name = "관리자 업로드", description = "AI/관리자 산출물 적재와 운영 보조 기능을 제공하는 API입니다.")
 public class AdminController {
 
     private final AdminService adminService;
+    private final AnalysisInputExportService analysisInputExportService;
 
     @Operation(
             summary = "인물 업로드",
@@ -40,7 +43,7 @@ public class AdminController {
         return ApiResponse.onSuccess("Characters have been successfully uploaded.");
     }
 
-    @Operation(summary = "인물 전체 삭제", description = "특정 책에 적재된 인물 정보를 모두 삭제합니다.")
+    @Operation(summary = "인물 전체 삭제", description = "특정 도서에 적재된 인물 정보를 모두 삭제합니다.")
     @DeleteMapping("/books/{bookId}/characters")
     public ApiResponse<String> deleteCharacters(
             @Parameter(description = "삭제 대상 도서 ID", required = true) @PathVariable Long bookId) {
@@ -103,6 +106,17 @@ public class AdminController {
         return ApiResponse.onSuccess("Chapter summaries have been successfully uploaded.");
     }
 
+    @Operation(
+            summary = "AI 분석 입력 산출물 조회",
+            description = "정규화가 완료된 도서의 `meta.json`과 챕터별 `chapter_*.txt`를 presigned URL로 내려줍니다. AI 서버는 이 응답을 받아 만료 시간 안에 private S3 산출물을 다운로드하면 됩니다."
+    )
+    @GetMapping("/books/{bookId}/analysis-input")
+    public ApiResponse<AnalysisInputResponseDTO> getAnalysisInput(
+            @Parameter(description = "정규화 산출물을 조회할 도서 ID", required = true) @PathVariable Long bookId) {
+        AnalysisInputResponseDTO response = analysisInputExportService.getAnalysisInput(bookId);
+        return ApiResponse.onSuccess(response);
+    }
+
     @Operation(summary = "챕터 요약 삭제", description = "특정 챕터에 적재된 POV summary를 삭제합니다.")
     @DeleteMapping("/books/{bookId}/chapters/{chapterIdx}/summary")
     public ApiResponse<String> deleteChapterSummary(
@@ -112,7 +126,7 @@ public class AdminController {
         return ApiResponse.onSuccess("Chapter summary has been successfully deleted.");
     }
 
-    @Operation(summary = "미요약 도서 목록 조회", description = "legacy summary 플래그 기준으로 아직 요약이 완료되지 않은 책을 조회합니다.")
+    @Operation(summary = "미요약 도서 목록 조회", description = "legacy summary 플래그 기준으로 아직 요약이 완료되지 않은 도서를 조회합니다.")
     @GetMapping("/books/unsummarized")
     public ApiResponse<List<BookSummaryDTO>> getUnsummarizedBooks() {
         List<BookSummaryDTO> response = adminService.getUnsummarizedBooks();
@@ -128,7 +142,7 @@ public class AdminController {
 
     @Operation(
             summary = "캐릭터 이미지 재생성",
-            description = "특정 캐릭터의 프로필 이미지를 다시 생성합니다. 기존 이미지 품질이 낮거나 생성에 실패했을 때 사용합니다.",
+            description = "특정 캐릭터의 프로필 이미지를 다시 생성합니다. 기존 이미지가 없거나 생성이 실패했을 때 사용합니다.",
             security = {}
     )
     @PostMapping(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,6 +79,7 @@ artifact:
     public-prefix: ${ARTIFACT_PUBLIC_PREFIX:public}
     private-prefix: ${ARTIFACT_PRIVATE_PREFIX:private}
     cloud-front-base-url: ${CLOUDFRONT_BASE_URL:}
+    private-url-ttl: ${ARTIFACT_PRIVATE_URL_TTL:1h}
 
 locator:
   mode: ${LOCATOR_MODE:on}

--- a/src/test/java/com/kw/readwith/service/AnalysisInputExportServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/AnalysisInputExportServiceTest.java
@@ -1,0 +1,107 @@
+package com.kw.readwith.service;
+
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.aws.s3.AmazonS3Manager;
+import com.kw.readwith.config.ArtifactStorageProperties;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Chapter;
+import com.kw.readwith.domain.enums.NormalizationStatus;
+import com.kw.readwith.dto.admin.AnalysisInputResponseDTO;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AnalysisInputExportServiceTest {
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private ChapterRepository chapterRepository;
+
+    @Mock
+    private AmazonS3Manager amazonS3Manager;
+
+    @Mock
+    private ArtifactStorageProperties artifactStorageProperties;
+
+    @InjectMocks
+    private AnalysisInputExportService analysisInputExportService;
+
+    @Test
+    @DisplayName("정규화 산출물 export는 meta와 chapter txt presigned URL을 함께 내려준다")
+    void getAnalysisInputReturnsPresignedUrls() {
+        Book book = Book.builder()
+                .id(42L)
+                .title("Sherlock Holmes")
+                .author("Arthur Conan Doyle")
+                .language("en")
+                .normalizationStatus(NormalizationStatus.READY)
+                .normalizedArtifactPath("books/42/normalizations/run-1")
+                .normalizationRunId("run-1")
+                .ruleVersion("v1")
+                .locatorVersion("v2")
+                .build();
+        Chapter chapter1 = Chapter.builder().idx(1).title("Chapter 1").build();
+        Chapter chapter2 = Chapter.builder().idx(2).title("Chapter 2").build();
+
+        when(bookRepository.findById(42L)).thenReturn(Optional.of(book));
+        when(chapterRepository.findByBookId(42L)).thenReturn(List.of(chapter2, chapter1));
+        when(artifactStorageProperties.getPrivatePrefix()).thenReturn("private");
+        when(artifactStorageProperties.getPrivateUrlTtl()).thenReturn(Duration.ofHours(1));
+        when(amazonS3Manager.generatePresignedGetUrl(eq("private/books/42/normalizations/run-1/meta.json"), eq(Duration.ofHours(1))))
+                .thenReturn("https://signed/meta");
+        when(amazonS3Manager.generatePresignedGetUrl(eq("private/books/42/normalizations/run-1/text/chapter_001.txt"), eq(Duration.ofHours(1))))
+                .thenReturn("https://signed/ch1");
+        when(amazonS3Manager.generatePresignedGetUrl(eq("private/books/42/normalizations/run-1/text/chapter_002.txt"), eq(Duration.ofHours(1))))
+                .thenReturn("https://signed/ch2");
+
+        AnalysisInputResponseDTO response = analysisInputExportService.getAnalysisInput(42L);
+
+        assertThat(response.getBookId()).isEqualTo(42L);
+        assertThat(response.getMetaUrl()).isEqualTo("https://signed/meta");
+        assertThat(response.getChapters()).hasSize(2);
+        assertThat(response.getChapters().get(0).getChapterIndex()).isEqualTo(1);
+        assertThat(response.getChapters().get(0).getTxtUrl()).isEqualTo("https://signed/ch1");
+        assertThat(response.getChapters().get(1).getChapterIndex()).isEqualTo(2);
+        assertThat(response.getChapters().get(1).getTxtUrl()).isEqualTo("https://signed/ch2");
+        assertThat(response.getExpiresAt()).isNotNull();
+
+        verify(amazonS3Manager).generatePresignedGetUrl("private/books/42/normalizations/run-1/meta.json", Duration.ofHours(1));
+        verify(amazonS3Manager).generatePresignedGetUrl("private/books/42/normalizations/run-1/text/chapter_001.txt", Duration.ofHours(1));
+        verify(amazonS3Manager).generatePresignedGetUrl("private/books/42/normalizations/run-1/text/chapter_002.txt", Duration.ofHours(1));
+    }
+
+    @Test
+    @DisplayName("정규화 미완료 도서는 analysis input 조회를 거부한다")
+    void getAnalysisInputRejectsNonReadyBook() {
+        Book book = Book.builder()
+                .id(42L)
+                .normalizationStatus(NormalizationStatus.QUEUED)
+                .normalizedArtifactPath("books/42/normalizations/run-1")
+                .build();
+
+        when(bookRepository.findById(42L)).thenReturn(Optional.of(book));
+
+        assertThatThrownBy(() -> analysisInputExportService.getAnalysisInput(42L))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(exception -> assertThat(((GeneralException) exception).getErrorReason().getMessage())
+                        .contains("정규화가 완료된 도서만"));
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
정규화가 끝난 도서의 `meta.json`, `chapter_*.txt` 산출물을 AI 서버가 바로 가져갈 수 있도록 presigned URL export API를 추가한 PR입니다.

기존에는
- EPUB 업로드
- 정규화 완료
- Admin 업로드 API 존재

까지는 있었지만, 정규화 이후 AI 서버가 사용할 입력 산출물을 backend가 어떤 경로로 넘겨줄지 빠져 있었습니다.

이번 PR에서는 그 사이 단계로
- private S3 산출물에 대한 presigned GET URL 생성
- `analysis-input` 응답 DTO/서비스 추가
- Admin API에서 export endpoint 노출

을 반영했습니다.

## 📋 변경 사항
- S3 presigned URL 지원
  - `AmazonS3Manager`에 private object용 presigned GET URL 생성 메서드 추가
  - `artifact.storage.private-url-ttl` 설정 추가
  - 기본 TTL은 `1h`

- AI 입력 export API 추가
  - `GET /api/admin/books/{bookId}/analysis-input`
  - `GET /api/v2/admin/books/{bookId}/analysis-input`
  - 정규화 완료 도서에 대해 아래 응답 제공
    - `metaUrl`
    - `chapters[].txtUrl`
    - `expiresAt`
    - `normalizationRunId`
    - `ruleVersion`
    - `locatorVersion`
    - `normalizedArtifactPath`

- 응답 구조
  - `AnalysisInputResponseDTO`
  - `AnalysisInputChapterDTO`
  - 챕터 목록은 chapter index 기준 오름차순 정렬
  - txt 경로는 `private/books/{bookId}/normalizations/{runId}/text/chapter_{n}.txt` 규칙 기준으로 생성

- 유효성
  - 정규화 완료(`normalizationStatus=READY`)가 아닌 도서는 export 불가
  - chapter projection이 없으면 export 불가

## 🔍 Code Review
주요 확인 포인트는 아래입니다.
- AI 서버가 사용할 입력 산출물 전달 경로로 `presigned GET URL` 방식이 적절한지
- 응답에 포함한 필드(`metaUrl`, `chapters[].txtUrl`, `expiresAt`, run/version 정보`)가 AI 연동에 충분한지
- 현재 TTL 기본값 `1h`가 운영상 적절한지
- 경로 규칙이 실제 정규화 산출물 저장 구조와 일치하는지
- `analysis-input`를 Admin API 하위에 두는 현재 배치가 적절한지

검증한 항목
- `compileJava`
- `compileTestJava`
- `AnalysisInputExportServiceTest`

## 📸 ScreenShot
- 백엔드 작업으로 별도 스크린샷 없음