### PR TITLE
fix: S3 chapter txt를 기준으로 이벤트를 검증하도록 raw_text projection 구조 개선

### DIFF
--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -17,6 +17,7 @@ import com.kw.readwith.dto.admin.*;
 import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.dto.common.LocatorDTO;
 import com.kw.readwith.repository.*;
+import com.kw.readwith.service.normalization.NormalizedArtifactStorageService;
 import com.kw.readwith.service.normalization.NormalizationVersionService;
 import com.kw.readwith.util.LocatorSupport;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +61,7 @@ public class AdminService {
     private final LocatorSupport locatorSupport;
     private final V2TransitionGuard transitionGuard;
     private final NormalizationVersionService normalizationVersionService;
+    private final NormalizedArtifactStorageService normalizedArtifactStorageService;
     
     @PersistenceContext
     private EntityManager entityManager;
@@ -176,6 +179,7 @@ public class AdminService {
 
         try {
             List<Event> allNewEvents = new ArrayList<>();
+            Map<Integer, String> chapterTextCache = new HashMap<>();
 
             for (MultipartFile eventFile : eventFiles) {
                 if (eventFile == null || eventFile.isEmpty()) {
@@ -203,6 +207,10 @@ public class AdminService {
                         log.warn("No events found in file {}", eventFile.getOriginalFilename());
                         continue;
                     }
+                    String chapterText = chapterTextCache.computeIfAbsent(
+                            chapterIdx,
+                            idx -> loadNormalizedChapterText(book, idx)
+                    );
 
                     Set<Integer> seenEventIndexes = new LinkedHashSet<>();
                     List<Event> newEventsFromFile = new ArrayList<>();
@@ -222,7 +230,7 @@ public class AdminService {
                         }
 
                         String rawText = requireRawText(dto.getEventText() != null ? dto.getEventText() : dto.getText(), "event.eventText");
-                        validateEventText(chapter, startTxtOffset, endTxtOffset, rawText, eventId);
+                        validateEventText(chapterText, startTxtOffset, endTxtOffset, rawText, eventId);
 
                         Integer eventIdx = parseEventIdx(eventId, chapterIdx);
                         if (!seenEventIndexes.add(eventIdx)) {
@@ -837,8 +845,21 @@ public class AdminService {
         throw new GeneralException(ErrorStatus._BAD_REQUEST, fieldName + " ?類ㅻ뻼????而?몴?? ??녿뮸??덈뼄: " + rawValue);
     }
 
-    private void validateEventText(Chapter chapter, int startTxtOffset, int endTxtOffset, String eventText, String eventId) {
-        String chapterText = normalizeChapterText(chapter.getRawText());
+    private String loadNormalizedChapterText(Book book, int chapterIdx) {
+        String artifactRoot = book.getNormalizedArtifactPath();
+        if (artifactRoot == null || artifactRoot.isBlank()) {
+            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "Normalized chapter text is not available for validation.");
+        }
+
+        try {
+            return normalizeChapterText(normalizedArtifactStorageService.loadNormalizedChapterText(artifactRoot, chapterIdx));
+        } catch (RuntimeException e) {
+            log.error("Failed to load normalized chapter text. bookId={}, chapterIdx={}", book.getId(), chapterIdx, e);
+            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "Failed to load normalized chapter text for validation.");
+        }
+    }
+
+    private void validateEventText(String chapterText, int startTxtOffset, int endTxtOffset, String eventText, String eventId) {
         if (chapterText == null) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST, "筌?벤苑??癒???餓Β??쑬由븝쭪? ??녿툡 eventText??野꺜筌앹빜釉?????곷뮸??덈뼄.");
         }

--- a/src/main/java/com/kw/readwith/service/normalization/NormalizationJobService.java
+++ b/src/main/java/com/kw/readwith/service/normalization/NormalizationJobService.java
@@ -39,6 +39,8 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class NormalizationJobService {
 
+    private static final int CHAPTER_RAW_TEXT_PREVIEW_CODE_POINTS = 2000;
+
     private final BookRepository bookRepository;
     private final ChapterRepository chapterRepository;
     private final ProcessingJobRepository processingJobRepository;
@@ -245,7 +247,7 @@ public class NormalizationJobService {
                             artifact.getTotalCodePoints(),
                             artifact.getStartPos(),
                             artifact.getEndPos(),
-                            artifact.getRawText()
+                            buildRawTextPreview(artifact.getRawText())
                     );
                     return chapter;
                 })
@@ -290,6 +292,20 @@ public class NormalizationJobService {
         } catch (JsonProcessingException e) {
             return "{\"serializationError\":true}";
         }
+    }
+
+    private String buildRawTextPreview(String rawText) {
+        if (rawText == null || rawText.isEmpty()) {
+            return null;
+        }
+
+        int totalCodePoints = rawText.codePointCount(0, rawText.length());
+        if (totalCodePoints <= CHAPTER_RAW_TEXT_PREVIEW_CODE_POINTS) {
+            return rawText;
+        }
+
+        int previewEndIndex = rawText.offsetByCodePoints(0, CHAPTER_RAW_TEXT_PREVIEW_CODE_POINTS);
+        return rawText.substring(0, previewEndIndex);
     }
 
     private TransactionTemplate writableTransaction() {

--- a/src/main/java/com/kw/readwith/service/normalization/NormalizedArtifactStorageService.java
+++ b/src/main/java/com/kw/readwith/service/normalization/NormalizedArtifactStorageService.java
@@ -57,6 +57,13 @@ public class NormalizedArtifactStorageService {
         }
     }
 
+    public String loadNormalizedChapterText(String artifactRoot, int chapterIndex) {
+        return new String(
+                loadPrivateObject(buildChapterTextRelativePath(artifactRoot, chapterIndex)),
+                StandardCharsets.UTF_8
+        );
+    }
+
     public String storeNormalizationArtifacts(Long bookId, String runId, NormalizationPipelineResult result) {
         String artifactRoot = buildArtifactRoot(bookId, runId);
         try {
@@ -86,7 +93,7 @@ public class NormalizedArtifactStorageService {
                         "application/xhtml+xml"
                 );
                 amazonS3Manager.uploadBytes(
-                        privateKey(artifactRoot + "/text/" + chapterFileName + ".txt"),
+                        privateKey(buildChapterTextRelativePath(artifactRoot, chapter.getChapterIndex())),
                         chapter.getRawText().getBytes(StandardCharsets.UTF_8),
                         "text/plain"
                 );
@@ -118,6 +125,10 @@ public class NormalizedArtifactStorageService {
 
     private String buildArtifactRoot(Long bookId, String runId) {
         return "books/" + bookId + "/normalizations/" + runId;
+    }
+
+    private String buildChapterTextRelativePath(String artifactRoot, int chapterIndex) {
+        return artifactRoot + "/text/" + String.format("chapter_%03d.txt", chapterIndex);
     }
 
     private String publicKey(String relativePath) {

--- a/src/test/java/com/kw/readwith/service/AdminServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/AdminServiceTest.java
@@ -3,6 +3,7 @@ package com.kw.readwith.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.config.V2TransitionGuard;
 import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.Character;
@@ -10,7 +11,18 @@ import com.kw.readwith.domain.Event;
 import com.kw.readwith.domain.mapping.EventCharacterStat;
 import com.kw.readwith.domain.mapping.EventRelationshipEdge;
 import com.kw.readwith.dto.admin.UnsummarizedItemDTO;
-import com.kw.readwith.repository.*;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.CharacterPovSummaryRepository;
+import com.kw.readwith.repository.CharacterRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import com.kw.readwith.repository.EventCharacterStatRepository;
+import com.kw.readwith.repository.EventRelationshipEdgeRepository;
+import com.kw.readwith.repository.EventRepository;
+import com.kw.readwith.service.normalization.NormalizationVersionService;
+import com.kw.readwith.service.normalization.NormalizedArtifactStorageService;
+import com.kw.readwith.util.LocatorSupport;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,8 +32,8 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -29,8 +41,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -55,205 +67,296 @@ class AdminServiceTest {
     private EventCharacterStatRepository statRepository;
     @Mock
     private CharacterPovSummaryRepository characterPovSummaryRepository;
+    @Mock
+    private CharacterImageService characterImageService;
+    @Mock
+    private BookAnalysisStatusService bookAnalysisStatusService;
+    @Mock
+    private LocatorSupport locatorSupport;
+    @Mock
+    private V2TransitionGuard transitionGuard;
+    @Mock
+    private NormalizationVersionService normalizationVersionService;
+    @Mock
+    private NormalizedArtifactStorageService normalizedArtifactStorageService;
+    @Mock
+    private EntityManager entityManager;
 
     @Spy
     private ObjectMapper objectMapper;
 
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(adminService, "entityManager", entityManager);
+    }
+
     @Test
-    @DisplayName("요약 안된 챕터 조회 시, DTO 리스트를 정확히 반환한다.")
+    @DisplayName("getUnsummarizedChapters returns DTOs from repository chapters")
     void getUnsummarizedChapters() {
-        // given
-        Book mockBook = Book.builder().id(1L).title("테스트 책").build();
-        Chapter mockChapter = Chapter.builder().id(10L).title("테스트 챕터").book(mockBook).build();
-        List<Chapter> mockChapters = List.of(mockChapter);
+        Book book = Book.builder().id(1L).title("Test Book").build();
+        Chapter chapter = Chapter.builder().id(10L).title("Test Chapter").book(book).build();
 
-        given(chapterRepository.findUnsummarizedChapters()).willReturn(mockChapters);
+        given(chapterRepository.findUnsummarizedChapters()).willReturn(List.of(chapter));
 
-        // when
         List<UnsummarizedItemDTO> result = adminService.getUnsummarizedChapters();
 
-        // then
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getId()).isEqualTo(10L);
-        assertThat(result.get(0).getName()).isEqualTo("테스트 챕터"); // 실제 필드명 'name' 사용
-        assertThat(result.get(0).getBookTitle()).isEqualTo("테스트 책"); // 실제 필드명 'bookTitle' 사용
+        assertThat(result.get(0).getName()).isEqualTo("Test Chapter");
+        assertThat(result.get(0).getBookTitle()).isEqualTo("Test Book");
         verify(chapterRepository, times(1)).findUnsummarizedChapters();
     }
-    
+
     @Test
-    @DisplayName("인물 정보 업로드 시, 새로운 인물만 정확히 저장된다.")
+    @DisplayName("uploadCharacters saves parsed characters")
     void uploadCharacters_savesNewCharacters() throws IOException {
-        // given
         Long bookId = 1L;
-        String jsonContent = "{\"characters\": [{\"id\": 1, \"common_name\": \"새로운 인물\", \"names\": [\"별명\"], \"main_character\": true, \"description\": \"설명\", \"portrait_prompt\": \"프롬프트\"}]}";
-        MockMultipartFile file = new MockMultipartFile("file", "characters.json", "application/json", jsonContent.getBytes());
+        String jsonContent = """
+                {
+                  "characters": [
+                    {
+                      "id": "1",
+                      "common_name": "Harry Potter",
+                      "names": ["The Boy Who Lived"],
+                      "descriptions": {
+                        "ko": "wizard"
+                      },
+                      "portrait_prompt": "portrait prompt"
+                    }
+                  ]
+                }
+                """;
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "characters.json",
+                "application/json",
+                jsonContent.getBytes(StandardCharsets.UTF_8)
+        );
 
-        Book mockBook = Book.builder().id(bookId).build();
-        given(bookRepository.findById(bookId)).willReturn(Optional.of(mockBook));
-        // '새로운 인물'은 DB에 없다고 가정
-        given(characterRepository.findByBookAndName(mockBook, "새로운 인물")).willReturn(Optional.empty());
+        Book book = Book.builder().id(bookId).build();
+        given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
+        given(characterRepository.findByBookAndCharacterId(book, 1L)).willReturn(Optional.empty());
+        given(characterRepository.saveAll(anyList())).willAnswer(invocation -> invocation.getArgument(0));
 
-        // when
         adminService.uploadCharacters(bookId, file);
 
-        // then
         ArgumentCaptor<List<Character>> captor = ArgumentCaptor.forClass(List.class);
         verify(characterRepository, times(1)).saveAll(captor.capture());
         List<Character> savedCharacters = captor.getValue();
         assertThat(savedCharacters).hasSize(1);
-        assertThat(savedCharacters.get(0).getName()).isEqualTo("새로운 인물");
+        assertThat(savedCharacters.get(0).getName()).isEqualTo("Harry Potter");
     }
 
     @Test
-    @DisplayName("이벤트 정보 업로드 시, 데이터를 정확히 저장한다.")
+    @DisplayName("uploadEvents validates against normalized chapter text and saves events")
     void uploadEvents_savesEvents() throws IOException {
-        // given
         Long bookId = 1L;
         int chapterIdx = 1;
         String fileName = String.format("chapter%d_events.json", chapterIdx);
-        String jsonContent = "[{\"event_id\": 1, \"start\": 0, \"end\": 100, \"text\": \"이벤트 내용\"}]";
-        MockMultipartFile file = new MockMultipartFile("files", fileName, "application/json", jsonContent.getBytes());
+        String jsonContent = """
+                {
+                  "chapterIndex": 1,
+                  "items": [
+                    {
+                      "event_id": "ch1-e1",
+                      "startTxtOffset": 0,
+                      "endTxtOffset": 6,
+                      "eventText": "ABCDEF"
+                    }
+                  ]
+                }
+                """;
+        MockMultipartFile file = new MockMultipartFile(
+                "files",
+                fileName,
+                "application/json",
+                jsonContent.getBytes(StandardCharsets.UTF_8)
+        );
 
-        Book mockBook = Book.builder().id(bookId).build();
-        Chapter mockChapter = Chapter.builder().id(10L).book(mockBook).build();
+        Book book = Book.builder()
+                .id(bookId)
+                .normalizedArtifactPath("books/1/normalizations/run-1")
+                .build();
+        Chapter chapter = Chapter.builder()
+                .id(10L)
+                .idx(chapterIdx)
+                .book(book)
+                .rawText("preview only")
+                .build();
 
-        given(bookRepository.findById(bookId)).willReturn(Optional.of(mockBook));
-        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(mockChapter));
-        given(eventRepository.existsByChapter(mockChapter)).willReturn(false);
+        given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
+        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(chapter));
+        given(eventRepository.existsByChapter(chapter)).willReturn(false);
+        given(eventRepository.saveAll(anyList())).willAnswer(invocation -> invocation.getArgument(0));
+        given(normalizedArtifactStorageService.loadNormalizedChapterText("books/1/normalizations/run-1", chapterIdx))
+                .willReturn("ABCDEF");
 
-        // when
         adminService.uploadEvents(bookId, List.of(file));
 
-        // then
         ArgumentCaptor<List<Event>> captor = ArgumentCaptor.forClass(List.class);
         verify(eventRepository, times(1)).saveAll(captor.capture());
         List<Event> savedEvents = captor.getValue();
         assertThat(savedEvents).hasSize(1);
         assertThat(savedEvents.get(0).getIdx()).isEqualTo(1);
-        assertThat(savedEvents.get(0).getRawText()).isEqualTo("이벤트 내용");
+        assertThat(savedEvents.get(0).getRawText()).isEqualTo("ABCDEF");
+        verify(normalizedArtifactStorageService, times(1))
+                .loadNormalizedChapterText("books/1/normalizations/run-1", chapterIdx);
     }
 
     @Test
-    @DisplayName("이벤트 정보 업로드 시, 데이터가 이미 존재하면 예외를 발생시킨다.")
+    @DisplayName("uploadEvents rejects a chapter that already has events")
     void uploadEvents_throwsException_whenDataExists() throws IOException {
-        // given
         Long bookId = 1L;
         int chapterIdx = 1;
         String fileName = String.format("chapter%d_events.json", chapterIdx);
-        MockMultipartFile file = new MockMultipartFile("files", fileName, "application/json", "[]".getBytes());
+        String jsonContent = """
+                {
+                  "chapterIndex": 1,
+                  "items": []
+                }
+                """;
+        MockMultipartFile file = new MockMultipartFile(
+                "files",
+                fileName,
+                "application/json",
+                jsonContent.getBytes(StandardCharsets.UTF_8)
+        );
 
-        Book mockBook = Book.builder().id(bookId).build();
-        Chapter mockChapter = Chapter.builder().id(10L).book(mockBook).build();
+        Book book = Book.builder().id(bookId).normalizedArtifactPath("books/1/normalizations/run-1").build();
+        Chapter chapter = Chapter.builder().id(10L).idx(chapterIdx).book(book).build();
 
-        given(bookRepository.findById(bookId)).willReturn(Optional.of(mockBook));
-        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(mockChapter));
-        // 데이터가 이미 존재한다고 가정
-        given(eventRepository.existsByChapter(mockChapter)).willReturn(true);
+        given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
+        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(chapter));
+        given(eventRepository.existsByChapter(chapter)).willReturn(true);
 
-        // when & then
         GeneralException exception = assertThrows(GeneralException.class, () -> adminService.uploadEvents(bookId, List.of(file)));
+
         assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.EVENT_DATA_ALREADY_EXISTS);
     }
 
     @Test
