### PR TITLE
feat: EPUB 업로드 시 북커버 이미지 추출 및 저장 지원

### DIFF
--- a/src/main/java/com/kw/readwith/domain/Book.java
+++ b/src/main/java/com/kw/readwith/domain/Book.java
@@ -115,6 +115,10 @@ public class Book extends BaseEntity {
         this.epubPath = epubPath;
     }
 
+    public void updateCoverImage(String coverImgUrl) {
+        this.coverImgUrl = coverImgUrl;
+    }
+
     public void markNormalizationQueued() {
         if (!hasActiveNormalization()) {
             this.normalizationStatus = NormalizationStatus.QUEUED;

--- a/src/main/java/com/kw/readwith/service/BookService.java
+++ b/src/main/java/com/kw/readwith/service/BookService.java
@@ -18,6 +18,7 @@ import com.kw.readwith.service.normalization.NormalizationJobService;
 import com.kw.readwith.service.normalization.NormalizedArtifactStorageService;
 import com.kw.readwith.service.normalization.NormalizationVersionService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -29,6 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class BookService {
@@ -146,6 +148,7 @@ public class BookService {
         String sourceVersion = normalizedArtifactStorageService.newSourceVersion();
         String sourcePath = normalizedArtifactStorageService.storeSourceEpub(savedBook.getId(), sourceVersion, epubFile);
         savedBook.assignUploadedSource(sourcePath);
+        storeCoverImageIfPresent(savedBook, sourceVersion, extractedMetadata);
         savedBook.markNormalizationQueued();
         savedBook.resetAnalysisStatus();
 
@@ -184,6 +187,18 @@ public class BookService {
 
     private String enumName(Enum<?> value) {
         return value == null ? null : value.name();
+    }
+
+    private void storeCoverImageIfPresent(Book book, String sourceVersion, ExtractedEpubMetadata extractedMetadata) {
+        if (extractedMetadata.cover() == null || extractedMetadata.cover().isEmpty()) {
+            return;
+        }
+        try {
+            String coverUrl = normalizedArtifactStorageService.storeBookCover(book.getId(), sourceVersion, extractedMetadata.cover());
+            book.updateCoverImage(coverUrl);
+        } catch (RuntimeException e) {
+            log.warn("Failed to store EPUB cover image. bookId={}, sourceVersion={}", book.getId(), sourceVersion, e);
+        }
     }
 
     private String resolveRequiredMetadata(String fieldName, String extractedValue, String fallbackValue) {

--- a/src/main/java/com/kw/readwith/service/normalization/EpubMetadataExtractorService.java
+++ b/src/main/java/com/kw/readwith/service/normalization/EpubMetadataExtractorService.java
@@ -12,8 +12,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
 import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
@@ -57,26 +61,12 @@ public class EpubMetadataExtractorService {
 
         try (InputStream inputStream = zipFile.getInputStream(packageEntry)) {
             org.w3c.dom.Document document = newSecureDocumentBuilderFactory().newDocumentBuilder().parse(inputStream);
-            NodeList nodes = document.getElementsByTagName("*");
+            String title = findFirstTextByLocalName(document.getElementsByTagName("*"), "title");
+            String author = findFirstTextByLocalName(document.getElementsByTagName("*"), "creator");
+            String language = findFirstTextByLocalName(document.getElementsByTagName("*"), "language");
+            ExtractedEpubCover cover = extractCover(zipFile, packagePath, document);
 
-            String title = null;
-            String author = null;
-            String language = null;
-
-            for (int i = 0; i < nodes.getLength(); i++) {
-                Node node = nodes.item(i);
-                if (title == null && matchesLocalName(node, "title")) {
-                    title = normalize(node.getTextContent());
-                }
-                if (author == null && matchesLocalName(node, "creator")) {
-                    author = normalize(node.getTextContent());
-                }
-                if (language == null && matchesLocalName(node, "language")) {
-                    language = normalize(node.getTextContent());
-                }
-            }
-
-            return new ExtractedEpubMetadata(blankToNull(title), blankToNull(author), blankToNull(language));
+            return new ExtractedEpubMetadata(blankToNull(title), blankToNull(author), blankToNull(language), cover);
         } catch (GeneralException e) {
             throw e;
         } catch (Exception e) {
@@ -125,8 +115,238 @@ public class EpubMetadataExtractorService {
         return null;
     }
 
+    private ExtractedEpubCover extractCover(ZipFile zipFile,
+                                            String packagePath,
+                                            org.w3c.dom.Document packageDocument) {
+        Map<String, ManifestItem> manifestItems = readManifestItems(packageDocument, packagePath);
+
+        ManifestItem manifestCover = resolveCoverManifestItem(packageDocument, manifestItems);
+        if (manifestCover != null) {
+            ExtractedEpubCover cover = loadCoverFromManifestItem(zipFile, manifestItems, manifestCover);
+            if (cover != null) {
+                return cover;
+            }
+        }
+
+        String guideHref = resolveGuideCoverHref(packageDocument);
+        if (guideHref != null) {
+            return loadCoverFromHref(zipFile, packagePath, guideHref, manifestItems);
+        }
+
+        return null;
+    }
+
+    private Map<String, ManifestItem> readManifestItems(org.w3c.dom.Document packageDocument, String packagePath) {
+        Map<String, ManifestItem> manifestItems = new HashMap<>();
+        String packageDir = packageDirectory(packagePath);
+        NodeList nodes = packageDocument.getElementsByTagName("*");
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            if (!matchesLocalName(node, "item")) {
+                continue;
+            }
+            String id = attributeValue(node, "id");
+            String href = attributeValue(node, "href");
+            String mediaType = attributeValue(node, "media-type");
+            String properties = attributeValue(node, "properties");
+            if (id == null || href == null) {
+                continue;
+            }
+            manifestItems.put(id, new ManifestItem(
+                    id,
+                    resolveRelativePath(packageDir, href),
+                    blankToNull(mediaType),
+                    properties == null ? "" : properties
+            ));
+        }
+        return manifestItems;
+    }
+
+    private ManifestItem resolveCoverManifestItem(org.w3c.dom.Document packageDocument, Map<String, ManifestItem> manifestItems) {
+        String coverItemId = resolveCoverItemId(packageDocument);
+        if (coverItemId != null && manifestItems.containsKey(coverItemId)) {
+            return manifestItems.get(coverItemId);
+        }
+
+        for (ManifestItem item : manifestItems.values()) {
+            if (item.hasProperty("cover-image")) {
+                return item;
+            }
+        }
+
+        for (ManifestItem item : manifestItems.values()) {
+            if (item.isImage() && item.looksLikeCover()) {
+                return item;
+            }
+        }
+
+        return null;
+    }
+
+    private String resolveCoverItemId(org.w3c.dom.Document packageDocument) {
+        NodeList nodes = packageDocument.getElementsByTagName("*");
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            if (!matchesLocalName(node, "meta")) {
+                continue;
+            }
+            String name = attributeValue(node, "name");
+            if (!"cover".equalsIgnoreCase(name)) {
+                continue;
+            }
+            return blankToNull(attributeValue(node, "content"));
+        }
+        return null;
+    }
+
+    private String resolveGuideCoverHref(org.w3c.dom.Document packageDocument) {
+        NodeList nodes = packageDocument.getElementsByTagName("*");
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            if (!matchesLocalName(node, "reference")) {
+                continue;
+            }
+            String type = attributeValue(node, "type");
+            if (!"cover".equalsIgnoreCase(type)) {
+                continue;
+            }
+            return blankToNull(attributeValue(node, "href"));
+        }
+        return null;
+    }
+
+    private ExtractedEpubCover loadCoverFromManifestItem(ZipFile zipFile,
+                                                         Map<String, ManifestItem> manifestItems,
+                                                         ManifestItem manifestItem) {
+        if (manifestItem.isImage()) {
+            return loadBinaryCover(zipFile, manifestItem.href(), manifestItem.mediaType());
+        }
+
+        if (manifestItem.isXhtml()) {
+            return loadCoverFromContentDocument(zipFile, manifestItem.href(), manifestItems);
+        }
+
+        return null;
+    }
+
+    private ExtractedEpubCover loadCoverFromHref(ZipFile zipFile,
+                                                 String basePath,
+                                                 String href,
+                                                 Map<String, ManifestItem> manifestItems) {
+        String normalizedHref = stripFragment(href);
+        if (isExternalReference(normalizedHref)) {
+            return null;
+        }
+        String resolvedPath = resolveRelativePath(packageDirectory(basePath), normalizedHref);
+        ManifestItem manifestItem = findManifestItemByHref(manifestItems, resolvedPath);
+        String mediaType = manifestItem == null ? detectContentTypeFromPath(resolvedPath) : manifestItem.mediaType();
+
+        if (isImageMediaType(mediaType)) {
+            return loadBinaryCover(zipFile, resolvedPath, mediaType);
+        }
+
+        if (isXhtmlMediaType(mediaType)) {
+            return loadCoverFromContentDocument(zipFile, resolvedPath, manifestItems);
+        }
+
+        return null;
+    }
+
+    private ExtractedEpubCover loadCoverFromContentDocument(ZipFile zipFile,
+                                                            String contentDocumentPath,
+                                                            Map<String, ManifestItem> manifestItems) {
+        ZipEntry entry = findEntry(zipFile, contentDocumentPath);
+        if (entry == null) {
+            return null;
+        }
+
+        try (InputStream inputStream = zipFile.getInputStream(entry)) {
+            org.w3c.dom.Document document = newSecureDocumentBuilderFactory().newDocumentBuilder().parse(inputStream);
+            NodeList nodes = document.getElementsByTagName("*");
+            for (int i = 0; i < nodes.getLength(); i++) {
+                Node node = nodes.item(i);
+                if (matchesLocalName(node, "img")) {
+                    String src = blankToNull(attributeValue(node, "src"));
+                    if (src != null) {
+                        return loadCoverFromHref(zipFile, contentDocumentPath, src, manifestItems);
+                    }
+                }
+                if (matchesLocalName(node, "image")) {
+                    String href = blankToNull(attributeValue(node, "href"));
+                    if (href == null) {
+                        href = blankToNull(attributeValue(node, "xlink:href"));
+                    }
+                    if (href != null) {
+                        return loadCoverFromHref(zipFile, contentDocumentPath, href, manifestItems);
+                    }
+                }
+            }
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private ExtractedEpubCover loadBinaryCover(ZipFile zipFile, String entryPath, String mediaType) {
+        ZipEntry entry = findEntry(zipFile, entryPath);
+        if (entry == null) {
+            return null;
+        }
+
+        try (InputStream inputStream = zipFile.getInputStream(entry)) {
+            byte[] bytes = inputStream.readAllBytes();
+            if (bytes.length == 0) {
+                return null;
+            }
+            return new ExtractedEpubCover(fileName(entryPath), mediaType, bytes);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private ManifestItem findManifestItemByHref(Map<String, ManifestItem> manifestItems, String href) {
+        for (ManifestItem manifestItem : manifestItems.values()) {
+            if (Objects.equals(manifestItem.href(), href)) {
+                return manifestItem;
+            }
+        }
+        return null;
+    }
+
+    private String findFirstTextByLocalName(NodeList nodes, String localName) {
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            if (matchesLocalName(node, localName)) {
+                return normalize(node.getTextContent());
+            }
+        }
+        return null;
+    }
+
     private boolean matchesLocalName(Node node, String localName) {
         return localName.equalsIgnoreCase(node.getLocalName()) || localName.equalsIgnoreCase(node.getNodeName());
+    }
+
+    private String attributeValue(Node node, String attributeName) {
+        if (node.getAttributes() == null) {
+            return null;
+        }
+        Node attributeNode = node.getAttributes().getNamedItem(attributeName);
+        if (attributeNode != null) {
+            return attributeNode.getNodeValue();
+        }
+        for (int i = 0; i < node.getAttributes().getLength(); i++) {
+            Node candidate = node.getAttributes().item(i);
+            if (candidate == null) {
+                continue;
+            }
+            String nodeName = candidate.getNodeName();
+            String localName = candidate.getLocalName();
+            if (attributeName.equalsIgnoreCase(nodeName) || attributeName.equalsIgnoreCase(localName)) {
+                return candidate.getNodeValue();
+            }
+        }
+        return null;
     }
 
     private DocumentBuilderFactory newSecureDocumentBuilderFactory() throws Exception {
@@ -148,6 +368,82 @@ public class EpubMetadataExtractorService {
         return value == null || value.isBlank() ? null : value;
     }
 
+    private String packageDirectory(String packagePath) {
+        Path parent = Paths.get(packagePath).getParent();
+        if (parent == null) {
+            return "";
+        }
+        return parent.toString().replace("\\", "/");
+    }
+
+    private String resolveRelativePath(String baseDirectory, String href) {
+        String normalizedHref = href.replace("\\", "/");
+        if (normalizedHref.startsWith("/")) {
+            return normalizedHref.substring(1);
+        }
+        Path basePath = baseDirectory == null || baseDirectory.isBlank()
+                ? Paths.get("")
+                : Paths.get(baseDirectory);
+        return basePath.resolve(normalizedHref).normalize().toString().replace("\\", "/");
+    }
+
+    private String detectContentTypeFromPath(String path) {
+        String lower = path.toLowerCase(Locale.ROOT);
+        if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) {
+            return "image/jpeg";
+        }
+        if (lower.endsWith(".png")) {
+            return "image/png";
+        }
+        if (lower.endsWith(".gif")) {
+            return "image/gif";
+        }
+        if (lower.endsWith(".webp")) {
+            return "image/webp";
+        }
+        if (lower.endsWith(".svg")) {
+            return "image/svg+xml";
+        }
+        if (lower.endsWith(".xhtml") || lower.endsWith(".html") || lower.endsWith(".htm")) {
+            return "application/xhtml+xml";
+        }
+        return null;
+    }
+
+    private boolean isImageMediaType(String mediaType) {
+        return mediaType != null && mediaType.toLowerCase(Locale.ROOT).startsWith("image/");
+    }
+
+    private boolean isXhtmlMediaType(String mediaType) {
+        if (mediaType == null) {
+            return false;
+        }
+        String lower = mediaType.toLowerCase(Locale.ROOT);
+        return "application/xhtml+xml".equals(lower) || "text/html".equals(lower);
+    }
+
+    private String fileName(String path) {
+        Path filePath = Paths.get(path);
+        Path fileName = filePath.getFileName();
+        return fileName == null ? "cover" : fileName.toString();
+    }
+
+    private String stripFragment(String href) {
+        int fragmentIndex = href.indexOf('#');
+        if (fragmentIndex < 0) {
+            return href;
+        }
+        return href.substring(0, fragmentIndex);
+    }
+
+    private boolean isExternalReference(String href) {
+        String lower = href.toLowerCase(Locale.ROOT);
+        return lower.startsWith("http://")
+                || lower.startsWith("https://")
+                || lower.startsWith("data:")
+                || lower.startsWith("mailto:");
+    }
+
     private void deleteTempFile(Path tempFile) {
         if (tempFile == null) {
             return;
@@ -155,6 +451,40 @@ public class EpubMetadataExtractorService {
         try {
             Files.deleteIfExists(tempFile);
         } catch (IOException ignored) {
+        }
+    }
+
+    private record ManifestItem(
+            String id,
+            String href,
+            String mediaType,
+            String properties
+    ) {
+        private boolean hasProperty(String property) {
+            for (String candidate : properties.split("\\s+")) {
+                if (property.equalsIgnoreCase(candidate)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean isImage() {
+            return mediaType != null && mediaType.toLowerCase(Locale.ROOT).startsWith("image/");
+        }
+
+        private boolean isXhtml() {
+            if (mediaType == null) {
+                return false;
+            }
+            String lower = mediaType.toLowerCase(Locale.ROOT);
+            return "application/xhtml+xml".equals(lower) || "text/html".equals(lower);
+        }
+
+        private boolean looksLikeCover() {
+            String idLower = id.toLowerCase(Locale.ROOT);
+            String hrefLower = href.toLowerCase(Locale.ROOT);
+            return idLower.contains("cover") || hrefLower.contains("cover");
         }
     }
 }

--- a/src/main/java/com/kw/readwith/service/normalization/ExtractedEpubCover.java
+++ b/src/main/java/com/kw/readwith/service/normalization/ExtractedEpubCover.java
@@ -1,0 +1,12 @@
+package com.kw.readwith.service.normalization;
+
+public record ExtractedEpubCover(
+        String fileName,
+        String contentType,
+        byte[] bytes
+) {
+
+    public boolean isEmpty() {
+        return bytes == null || bytes.length == 0;
+    }
+}

--- a/src/main/java/com/kw/readwith/service/normalization/ExtractedEpubMetadata.java
+++ b/src/main/java/com/kw/readwith/service/normalization/ExtractedEpubMetadata.java
@@ -3,10 +3,11 @@ package com.kw.readwith.service.normalization;
 public record ExtractedEpubMetadata(
         String title,
         String author,
-        String language
+        String language,
+        ExtractedEpubCover cover
 ) {
 
     public static ExtractedEpubMetadata empty() {
-        return new ExtractedEpubMetadata(null, null, null);
+        return new ExtractedEpubMetadata(null, null, null, null);
     }
 }

--- a/src/main/java/com/kw/readwith/service/normalization/NormalizedArtifactStorageService.java
+++ b/src/main/java/com/kw/readwith/service/normalization/NormalizedArtifactStorageService.java
@@ -64,6 +64,16 @@ public class NormalizedArtifactStorageService {
         );
     }
 
+    public String storeBookCover(Long bookId, String sourceVersion, ExtractedEpubCover cover) {
+        String relativePath = buildCoverRelativePath(bookId, sourceVersion, cover.fileName());
+        amazonS3Manager.uploadBytes(
+                publicKey(relativePath),
+                cover.bytes(),
+                cover.contentType()
+        );
+        return resolvePublicUrl(relativePath);
+    }
+
     public String storeNormalizationArtifacts(Long bookId, String runId, NormalizationPipelineResult result) {
         String artifactRoot = buildArtifactRoot(bookId, runId);
         try {
@@ -112,11 +122,15 @@ public class NormalizedArtifactStorageService {
 
     public String resolveCombinedXhtmlUrl(String artifactRoot) {
         String publicRelativePath = artifactRoot + "/combined.xhtml";
+        return resolvePublicUrl(publicRelativePath);
+    }
+
+    public String resolvePublicUrl(String relativePath) {
         String cloudFrontBaseUrl = trimTrailingSlash(artifactStorageProperties.getCloudFrontBaseUrl());
         if (!cloudFrontBaseUrl.isBlank()) {
-            return cloudFrontBaseUrl + "/" + publicKey(publicRelativePath);
+            return cloudFrontBaseUrl + "/" + publicKey(relativePath);
         }
-        return amazonS3Manager.getObjectUrl(publicKey(publicRelativePath));
+        return amazonS3Manager.getObjectUrl(publicKey(relativePath));
     }
 
     private String buildSourceRelativePath(Long bookId, String sourceVersion) {
@@ -125,6 +139,10 @@ public class NormalizedArtifactStorageService {
 
     private String buildArtifactRoot(Long bookId, String runId) {
         return "books/" + bookId + "/normalizations/" + runId;
+    }
+
+    private String buildCoverRelativePath(Long bookId, String sourceVersion, String fileName) {
+        return "books/" + bookId + "/covers/" + sourceVersion + "/cover" + extractExtension(fileName);
     }
 
     private String buildChapterTextRelativePath(String artifactRoot, int chapterIndex) {
@@ -144,5 +162,16 @@ public class NormalizedArtifactStorageService {
             return "";
         }
         return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+
+    private String extractExtension(String fileName) {
+        if (fileName == null) {
+            return "";
+        }
+        int idx = fileName.lastIndexOf('.');
+        if (idx < 0) {
+            return "";
+        }
+        return fileName.substring(idx);
     }
 }

--- a/src/test/java/com/kw/readwith/service/BookServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/BookServiceTest.java
@@ -6,20 +6,21 @@ import com.kw.readwith.domain.User;
 import com.kw.readwith.domain.enums.AnalysisStatus;
 import com.kw.readwith.domain.enums.NormalizationStatus;
 import com.kw.readwith.domain.enums.NormalizationVersionStatus;
-import com.kw.readwith.domain.enums.Provider;
 import com.kw.readwith.domain.enums.ProcessingJobStatus;
 import com.kw.readwith.domain.enums.ProcessingPipelineType;
+import com.kw.readwith.domain.enums.Provider;
 import com.kw.readwith.domain.processing.ProcessingJob;
 import com.kw.readwith.dto.book.BookDetailDTO;
 import com.kw.readwith.repository.BookRepository;
 import com.kw.readwith.repository.FavoriteRepository;
 import com.kw.readwith.repository.UserRepository;
 import com.kw.readwith.service.normalization.EpubMetadataExtractorService;
+import com.kw.readwith.service.normalization.ExtractedEpubCover;
 import com.kw.readwith.service.normalization.ExtractedEpubMetadata;
 import com.kw.readwith.service.normalization.NormalizationJobDispatcher;
 import com.kw.readwith.service.normalization.NormalizationJobService;
-import com.kw.readwith.service.normalization.NormalizedArtifactStorageService;
 import com.kw.readwith.service.normalization.NormalizationVersionService;
+import com.kw.readwith.service.normalization.NormalizedArtifactStorageService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -40,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -89,19 +91,19 @@ class BookServiceTest {
     }
 
     @Test
-    @DisplayName("uploadBook stores extracted EPUB metadata when request metadata is missing")
-    void uploadBookUsesExtractedMetadata() {
-        MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "dracula.epub",
-                "application/epub+zip",
-                "epub".getBytes(StandardCharsets.UTF_8)
-        );
+    @DisplayName("uploadBook stores extracted EPUB metadata and cover image")
+    void uploadBookUsesExtractedMetadataAndCoverImage() {
+        MockMultipartFile file = sampleEpubFile();
         User uploader = sampleUser();
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(uploader));
         when(epubMetadataExtractorService.extract(file))
-                .thenReturn(new ExtractedEpubMetadata("Dracula", "Bram Stoker", "en"));
+                .thenReturn(new ExtractedEpubMetadata(
+                        "Dracula",
+                        "Bram Stoker",
+                        "en",
+                        new ExtractedEpubCover("cover.jpg", "image/jpeg", "cover".getBytes(StandardCharsets.UTF_8))
+                ));
         when(bookRepository.save(any(Book.class))).thenAnswer(invocation -> {
             Book saved = invocation.getArgument(0);
             ReflectionTestUtils.setField(saved, "id", 101L);
@@ -110,6 +112,8 @@ class BookServiceTest {
         when(normalizedArtifactStorageService.newSourceVersion()).thenReturn("source-v1");
         when(normalizedArtifactStorageService.storeSourceEpub(101L, "source-v1", file))
                 .thenReturn("books/101/source/source-v1/book.epub");
+        when(normalizedArtifactStorageService.storeBookCover(eq(101L), eq("source-v1"), any(ExtractedEpubCover.class)))
+                .thenReturn("https://cdn.readwith.store/public/books/101/covers/source-v1/cover.jpg");
         when(normalizationJobService.createQueuedJob(any(Book.class), eq("source-v1"), eq("UPLOAD")))
                 .thenAnswer(invocation -> ProcessingJob.builder()
                         .id(55L)
@@ -129,29 +133,76 @@ class BookServiceTest {
         assertThat(savedBook.getTitle()).isEqualTo("Dracula");
         assertThat(savedBook.getAuthor()).isEqualTo("Bram Stoker");
         assertThat(savedBook.getLanguage()).isEqualTo("en");
+        assertThat(savedBook.getCoverImgUrl()).isEqualTo("https://cdn.readwith.store/public/books/101/covers/source-v1/cover.jpg");
         assertThat(savedBook.getNormalizationStatus()).isEqualTo(NormalizationStatus.QUEUED);
         assertThat(savedBook.getAnalysisStatus()).isEqualTo(AnalysisStatus.NONE);
 
         assertThat(response.getTitle()).isEqualTo("Dracula");
         assertThat(response.getAuthor()).isEqualTo("Bram Stoker");
         assertThat(response.getLanguage()).isEqualTo("en");
+        assertThat(response.getCoverImgUrl()).isEqualTo("https://cdn.readwith.store/public/books/101/covers/source-v1/cover.jpg");
     }
 
     @Test
-    @DisplayName("uploadBook는 제목/저자 메타데이터가 없으면 요청값이 있어도 실패한다")
+    @DisplayName("uploadBook requires title and author metadata from the EPUB package")
     void uploadBookRequiresTitleAndAuthorMetadataFromEpub() {
-        MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "custom.epub",
-                "application/epub+zip",
-                "epub".getBytes(StandardCharsets.UTF_8)
-        );
+        MockMultipartFile file = sampleEpubFile();
         User uploader = sampleUser();
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(uploader));
         when(epubMetadataExtractorService.extract(file)).thenReturn(ExtractedEpubMetadata.empty());
 
         assertThrows(GeneralException.class, () -> bookService.uploadBook(1L, file, "Manual Title", "Manual Author", "ko"));
+    }
+
+    @Test
+    @DisplayName("uploadBook continues when cover upload fails")
+    void uploadBookContinuesWhenCoverUploadFails() {
+        MockMultipartFile file = sampleEpubFile();
+        User uploader = sampleUser();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(uploader));
+        when(epubMetadataExtractorService.extract(file))
+                .thenReturn(new ExtractedEpubMetadata(
+                        "Dracula",
+                        "Bram Stoker",
+                        "en",
+                        new ExtractedEpubCover("cover.jpg", "image/jpeg", "cover".getBytes(StandardCharsets.UTF_8))
+                ));
+        when(bookRepository.save(any(Book.class))).thenAnswer(invocation -> {
+            Book saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 101L);
+            return saved;
+        });
+        when(normalizedArtifactStorageService.newSourceVersion()).thenReturn("source-v1");
+        when(normalizedArtifactStorageService.storeSourceEpub(101L, "source-v1", file))
+                .thenReturn("books/101/source/source-v1/book.epub");
+        doThrow(new IllegalStateException("cover upload failed"))
+                .when(normalizedArtifactStorageService)
+                .storeBookCover(eq(101L), eq("source-v1"), any(ExtractedEpubCover.class));
+        when(normalizationJobService.createQueuedJob(any(Book.class), eq("source-v1"), eq("UPLOAD")))
+                .thenAnswer(invocation -> ProcessingJob.builder()
+                        .id(55L)
+                        .book(invocation.getArgument(0))
+                        .pipelineType(ProcessingPipelineType.NORMALIZATION)
+                        .runId("run-1")
+                        .sourceVersion("source-v1")
+                        .status(ProcessingJobStatus.QUEUED)
+                        .build());
+
+        BookDetailDTO response = bookService.uploadBook(1L, file, null, null, null);
+
+        assertThat(response.getTitle()).isEqualTo("Dracula");
+        assertThat(response.getCoverImgUrl()).isNull();
+    }
+
+    private MockMultipartFile sampleEpubFile() {
+        return new MockMultipartFile(
+                "file",
+                "dracula.epub",
+                "application/epub+zip",
+                "epub".getBytes(StandardCharsets.UTF_8)
+        );
     }
 
     private User sampleUser() {

--- a/src/test/java/com/kw/readwith/service/EpubMetadataExtractorServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/EpubMetadataExtractorServiceTest.java
@@ -1,6 +1,7 @@
 package com.kw.readwith.service;
 
 import com.kw.readwith.service.normalization.EpubMetadataExtractorService;
+import com.kw.readwith.service.normalization.ExtractedEpubCover;
 import com.kw.readwith.service.normalization.ExtractedEpubMetadata;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,7 @@ class EpubMetadataExtractorServiceTest {
         assertThat(metadata.title()).isEqualTo("Dracula");
         assertThat(metadata.author()).isEqualTo("Bram Stoker");
         assertThat(metadata.language()).isEqualTo("en");
+        assertThat(metadata.cover()).isNull();
     }
 
     @Test
@@ -60,9 +62,58 @@ class EpubMetadataExtractorServiceTest {
         assertThat(metadata.title()).isEqualTo("Little Women");
         assertThat(metadata.author()).isNull();
         assertThat(metadata.language()).isNull();
+        assertThat(metadata.cover()).isNull();
+    }
+
+    @Test
+    @DisplayName("EPUB package metadata extracts cover image when manifest declares cover-image")
+    void extractMetadataIncludesCoverImage() throws Exception {
+        byte[] coverBytes = "cover-image".getBytes(StandardCharsets.UTF_8);
+        MockMultipartFile epubFile = new MockMultipartFile(
+                "file",
+                "sample.epub",
+                "application/epub+zip",
+                createSampleEpub(
+                        """
+                        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                          <dc:title>Dracula</dc:title>
+                          <dc:creator>Bram Stoker</dc:creator>
+                          <dc:language>en</dc:language>
+                          <meta name="cover" content="cover-image"/>
+                        </metadata>
+                        """,
+                        """
+                        <item id="cover-image" href="images/cover.jpg" media-type="image/jpeg" properties="cover-image"/>
+                        <item id="chap1" href="chap1.xhtml" media-type="application/xhtml+xml"/>
+                        """,
+                        coverBytes
+                )
+        );
+
+        ExtractedEpubMetadata metadata = epubMetadataExtractorService.extract(epubFile);
+
+        assertThat(metadata.title()).isEqualTo("Dracula");
+        assertThat(metadata.author()).isEqualTo("Bram Stoker");
+        assertThat(metadata.language()).isEqualTo("en");
+        assertThat(metadata.cover()).isNotNull();
+
+        ExtractedEpubCover cover = metadata.cover();
+        assertThat(cover.fileName()).isEqualTo("cover.jpg");
+        assertThat(cover.contentType()).isEqualTo("image/jpeg");
+        assertThat(cover.bytes()).isEqualTo(coverBytes);
     }
 
     private byte[] createSampleEpub(String metadataXml) throws IOException {
+        return createSampleEpub(
+                metadataXml,
+                """
+                <item id="chap1" href="chap1.xhtml" media-type="application/xhtml+xml"/>
+                """,
+                null
+        );
+    }
+
+    private byte[] createSampleEpub(String metadataXml, String manifestItemsXml, byte[] coverBytes) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
@@ -80,7 +131,7 @@ class EpubMetadataExtractorServiceTest {
                     <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
                     """ + metadataXml + """
                       <manifest>
-                        <item id="chap1" href="chap1.xhtml" media-type="application/xhtml+xml"/>
+                        """ + manifestItemsXml + """
                       </manifest>
                       <spine>
                         <itemref idref="chap1"/>
@@ -95,14 +146,22 @@ class EpubMetadataExtractorServiceTest {
                       <body><p>Sample text.</p></body>
                     </html>
                     """);
+
+            if (coverBytes != null) {
+                writeZipEntry(zipOutputStream, "OEBPS/images/cover.jpg", coverBytes);
+            }
         }
 
         return outputStream.toByteArray();
     }
 
     private void writeZipEntry(ZipOutputStream zipOutputStream, String name, String content) throws IOException {
+        writeZipEntry(zipOutputStream, name, content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void writeZipEntry(ZipOutputStream zipOutputStream, String name, byte[] content) throws IOException {
         zipOutputStream.putNextEntry(new ZipEntry(name));
-        zipOutputStream.write(content.getBytes(StandardCharsets.UTF_8));
+        zipOutputStream.write(content);
         zipOutputStream.closeEntry();
     }
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
EPUB 업로드 시 OPF/manifest 기준으로 북커버 이미지를 추출하고, public S3 경로에 저장한 뒤 `book.coverImgUrl`에 반영하도록 추가했습니다.

기존에는 `coverImgUrl` 필드는 존재했지만 업로드 시 항상 `null`로 저장되고 있었고, 이번 변경으로 업로드 응답과 이후 책 조회 응답에서 커버 URL을 받을 수 있습니다.
커버 저장은 best-effort로 처리해서, 커버 추출 또는 업로드에 실패하더라도 책 업로드 자체는 계속 성공하도록 두었습니다.

## 📋 변경 사항
- EPUB 메타데이터 추출 단계에서 title/author/language 외에 cover image도 함께 추출하도록 확장했습니다.
- cover 탐색 우선순위를 `meta name="cover"` -> `properties="cover-image"` -> cover로 추정되는 manifest item -> guide/cover page fallback 순으로 추가했습니다.
- XHTML cover page만 존재하는 EPUB도 내부 `img`를 따라가서 실제 이미지 파일을 추출하도록 처리했습니다.
- 추출한 cover 이미지를 public S3 경로에 업로드하고, 최종 공개 URL을 `book.coverImgUrl`에 저장하도록 추가했습니다.
- 커버 업로드 실패가 전체 책 업로드를 막지 않도록 로그만 남기고 계속 진행하도록 처리했습니다.
- 관련 단위 테스트를 추가해 cover 추출, 업로드 성공, 업로드 실패 fallback 경로를 검증했습니다.

## 🔍 Code Review
- EPUB마다 cover 선언 방식이 다른데, 현재 우선순위가 실제 샘플북들에서 충분히 안정적으로 동작하는지 확인 부탁드립니다.
- cover 이미지를 public으로 노출하는 현재 정책이 서비스 의도와 맞는지 확인 부탁드립니다.
- cover 업로드 실패를 best-effort로 둔 판단이 맞는지, 아니면 특정 실패는 업로드 자체를 막아야 하는지 확인 부탁드립니다.
- 업로드 응답과 책 조회 응답에서 `coverImgUrl`이 기대한 시점에 채워지는지 확인 부탁드립니다.

## 📸 ScreenShot
- 없음