### PR TITLE
fix : 엔드투엔드 테스트를 위한 EPUB 업로드 안정화

### DIFF
--- a/.platform/nginx.conf
+++ b/.platform/nginx.conf
@@ -49,6 +49,7 @@ http {
           proxy_set_header    Host                $host;
           proxy_set_header    X-Real-IP           $remote_addr;
           proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+          proxy_set_header    X-Forwarded-Proto   $scheme;
       }
 
       access_log    /var/log/nginx/access.log main;

--- a/src/main/java/com/kw/readwith/config/SecurityConfig.java
+++ b/src/main/java/com/kw/readwith/config/SecurityConfig.java
@@ -87,6 +87,7 @@ public class SecurityConfig {
 
         configuration.setAllowedOriginPatterns(Arrays.asList(
                 "http://localhost:5173",
+                "https://dev.readwith.store",
                 "https://readwith-frontend.vercel.app",
                 "https://readwith-frontend-*.vercel.app",
                 "https://*.vercel.app"

--- a/src/main/java/com/kw/readwith/service/normalization/NormalizationJobService.java
+++ b/src/main/java/com/kw/readwith/service/normalization/NormalizationJobService.java
@@ -22,6 +22,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.io.IOException;
@@ -48,37 +50,36 @@ public class NormalizationJobService {
     private final ObjectMapper objectMapper;
     private final PlatformTransactionManager transactionManager;
 
+    @Transactional(propagation = Propagation.MANDATORY)
     public ProcessingJob createQueuedJob(Book book, String sourceVersion, String triggeredBy) {
-        return writableTransaction().execute(status -> {
-            processingJobRepository.findFirstByBookIdAndPipelineTypeAndStatusInOrderByCreatedAtDesc(
-                            book.getId(),
-                            ProcessingPipelineType.NORMALIZATION,
-                            EnumSet.of(ProcessingJobStatus.QUEUED, ProcessingJobStatus.PROCESSING)
-                    )
-                    .ifPresent(existing -> {
-                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "A normalization job is already active for this book.");
-                    });
+        processingJobRepository.findFirstByBookIdAndPipelineTypeAndStatusInOrderByCreatedAtDesc(
+                        book.getId(),
+                        ProcessingPipelineType.NORMALIZATION,
+                        EnumSet.of(ProcessingJobStatus.QUEUED, ProcessingJobStatus.PROCESSING)
+                )
+                .ifPresent(existing -> {
+                    throw new GeneralException(ErrorStatus._BAD_REQUEST, "A normalization job is already active for this book.");
+                });
 
-            ProcessingJob job = ProcessingJob.builder()
-                    .book(book)
-                    .pipelineType(ProcessingPipelineType.NORMALIZATION)
-                    .runId(normalizedArtifactStorageService.newNormalizationRunId())
-                    .sourceVersion(sourceVersion)
-                    .ruleVersion(epubNormalizationProperties.getRuleVersion())
-                    .locatorVersion(epubNormalizationProperties.getLocatorVersion())
-                    .status(ProcessingJobStatus.QUEUED)
-                    .currentStep("queued")
-                    .triggeredBy(triggeredBy)
-                    .build();
+        ProcessingJob job = ProcessingJob.builder()
+                .book(book)
+                .pipelineType(ProcessingPipelineType.NORMALIZATION)
+                .runId(normalizedArtifactStorageService.newNormalizationRunId())
+                .sourceVersion(sourceVersion)
+                .ruleVersion(epubNormalizationProperties.getRuleVersion())
+                .locatorVersion(epubNormalizationProperties.getLocatorVersion())
+                .status(ProcessingJobStatus.QUEUED)
+                .currentStep("queued")
+                .triggeredBy(triggeredBy)
+                .build();
 
-            ProcessingJob savedJob = processingJobRepository.save(job);
-            writeLog(savedJob, ProcessingJobLogLevel.INFO, "queued", "Normalization job has been queued.", Map.of(
-                    "runId", savedJob.getRunId(),
-                    "ruleVersion", epubNormalizationProperties.getRuleVersion(),
-                    "locatorVersion", epubNormalizationProperties.getLocatorVersion()
-            ));
-            return savedJob;
-        });
+        ProcessingJob savedJob = processingJobRepository.save(job);
+        writeLog(savedJob, ProcessingJobLogLevel.INFO, "queued", "Normalization job has been queued.", Map.of(
+                "runId", savedJob.getRunId(),
+                "ruleVersion", epubNormalizationProperties.getRuleVersion(),
+                "locatorVersion", epubNormalizationProperties.getLocatorVersion()
+        ));
+        return savedJob;
     }
 
     public void execute(Long jobId) {

--- a/src/test/java/com/kw/readwith/config/V2ApiContractInterceptorTest.java
+++ b/src/test/java/com/kw/readwith/config/V2ApiContractInterceptorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.method.HandlerMethod;
 
 import java.lang.reflect.Method;
@@ -13,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class V2ApiContractInterceptorTest {
+public class V2ApiContractInterceptorTest {
 
     private final ApiContractProperties apiContractProperties = new ApiContractProperties();
     private final V2ApiContractInterceptor interceptor = new V2ApiContractInterceptor(apiContractProperties);
@@ -49,6 +50,20 @@ class V2ApiContractInterceptorTest {
 
         assertAllowed("/api/books/1/manifest");
         assertAllowed("/api/progress/1");
+    }
+
+    @Test
+    @DisplayName("dev swagger UI origin??epub upload CORS??허용한다")
+    void allowsDevSwaggerUiOriginForUploadCors() {
+        SecurityConfig securityConfig = new SecurityConfig(null, null, null);
+        MockHttpServletRequest request = new MockHttpServletRequest("OPTIONS", "/api/v2/books");
+        request.addHeader("Origin", "https://dev.readwith.store");
+
+        CorsConfiguration corsConfiguration = securityConfig.corsConfigurationSource().getCorsConfiguration(request);
+
+        assertThat(corsConfiguration).isNotNull();
+        assertThat(corsConfiguration.checkOrigin("https://dev.readwith.store"))
+                .isEqualTo("https://dev.readwith.store");
     }
 
     private void assertBlocked(String requestUri) {

--- a/src/test/java/com/kw/readwith/service/normalization/NormalizationJobServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/normalization/NormalizationJobServiceTest.java
@@ -1,0 +1,117 @@
+package com.kw.readwith.service.normalization;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kw.readwith.config.EpubNormalizationProperties;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.enums.ProcessingJobLogLevel;
+import com.kw.readwith.domain.enums.ProcessingJobStatus;
+import com.kw.readwith.domain.enums.ProcessingPipelineType;
+import com.kw.readwith.domain.processing.ProcessingJob;
+import com.kw.readwith.domain.processing.ProcessingJobLog;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import com.kw.readwith.repository.ProcessingJobLogRepository;
+import com.kw.readwith.repository.ProcessingJobRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class NormalizationJobServiceTest {
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private ChapterRepository chapterRepository;
+
+    @Mock
+    private ProcessingJobRepository processingJobRepository;
+
+    @Mock
+    private ProcessingJobLogRepository processingJobLogRepository;
+
+    @Mock
+    private NormalizationPipelineService normalizationPipelineService;
+
+    @Mock
+    private NormalizedArtifactStorageService normalizedArtifactStorageService;
+
+    @Mock
+    private LocatorResolutionService locatorResolutionService;
+
+    @Mock
+    private PlatformTransactionManager transactionManager;
+
+    private final EpubNormalizationProperties epubNormalizationProperties = new EpubNormalizationProperties();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private NormalizationJobService normalizationJobService;
+
+    @BeforeEach
+    void setUp() {
+        epubNormalizationProperties.setRuleVersion("rule-v1");
+        epubNormalizationProperties.setLocatorVersion("locator-v2");
+    }
+
+    @Test
+    @DisplayName("createQueuedJob uses the caller transaction for upload flow")
+    void createQueuedJobUsesCallerTransaction() {
+        Book book = Book.builder()
+                .title("Title")
+                .author("Author")
+                .language("en")
+                .build();
+        ReflectionTestUtils.setField(book, "id", 10L);
+
+        when(processingJobRepository.findFirstByBookIdAndPipelineTypeAndStatusInOrderByCreatedAtDesc(
+                10L,
+                ProcessingPipelineType.NORMALIZATION,
+                java.util.EnumSet.of(ProcessingJobStatus.QUEUED, ProcessingJobStatus.PROCESSING)
+        )).thenReturn(Optional.empty());
+        when(normalizedArtifactStorageService.newNormalizationRunId()).thenReturn("run-1");
+        when(processingJobRepository.save(any(ProcessingJob.class))).thenAnswer(invocation -> {
+            ProcessingJob savedJob = invocation.getArgument(0);
+            ReflectionTestUtils.setField(savedJob, "id", 55L);
+            return savedJob;
+        });
+        when(processingJobLogRepository.countByJobId(55L)).thenReturn(0L);
+
+        ProcessingJob job = normalizationJobService.createQueuedJob(book, "source-v1", "UPLOAD");
+
+        ArgumentCaptor<ProcessingJob> jobCaptor = ArgumentCaptor.forClass(ProcessingJob.class);
+        ArgumentCaptor<ProcessingJobLog> logCaptor = ArgumentCaptor.forClass(ProcessingJobLog.class);
+        verify(processingJobRepository).save(jobCaptor.capture());
+        verify(processingJobLogRepository).save(logCaptor.capture());
+        verifyNoInteractions(transactionManager);
+
+        ProcessingJob savedJob = jobCaptor.getValue();
+        ProcessingJobLog savedLog = logCaptor.getValue();
+
+        assertThat(job.getId()).isEqualTo(55L);
+        assertThat(savedJob.getBook()).isSameAs(book);
+        assertThat(savedJob.getStatus()).isEqualTo(ProcessingJobStatus.QUEUED);
+        assertThat(savedJob.getCurrentStep()).isEqualTo("queued");
+        assertThat(savedJob.getRunId()).isEqualTo("run-1");
+        assertThat(savedJob.getRuleVersion()).isEqualTo("rule-v1");
+        assertThat(savedJob.getLocatorVersion()).isEqualTo("locator-v2");
+        assertThat(savedLog.getLevel()).isEqualTo(ProcessingJobLogLevel.INFO);
+        assertThat(savedLog.getStep()).isEqualTo("queued");
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
엔드투엔드 테스트 중 확인된 EPUB 업로드 실패 2건을 함께 수정했습니다.
Swagger UI에서 `POST /api/v2/books` 호출 시 발생하던 `403 Invalid CORS request`와,
업로드 직후 `processing_job` 생성 과정에서 발생하던 `Lock wait timeout` 기반 `500`을 해결했습니다.

## 📋 변경 사항
- `https://dev.readwith.store`를 CORS 허용 origin에 추가했습니다.
- nginx 프록시에서 `X-Forwarded-Proto`를 백엔드로 전달하도록 수정했습니다.
- 업로드 시 `processing_job` 생성이 별도 `REQUIRES_NEW` 트랜잭션으로 분리되지 않도록 변경했습니다.
- `createQueuedJob()`이 호출자 트랜잭션에 합류하도록 조정해, 미커밋 `book` 행 참조로 인한 FK/락 대기를 제거했습니다.
- 관련 설정/서비스 테스트 코드를 보강했습니다.

## 🔍 Code Review
- `POST /api/v2/books`가 브라우저 환경에서 `https://dev.readwith.store` origin으로 정상 통과하는지 확인 부탁드립니다.
- EPUB 업로드 후 `processing_job`가 같은 업로드 트랜잭션에서 생성되고, 커밋 이후 dispatch만 수행되는 흐름이 의도와 맞는지 확인 부탁드립니다.
- 기존 정규화 실행 경로에서 `transitionToProcessing`, `advanceStep`, `completeSuccess`, `completeFailure`는 계속 독립 트랜잭션으로 동작하는 점 확인 부탁드립니다.


## 📸 ScreenShot