-    @DisplayName("챕터 요약본 업로드 시, 데이터를 정확히 저장한다.")
+    @DisplayName("uploadChapterSummaries saves summaries and updates chapter state")
     void uploadChapterSummaries_savesSummaries() throws IOException {
-        // given
         Long bookId = 1L;
         int chapterIdx = 1;
         String fileName = String.format("chapter%d_perspective_summaries.json", chapterIdx);
-        String jsonContent = "{\"10\": {\"character_name\": \"인물1\", \"summary\": \"요약 내용\"}}";
-        MockMultipartFile file = new MockMultipartFile("files", fileName, "application/json", jsonContent.getBytes());
+        String jsonContent = """
+                {
+                  "chapterIndex": 1,
+                  "language": "ko",
+                  "items": [
+                    {
+                      "characterId": "10",
+                      "characterName": "character-1",
+                      "summary": "summary text"
+                    }
+                  ]
+                }
+                """;
+        MockMultipartFile file = new MockMultipartFile(
+                "files",
+                fileName,
+                "application/json",
+                jsonContent.getBytes(StandardCharsets.UTF_8)
+        );
 
-        Book mockBook = Book.builder().id(bookId).build();
-        Chapter mockChapter = Chapter.builder().id(10L).book(mockBook).build();
-        Character mockCharacter = Character.builder().id(1L).build();
+        Book book = Book.builder().id(bookId).build();
+        Chapter chapter = Chapter.builder().id(10L).idx(chapterIdx).book(book).build();
+        Character character = Character.builder().id(1L).build();
 
-        given(bookRepository.findById(bookId)).willReturn(Optional.of(mockBook));
-        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(mockChapter));
-        given(characterPovSummaryRepository.existsByChapter(mockChapter)).willReturn(false);
-        given(characterRepository.findByBookAndCharacterId(mockBook, 10L)).willReturn(Optional.of(mockCharacter));
+        given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
+        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(chapter));
+        given(characterPovSummaryRepository.existsByChapter(chapter)).willReturn(false);
+        given(characterRepository.findByBookAndCharacterId(book, 10L)).willReturn(Optional.of(character));
+        given(chapterRepository.findByBookId(bookId)).willReturn(List.of(chapter));
 
-        // when
         adminService.uploadChapterSummaries(bookId, List.of(file));
 
-        // then
         verify(characterPovSummaryRepository, times(1)).saveAll(anyList());
-        assertThat(mockChapter.isPovSummariesCached()).isTrue();
+        assertThat(chapter.isPovSummariesCached()).isTrue();
     }
 
     @Test
-    @DisplayName("챕터 요약본 업로드 시, 요약본이 이미 존재하면 예외를 발생시킨다.")
+    @DisplayName("uploadChapterSummaries rejects a chapter that is already summarized")
     void uploadChapterSummaries_throwsException_whenSummaryExists() throws IOException {
-        // given
         Long bookId = 1L;
         int chapterIdx = 1;
         String fileName = String.format("chapter%d_perspective_summaries.json", chapterIdx);
-        MockMultipartFile file = new MockMultipartFile("files", fileName, "application/json", "{}".getBytes());
+        String jsonContent = """
+                {
+                  "chapterIndex": 1,
+                  "language": "ko",
+                  "items": []
+                }
+                """;
+        MockMultipartFile file = new MockMultipartFile(
+                "files",
+                fileName,
+                "application/json",
+                jsonContent.getBytes(StandardCharsets.UTF_8)
+        );
 
-        Book mockBook = Book.builder().id(bookId).build();
-        Chapter mockChapter = Chapter.builder().id(10L).book(mockBook).build();
+        Book book = Book.builder().id(bookId).build();
+        Chapter chapter = Chapter.builder().id(10L).idx(chapterIdx).book(book).build();
 
-        given(bookRepository.findById(bookId)).willReturn(Optional.of(mockBook));
-        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(mockChapter));
-        // 요약본이 이미 존재한다고 가정
-        given(characterPovSummaryRepository.existsByChapter(mockChapter)).willReturn(true);
+        given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
+        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(chapter));
+        given(characterPovSummaryRepository.existsByChapter(chapter)).willReturn(true);
 
-        // when & then
         GeneralException exception = assertThrows(GeneralException.class, () -> adminService.uploadChapterSummaries(bookId, List.of(file)));
+
         assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.CHAPTER_ALREADY_SUMMARIZED);
     }
 
     @Test
-    @DisplayName("관계 정보 파일 업로드 시, DTO 구조에 맞는 JSON을 파싱하여 관계 데이터를 정확히 저장한다.")
+    @DisplayName("uploadRelationships saves node weights and edges from the current payload shape")
     void uploadRelationships_withCorrectJsonStructure() throws IOException {
-        // given
         Long bookId = 1L;
         int chapterIdx = 1;
         int eventIdx = 1;
         String fileName = String.format("chapter%d_something_event_%d.json", chapterIdx, eventIdx);
+        String jsonContent = """
+                {
+                  "chapterIndex": 1,
+                  "eventId": "ch1-e1",
+                  "relations": [
+                    {
+                      "id1": "10",
+                      "id2": "20",
+                      "relation": ["friend"],
+                      "positivity": 0.9,
+                      "count": 5
+                    }
+                  ],
+                  "node_weights_accum": {
+                    "10": {
+                      "weight": 15.5,
+                      "count": 3
+                    }
+                  }
+                }
+                """;
+        MockMultipartFile file = new MockMultipartFile(
+                "files",
+                fileName,
+                "application/json",
+                jsonContent.getBytes(StandardCharsets.UTF_8)
+        );
 
-        // 실제 DTO 구조와 완벽하게 일치하는 JSON 문자열 생성
-        String jsonContent = "{\n" +
-                "  \"relations\": [\n" +
-                "    {\n" +
-                "      \"id1\": 10,\n" +
-                "      \"id2\": 20,\n" +
-                "      \"relation\": [\"friend\"],\n" +
-                "      \"positivity\": 0.9,\n" +
-                "      \"weight\": 0.8,\n" +
-                "      \"count\": 5\n" +
-                "    }\n" +
-                "  ],\n" +
-                "  \"node_weights_accum\": {\n" +
-                "    \"10\": {\n" +
-                "      \"weight\": 15.5,\n" +
-                "      \"count\": 3\n" +
-                "    }\n" +
-                "  },\n" +
-                "  \"log\": {}\n" +
-                "}";
+        Book book = Book.builder().id(bookId).build();
+        Event event = Event.builder().id(100L).build();
+        Character fromChar = Character.builder().id(10L).name("from").build();
+        Character toChar = Character.builder().id(20L).name("to").build();
 
-        MockMultipartFile mockFile = new MockMultipartFile("files", fileName, "application/json", jsonContent.getBytes(StandardCharsets.UTF_8));
-
-        Book mockBook = Book.builder().id(bookId).build();
-        Event mockEvent = Event.builder().id(100L).build();
-        Character fromChar = Character.builder().id(10L).name("캐릭터1").build();
-        Character toChar = Character.builder().id(20L).name("캐릭터2").build();
-
-        // Mock Repository 설정
-        given(bookRepository.findById(bookId)).willReturn(Optional.of(mockBook));
-        given(eventRepository.findByBookIdAndChapterIdxAndEventIdx(bookId, chapterIdx, eventIdx)).willReturn(Optional.of(mockEvent));
-        given(characterRepository.findByBookAndCharacterId(mockBook, 10L)).willReturn(Optional.of(fromChar));
-        given(characterRepository.findByBookAndCharacterId(mockBook, 20L)).willReturn(Optional.of(toChar));
+        given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
+        given(eventRepository.findByBookIdAndChapterIdxAndEventIdx(bookId, chapterIdx, eventIdx)).willReturn(Optional.of(event));
+        given(characterRepository.findByBookAndCharacterId(book, 10L)).willReturn(Optional.of(fromChar));
+        given(characterRepository.findByBookAndCharacterId(book, 20L)).willReturn(Optional.of(toChar));
         given(statRepository.findByEventAndCharacter(any(), any())).willReturn(Optional.empty());
         given(eventRelationshipEdgeRepository.existsByEventAndFromCharacterAndToCharacter(any(), any(), any())).willReturn(false);
 
-        // when
-        adminService.uploadRelationships(bookId, List.of(mockFile));
+        adminService.uploadRelationships(bookId, List.of(file));
 
-        // then
-        // 1. 가중치(Stat) 저장 검증
         ArgumentCaptor<List<EventCharacterStat>> statCaptor = ArgumentCaptor.forClass(List.class);
         verify(statRepository, times(1)).saveAll(statCaptor.capture());
         List<EventCharacterStat> savedStats = statCaptor.getValue();
@@ -261,7 +364,6 @@ class AdminServiceTest {
         assertThat(savedStats.get(0).getCharacter().getId()).isEqualTo(10L);
         assertThat(savedStats.get(0).getNodeWeight()).isEqualTo(15.5);
 
-        // 2. 관계(Edge) 저장 검증
         ArgumentCaptor<List<EventRelationshipEdge>> edgeCaptor = ArgumentCaptor.forClass(List.class);
         verify(eventRelationshipEdgeRepository, times(1)).saveAll(edgeCaptor.capture());
         List<EventRelationshipEdge> savedEdges = edgeCaptor.getValue();
@@ -273,147 +375,141 @@ class AdminServiceTest {
     }
 
     @Test
-    @DisplayName("관계 정보 업로드 시, 데이터가 이미 존재하면 예외를 발생시킨다.")
+    @DisplayName("uploadRelationships rejects duplicate relationship data")
     void uploadRelationships_throwsException_whenDataExists() throws IOException {
-        // given
         Long bookId = 1L;
         int chapterIdx = 1;
         int eventIdx = 1;
         String fileName = String.format("chapter%d_something_event_%d.json", chapterIdx, eventIdx);
-        // 테스트에 필요한 최소한의 JSON 구조
-        String jsonContent = "{\"relations\": [{\"id1\": 10, \"id2\": 20, \"relation\": [\"friend\"], \"positivity\": 0.9, \"count\": 1}]}";
-        MockMultipartFile mockFile = new MockMultipartFile("files", fileName, "application/json", jsonContent.getBytes(StandardCharsets.UTF_8));
+        String jsonContent = """
+                {
+                  "chapterIndex": 1,
+                  "eventId": "ch1-e1",
+                  "relations": [
+                    {
+                      "id1": "10",
+                      "id2": "20",
+                      "relation": ["friend"],
+                      "positivity": 0.9,
+                      "count": 1
+                    }
+                  ]
+                }
+                """;
+        MockMultipartFile file = new MockMultipartFile(
+                "files",
+                fileName,
+                "application/json",
+                jsonContent.getBytes(StandardCharsets.UTF_8)
+        );
 
-        Book mockBook = Book.builder().id(bookId).build();
-        Event mockEvent = Event.builder().id(100L).build();
-        Character fromChar = Character.builder().id(10L).name("캐릭터1").build();
-        Character toChar = Character.builder().id(20L).name("캐릭터2").build();
+        Book book = Book.builder().id(bookId).build();
+        Event event = Event.builder().id(100L).build();
+        Character fromChar = Character.builder().id(10L).name("from").build();
+        Character toChar = Character.builder().id(20L).name("to").build();
 
-        given(bookRepository.findById(bookId)).willReturn(Optional.of(mockBook));
-        given(eventRepository.findByBookIdAndChapterIdxAndEventIdx(bookId, chapterIdx, eventIdx)).willReturn(Optional.of(mockEvent));
-        given(characterRepository.findByBookAndCharacterId(mockBook, 10L)).willReturn(Optional.of(fromChar));
-        given(characterRepository.findByBookAndCharacterId(mockBook, 20L)).willReturn(Optional.of(toChar));
+        given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
+        given(eventRepository.findByBookIdAndChapterIdxAndEventIdx(bookId, chapterIdx, eventIdx)).willReturn(Optional.of(event));
+        given(characterRepository.findByBookAndCharacterId(book, 10L)).willReturn(Optional.of(fromChar));
+        given(characterRepository.findByBookAndCharacterId(book, 20L)).willReturn(Optional.of(toChar));
+        given(eventRelationshipEdgeRepository.existsByEventAndFromCharacterAndToCharacter(event, fromChar, toChar)).willReturn(true);
 
-        // 관계가 이미 존재한다고 가정
-        given(eventRelationshipEdgeRepository.existsByEventAndFromCharacterAndToCharacter(mockEvent, fromChar, toChar)).willReturn(true);
-
-        // when & then
-        GeneralException exception = assertThrows(GeneralException.class, () -> {
-            adminService.uploadRelationships(bookId, List.of(mockFile));
-        });
+        GeneralException exception = assertThrows(GeneralException.class, () -> adminService.uploadRelationships(bookId, List.of(file)));
 
         assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.RELATIONSHIP_DATA_ALREADY_EXISTS);
     }
 
     @Test
-    @DisplayName("관계 정보 삭제 시, 올바른 Event로 Repository의 deleteByEvent를 호출한다.")
+    @DisplayName("deleteRelationships deletes edge data for an event")
     void deleteRelationships_callsDeleteByEvent() {
-        // given
         Long bookId = 1L;
         int chapterIdx = 1;
         int eventIdx = 1;
-        Chapter mockChapter = Chapter.builder().id(10L).build();
-        Event mockEvent = Event.builder().id(100L).build();
+        Chapter chapter = Chapter.builder().id(10L).build();
+        Event event = Event.builder().id(100L).build();
 
-        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(mockChapter));
-        given(eventRepository.findByChapterAndIdx(mockChapter, eventIdx)).willReturn(Optional.of(mockEvent));
-        // 삭제할 데이터가 존재한다고 가정
-        given(eventRelationshipEdgeRepository.existsByEvent(mockEvent)).willReturn(true);
+        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(chapter));
+        given(eventRepository.findByChapterAndIdx(chapter, eventIdx)).willReturn(Optional.of(event));
+        given(eventRelationshipEdgeRepository.existsByEvent(event)).willReturn(true);
+        given(statRepository.existsByEvent(event)).willReturn(false);
 
-        // when
         adminService.deleteRelationships(bookId, chapterIdx, eventIdx);
 
-        // then
-        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-        verify(eventRelationshipEdgeRepository, times(1)).deleteByEvent(eventCaptor.capture());
-        assertThat(eventCaptor.getValue().getId()).isEqualTo(mockEvent.getId());
+        verify(eventRelationshipEdgeRepository, times(1)).deleteByEvent(event);
     }
 
     @Test
-    @DisplayName("인물 정보 삭제 시, 올바른 Book으로 Repository의 deleteByBook을 호출한다.")
+    @DisplayName("deleteCharacters deletes by book when character data exists")
     void deleteCharacters_callsDeleteByBook() {
-        // given
         Long bookId = 1L;
-        Book mockBook = Book.builder().id(bookId).build();
+        Book book = Book.builder().id(bookId).build();
 
-        given(bookRepository.findById(bookId)).willReturn(Optional.of(mockBook));
-        // 삭제할 데이터가 존재한다고 가정
-        given(characterRepository.existsByBook(mockBook)).willReturn(true);
+        given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
+        given(characterRepository.existsByBook(book)).willReturn(true);
 
-        // when
         adminService.deleteCharacters(bookId);
 
-        // then
-        verify(characterRepository, times(1)).deleteByBook(mockBook);
+        verify(characterRepository, times(1)).deleteByBook(book);
     }
 
     @Test
-    @DisplayName("인물 정보 삭제 시, 삭제할 데이터가 없으면 예외를 발생시킨다.")
+    @DisplayName("deleteCharacters rejects when no character data exists")
     void deleteCharacters_throwsException_whenNoData() {
-        // given
         Long bookId = 1L;
-        Book mockBook = Book.builder().id(bookId).build();
+        Book book = Book.builder().id(bookId).build();
 
-        given(bookRepository.findById(bookId)).willReturn(Optional.of(mockBook));
-        // 삭제할 데이터가 없다고 가정
-        given(characterRepository.existsByBook(mockBook)).willReturn(false);
+        given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
+        given(characterRepository.existsByBook(book)).willReturn(false);
 
-        // when & then
         GeneralException exception = assertThrows(GeneralException.class, () -> adminService.deleteCharacters(bookId));
+
         assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.NO_CHARACTERS_TO_DELETE);
     }
 
     @Test
-    @DisplayName("이벤트 정보 삭제 시, 올바른 Chapter로 Repository의 deleteByChapter를 호출한다.")
+    @DisplayName("deleteEvents deletes by chapter when event data exists")
     void deleteEvents_callsDeleteByChapter() {
-        // given
         Long bookId = 1L;
         int chapterIdx = 1;
-        Chapter mockChapter = Chapter.builder().id(10L).build();
+        Chapter chapter = Chapter.builder().id(10L).build();
 
-        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(mockChapter));
-        given(eventRepository.existsByChapter(mockChapter)).willReturn(true);
+        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(chapter));
+        given(eventRepository.existsByChapter(chapter)).willReturn(true);
 
-        // when
         adminService.deleteEvents(bookId, chapterIdx);
 
-        // then
-        verify(eventRepository, times(1)).deleteByChapter(mockChapter);
+        verify(eventRepository, times(1)).deleteByChapter(chapter);
     }
 
     @Test
-    @DisplayName("이벤트 정보 삭제 시, 삭제할 데이터가 없으면 예외를 발생시킨다.")
+    @DisplayName("deleteEvents rejects when a chapter has no events")
     void deleteEvents_throwsException_whenNoData() {
-        // given
         Long bookId = 1L;
         int chapterIdx = 1;
-        Chapter mockChapter = Chapter.builder().id(10L).build();
+        Chapter chapter = Chapter.builder().id(10L).build();
 
-        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(mockChapter));
-        given(eventRepository.existsByChapter(mockChapter)).willReturn(false);
+        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(chapter));
+        given(eventRepository.existsByChapter(chapter)).willReturn(false);
 
-        // when & then
         GeneralException exception = assertThrows(GeneralException.class, () -> adminService.deleteEvents(bookId, chapterIdx));
+
         assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.NO_EVENTS_TO_DELETE);
     }
 
     @Test
-    @DisplayName("챕터 요약본 삭제 시, Repository의 deleteByChapter를 호출하고 챕터 상태를 변경한다.")
+    @DisplayName("deleteChapterSummary deletes summaries and resets chapter summary state")
     void deleteChapterSummary_deletesAndUpdatesStatus() {
-        // given
         Long bookId = 1L;
         int chapterIdx = 1;
-        Chapter mockChapter = Chapter.builder().id(10L).build();
-        mockChapter.markAsSummarized(); // 초기 상태: 요약 완료
+        Chapter chapter = Chapter.builder().id(10L).build();
+        chapter.markAsSummarized();
 
-        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(mockChapter));
-        given(characterPovSummaryRepository.existsByChapter(mockChapter)).willReturn(true);
+        given(chapterRepository.findByBookIdAndIdx(bookId, chapterIdx)).willReturn(Optional.of(chapter));
+        given(characterPovSummaryRepository.existsByChapter(chapter)).willReturn(true);
 
-        // when
         adminService.deleteChapterSummary(bookId, chapterIdx);
 
-        // then
-        verify(characterPovSummaryRepository, times(1)).deleteByChapter(mockChapter);
-        assertThat(mockChapter.isPovSummariesCached()).isFalse(); // 상태가 '미완료'로 변경되었는지 확인
+        verify(characterPovSummaryRepository, times(1)).deleteByChapter(chapter);
+        assertThat(chapter.isPovSummariesCached()).isFalse();
     }
 }

--- a/src/test/java/com/kw/readwith/service/normalization/NormalizationJobServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/normalization/NormalizationJobServiceTest.java
@@ -3,6 +3,7 @@ package com.kw.readwith.service.normalization;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kw.readwith.config.EpubNormalizationProperties;
 import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Chapter;
 import com.kw.readwith.domain.enums.ProcessingJobLogLevel;
 import com.kw.readwith.domain.enums.ProcessingJobStatus;
 import com.kw.readwith.domain.enums.ProcessingPipelineType;
@@ -17,12 +18,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,13 +62,24 @@ public class NormalizationJobServiceTest {
     private final EpubNormalizationProperties epubNormalizationProperties = new EpubNormalizationProperties();
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    @InjectMocks
     private NormalizationJobService normalizationJobService;
 
     @BeforeEach
     void setUp() {
         epubNormalizationProperties.setRuleVersion("rule-v1");
         epubNormalizationProperties.setLocatorVersion("locator-v2");
+        normalizationJobService = new NormalizationJobService(
+                bookRepository,
+                chapterRepository,
+                processingJobRepository,
+                processingJobLogRepository,
+                normalizationPipelineService,
+                normalizedArtifactStorageService,
+                locatorResolutionService,
+                epubNormalizationProperties,
+                objectMapper,
+                transactionManager
+        );
     }
 
     @Test
@@ -113,5 +125,44 @@ public class NormalizationJobServiceTest {
         assertThat(savedJob.getLocatorVersion()).isEqualTo("locator-v2");
         assertThat(savedLog.getLevel()).isEqualTo(ProcessingJobLogLevel.INFO);
         assertThat(savedLog.getStep()).isEqualTo("queued");
+    }
+
+    @Test
+    @DisplayName("projectChapters stores only a preview in chapter rawText")
+    void projectChaptersStoresRawTextPreview() {
+        Book book = Book.builder()
+                .title("Title")
+                .author("Author")
+                .language("en")
+                .build();
+        ReflectionTestUtils.setField(book, "id", 10L);
+
+        String longRawText = "a".repeat(2500);
+        NormalizedChapterArtifact artifact = NormalizedChapterArtifact.builder()
+                .chapterIndex(1)
+                .title("Chapter 1")
+                .spineHref("chapter-1.xhtml")
+                .paragraphStarts(List.of(0))
+                .paragraphLengths(List.of(longRawText.length()))
+                .totalCodePoints(longRawText.length())
+                .startPos(0)
+                .endPos(longRawText.length() - 1)
+                .rawText(longRawText)
+                .normalizedXhtml("<html/>")
+                .build();
+
+        when(chapterRepository.findByBookId(10L)).thenReturn(List.of());
+        when(locatorResolutionService.writeIntegerList(List.of(0))).thenReturn("[0]");
+        when(locatorResolutionService.writeIntegerList(List.of(longRawText.length()))).thenReturn("[" + longRawText.length() + "]");
+
+        ReflectionTestUtils.invokeMethod(normalizationJobService, "projectChapters", book, List.of(artifact));
+
+        ArgumentCaptor<List<Chapter>> chapterCaptor = ArgumentCaptor.forClass(List.class);
+        verify(chapterRepository).saveAll(chapterCaptor.capture());
+        List<Chapter> savedChapters = chapterCaptor.getValue();
+
+        assertThat(savedChapters).hasSize(1);
+        assertThat(savedChapters.get(0).getRawText()).hasSize(2000);
+        assertThat(savedChapters.get(0).getRawText()).isEqualTo("a".repeat(2000));
     }
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
정규화 projection 단계에서 `chapter.raw_text` 길이 초과로 `writing_projection`이 실패하던 문제를 수정했습니다.

이번 PR에서는 DB `chapter.raw_text`를 정규화 결과의 canonical source로 계속 유지하지 않고,
이미 normalization 산출물로 저장되고 있는 S3 `text/chapter_XXX.txt`를 이벤트 검증의 기준 원문으로 사용하도록 변경했습니다.
동시에 DB에는 preview 용도의 `raw_text`만 저장하도록 줄여 projection 실패를 방지했습니다.

## 📋 변경 사항
- 관리자 이벤트 업로드 검증 시 `chapter.raw_text` 대신 S3 `text/chapter_XXX.txt`를 읽어 exact offset 비교를 수행하도록 변경했습니다.
- 같은 업로드 요청 안에서는 챕터 텍스트를 캐시해서 반복 S3 조회를 줄였습니다.
- normalization projection 시 DB `chapter.raw_text`에는 전체 전문이 아니라 preview만 저장하도록 변경했습니다.
- normalized chapter txt를 읽기 위한 storage helper를 추가했습니다.
- 관련 테스트를 현재 DTO/검증 흐름에 맞게 정리하고, S3 chapter txt 검증 경로와 raw text preview 저장을 검증하는 테스트를 추가했습니다.

이번 방향으로 결정한 이유:
- 현재 검증은 `startTxtOffset`, `endTxtOffset` 기준의 정확 비교가 핵심이라 `contains`, `startsWith`, preview 기반 검증으로 바꾸면 검증 의미가 무너집니다.
- chapter 전문은 이미 normalization 산출물로 S3에 저장되고 있으므로, 이를 canonical source로 쓰는 것이 중복 저장을 줄이고 구조상 더 자연스럽습니다.
- DB 컬럼을 `MEDIUMTEXT`/`LONGTEXT`로 키우는 방법도 가능하지만, 검증 기준 원문을 계속 DB에 중복 저장하게 되어 데이터 증가와 조회 부담이 남습니다.
- manifest 쪽은 chapter raw text 전체가 아니라 미리보기만 필요하므로, DB에는 preview만 보관하는 편이 역할에 맞습니다.

> 채택하지 않은 방식:
> - `TEXT -> MEDIUMTEXT/LONGTEXT` 단순 확장:
>   - 장애는 막을 수 있지만, full chapter text를 계속 DB에 쌓는 구조는 그대로 유지됩니다.
>   - 검증 기준 원문과 normalization 산출물이 이중화됩니다.
> - `contains`, `startsWith`, preview 검증:
>   - offset 검증이 아니라 느슨한 문자열 존재 검사가 되어 현재 관리자 업로드 검증 목적과 맞지 않습니다.

## 🔍 Code Review
- 관리자 이벤트 업로드가 여전히 `startTxtOffset` / `endTxtOffset` 기준으로 정확 비교되는지 확인 부탁드립니다.
- normalization projection 이후 `chapter.raw_text`가 preview 용도로만 남아도 manifest/관리자 화면 동작에 문제 없는지 확인 부탁드립니다.
- S3 chapter txt 로딩 실패 시 현재처럼 업로드를 500으로 실패시키는 정책이 맞는지 확인 부탁드립니다.

## 📸 ScreenShot
- 없음