### PR TITLE
feat: EPUB 정규화 규칙 v2 도입

### DIFF
--- a/src/main/java/com/kw/readwith/config/EpubNormalizationProperties.java
+++ b/src/main/java/com/kw/readwith/config/EpubNormalizationProperties.java
@@ -12,6 +12,6 @@ import org.springframework.stereotype.Component;
 public class EpubNormalizationProperties {
 
     private boolean enabled = false;
-    private String ruleVersion = "v1";
+    private String ruleVersion = "v2";
     private String locatorVersion = "v2";
 }

--- a/src/main/java/com/kw/readwith/service/normalization/CanonicalChapterPlan.java
+++ b/src/main/java/com/kw/readwith/service/normalization/CanonicalChapterPlan.java
@@ -1,0 +1,15 @@
+package com.kw.readwith.service.normalization;
+
+import java.util.List;
+
+record CanonicalChapterPlan(
+        int chapterIndex,
+        String title,
+        SplitUnitRole role,
+        List<SplitUnit> sourceUnits,
+        List<String> sourceDocHrefs,
+        List<String> sourceTitles,
+        CanonicalMergeReason mergedReason,
+        int estimatedCodePoints
+) {
+}

--- a/src/main/java/com/kw/readwith/service/normalization/CanonicalChapterPlanner.java
+++ b/src/main/java/com/kw/readwith/service/normalization/CanonicalChapterPlanner.java
@@ -1,0 +1,428 @@
+package com.kw.readwith.service.normalization;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class CanonicalChapterPlanner {
+
+    private static final Pattern NUMBER_AT_END = Pattern.compile("(\\d+|[IVXLCDM]+)$", Pattern.CASE_INSENSITIVE);
+    private static final List<String> PLACEHOLDER_TITLES = List.of(
+            "contents",
+            "table of contents",
+            "index",
+            "the full project gutenberg license"
+    );
+
+    private final int softMinCodePoints;
+    private final int targetMinCodePoints;
+    private final int targetMaxCodePoints;
+    private final int hardMaxCodePoints;
+    private final int softMaxChapterCount;
+
+    CanonicalChapterPlanner() {
+        this(3000, 8000, 30000, 45000, 20);
+    }
+
+    CanonicalChapterPlanner(
+            int softMinCodePoints,
+            int targetMinCodePoints,
+            int targetMaxCodePoints,
+            int hardMaxCodePoints,
+            int softMaxChapterCount
+    ) {
+        this.softMinCodePoints = softMinCodePoints;
+        this.targetMinCodePoints = targetMinCodePoints;
+        this.targetMaxCodePoints = targetMaxCodePoints;
+        this.hardMaxCodePoints = hardMaxCodePoints;
+        this.softMaxChapterCount = softMaxChapterCount;
+    }
+
+    List<CanonicalChapterPlan> plan(List<SplitUnit> splitUnits) {
+        List<SplitUnit> candidates = splitUnits.stream()
+                .filter(unit -> !isExcluded(unit.role()))
+                .toList();
+        if (candidates.isEmpty()) {
+            candidates = splitUnits;
+        }
+
+        List<UnitGroup> groups = initialGroups(candidates);
+        groups = mergeShortGroups(groups);
+        if (groups.size() > softMaxChapterCount) {
+            groups = bundleGroups(groups, true);
+            groups = mergeShortGroups(groups);
+        }
+        if (groups.size() > softMaxChapterCount) {
+            groups = bundleGroups(groups, false);
+            groups = mergeShortGroups(groups);
+        }
+        groups = splitOversizedGroups(groups);
+        if (groups.size() > softMaxChapterCount) {
+            groups = forceChapterCountWithinLimit(groups);
+        }
+
+        List<CanonicalChapterPlan> plans = new ArrayList<>();
+        int index = 1;
+        for (UnitGroup group : groups) {
+            if (group.units().isEmpty()) {
+                continue;
+            }
+
+            List<String> sourceDocHrefs = orderedSourceDocHrefs(group.units());
+            List<String> sourceTitles = group.units().stream().map(SplitUnit::title).toList();
+            plans.add(new CanonicalChapterPlan(
+                    index++,
+                    resolveGroupTitle(group),
+                    resolveGroupRole(group),
+                    List.copyOf(group.units()),
+                    sourceDocHrefs,
+                    sourceTitles,
+                    group.reason(),
+                    group.totalCodePoints()
+            ));
+        }
+        return plans;
+    }
+
+    private boolean isExcluded(SplitUnitRole role) {
+        return role == SplitUnitRole.FRONTMATTER
+                || role == SplitUnitRole.CONTENTS
+                || role == SplitUnitRole.LICENSE
+                || role == SplitUnitRole.INDEX
+                || role == SplitUnitRole.NOTES;
+    }
+
+    private List<UnitGroup> initialGroups(List<SplitUnit> units) {
+        List<UnitGroup> groups = new ArrayList<>();
+        int i = 0;
+        while (i < units.size()) {
+            SplitUnit unit = units.get(i);
+            if (unit.role() == SplitUnitRole.SCENE) {
+                String actTitle = closestAncestorMatching(unit, "act ");
+                if (actTitle != null) {
+                    List<SplitUnit> sceneGroup = new ArrayList<>();
+                    sceneGroup.add(unit);
+                    int j = i + 1;
+                    while (j < units.size()) {
+                        SplitUnit next = units.get(j);
+                        if (next.role() != SplitUnitRole.SCENE || !Objects.equals(actTitle, closestAncestorMatching(next, "act "))) {
+                            break;
+                        }
+                        sceneGroup.add(next);
+                        j++;
+                    }
+                    groups.add(new UnitGroup(sceneGroup, CanonicalMergeReason.PROMOTE_SCENE_TO_ACT, actTitle));
+                    i = j;
+                    continue;
+                }
+            }
+
+            groups.add(new UnitGroup(List.of(unit), CanonicalMergeReason.KEEP_AS_IS, null));
+            i++;
+        }
+        return groups;
+    }
+
+    private List<UnitGroup> mergeShortGroups(List<UnitGroup> groups) {
+        if (groups.size() < 2) {
+            return groups;
+        }
+
+        List<UnitGroup> merged = new ArrayList<>();
+        int index = 0;
+        while (index < groups.size()) {
+            UnitGroup current = groups.get(index);
+            if (current.totalCodePoints() >= softMinCodePoints || index == groups.size() - 1) {
+                merged.add(current);
+                index++;
+                continue;
+            }
+
+            UnitGroup next = groups.get(index + 1);
+            if (canMerge(current, next) && current.totalCodePoints() + next.totalCodePoints() <= Math.max(targetMaxCodePoints, hardMaxCodePoints)) {
+                merged.add(current.merge(next, current.reason() == CanonicalMergeReason.KEEP_AS_IS
+                        && next.reason() == CanonicalMergeReason.KEEP_AS_IS
+                        ? CanonicalMergeReason.MERGE_SHORT_SIBLINGS
+                        : CanonicalMergeReason.GROUP_SMALL_UNITS));
+                index += 2;
+                continue;
+            }
+
+            merged.add(current);
+            index++;
+        }
+        return merged;
+    }
+
+    private List<UnitGroup> bundleGroups(List<UnitGroup> groups, boolean preferParentBundles) {
+        List<UnitGroup> bundled = new ArrayList<>();
+        UnitGroup current = null;
+        String currentKey = null;
+
+        for (UnitGroup group : groups) {
+            String groupKey = preferParentBundles ? bundleKey(group) : broadBundleKey(group);
+            if (current == null) {
+                current = group;
+                currentKey = groupKey;
+                continue;
+            }
+
+            boolean sameKey = Objects.equals(currentKey, groupKey);
+            boolean shouldFlush = current.totalCodePoints() >= targetMinCodePoints && (!sameKey || current.totalCodePoints() >= targetMaxCodePoints);
+            if (shouldFlush) {
+                bundled.add(current);
+                current = group;
+                currentKey = groupKey;
+                continue;
+            }
+
+            current = current.merge(group, resolveBundleReason(current, group));
+            if (!sameKey) {
+                currentKey = groupKey;
+            }
+        }
+
+        if (current != null) {
+            bundled.add(current);
+        }
+        return bundled;
+    }
+
+    private List<UnitGroup> splitOversizedGroups(List<UnitGroup> groups) {
+        List<UnitGroup> result = new ArrayList<>();
+        for (UnitGroup group : groups) {
+            if (group.totalCodePoints() <= hardMaxCodePoints || group.units().size() == 1) {
+                result.add(group);
+                continue;
+            }
+
+            List<SplitUnit> bucket = new ArrayList<>();
+            int bucketSize = 0;
+            for (SplitUnit unit : group.units()) {
+                if (!bucket.isEmpty() && bucketSize >= targetMaxCodePoints) {
+                    result.add(new UnitGroup(List.copyOf(bucket), CanonicalMergeReason.GROUP_SMALL_UNITS, group.promotedTitle()));
+                    bucket = new ArrayList<>();
+                    bucketSize = 0;
+                }
+                bucket.add(unit);
+                bucketSize += unit.totalCodePoints();
+            }
+            if (!bucket.isEmpty()) {
+                result.add(new UnitGroup(List.copyOf(bucket), CanonicalMergeReason.GROUP_SMALL_UNITS, group.promotedTitle()));
+            }
+        }
+        return result;
+    }
+
+    private List<UnitGroup> forceChapterCountWithinLimit(List<UnitGroup> groups) {
+        if (groups.size() <= softMaxChapterCount) {
+            return groups;
+        }
+
+        int chunkSize = (int) Math.ceil((double) groups.size() / softMaxChapterCount);
+        List<UnitGroup> reduced = collapseByChunk(groups, chunkSize);
+        while (reduced.size() > softMaxChapterCount) {
+            chunkSize++;
+            reduced = collapseByChunk(groups, chunkSize);
+        }
+        return reduced;
+    }
+
+    private List<UnitGroup> collapseByChunk(List<UnitGroup> groups, int chunkSize) {
+        List<UnitGroup> collapsed = new ArrayList<>();
+        for (int start = 0; start < groups.size(); start += chunkSize) {
+            int end = Math.min(groups.size(), start + chunkSize);
+            UnitGroup merged = groups.get(start);
+            for (int i = start + 1; i < end; i++) {
+                merged = merged.merge(groups.get(i), CanonicalMergeReason.PROMOTE_TO_PARENT);
+            }
+            collapsed.add(merged);
+        }
+        return collapsed;
+    }
+
+    private CanonicalMergeReason resolveBundleReason(UnitGroup current, UnitGroup next) {
+        if (containsRole(current, SplitUnitRole.CANTO) || containsRole(next, SplitUnitRole.CANTO)) {
+            return CanonicalMergeReason.GROUP_CANTOS;
+        }
+        return CanonicalMergeReason.PROMOTE_TO_PARENT;
+    }
+
+    private boolean containsRole(UnitGroup group, SplitUnitRole role) {
+        return group.units().stream().anyMatch(unit -> unit.role() == role);
+    }
+
+    private boolean canMerge(UnitGroup left, UnitGroup right) {
+        String leftParent = nearestParentTitle(left);
+        String rightParent = nearestParentTitle(right);
+        if (leftParent != null && Objects.equals(leftParent, rightParent)) {
+            return true;
+        }
+        return containsFlexibleRole(left) || containsFlexibleRole(right);
+    }
+
+    private boolean containsFlexibleRole(UnitGroup group) {
+        return group.units().stream().anyMatch(unit -> switch (unit.role()) {
+            case CANTO, POEM, STORY, ESSAY, UNKNOWN, APPENDIX -> true;
+            default -> false;
+        });
+    }
+
+    private String nearestParentTitle(UnitGroup group) {
+        for (SplitUnit unit : group.units()) {
+            String parent = nearestMeaningfulAncestorTitle(unit);
+            if (parent != null && !parent.isBlank()) {
+                return parent;
+            }
+        }
+        return null;
+    }
+
+    private String bundleKey(UnitGroup group) {
+        SplitUnitRole dominantRole = resolveGroupRole(group);
+        for (SplitUnit unit : group.units()) {
+            String ancestor = switch (dominantRole) {
+                case CANTO -> closestAncestorMatching(unit, "book ");
+                case SCENE, ACT -> closestAncestorMatching(unit, "act ");
+                default -> unit.nearestAncestorTitle();
+            };
+            if (ancestor != null && !ancestor.isBlank()) {
+                return dominantRole + ":" + ancestor;
+            }
+        }
+        return broadBundleKey(group);
+    }
+
+    private String broadBundleKey(UnitGroup group) {
+        SplitUnitRole role = resolveGroupRole(group);
+        String ancestor = nearestParentTitle(group);
+        return role + ":" + (ancestor == null ? "ROOT" : ancestor);
+    }
+
+    private SplitUnitRole resolveGroupRole(UnitGroup group) {
+        if (group.reason() == CanonicalMergeReason.PROMOTE_SCENE_TO_ACT) {
+            return SplitUnitRole.ACT;
+        }
+        if (group.units().stream().anyMatch(unit -> unit.role() == SplitUnitRole.CANTO)) {
+            return SplitUnitRole.CANTO;
+        }
+        return group.units().get(0).role();
+    }
+
+    private String resolveGroupTitle(UnitGroup group) {
+        if (group.reason() == CanonicalMergeReason.PROMOTE_SCENE_TO_ACT && group.promotedTitle() != null) {
+            return group.promotedTitle();
+        }
+        if (group.units().size() == 1) {
+            return group.units().get(0).title();
+        }
+
+        String commonParent = nearestParentTitle(group);
+        if (group.reason() == CanonicalMergeReason.GROUP_CANTOS) {
+            String rangeTitle = buildRangeTitle(group, commonParent, "Cantos");
+            if (rangeTitle != null) {
+                return rangeTitle;
+            }
+        }
+        if (commonParent != null && !commonParent.isBlank()) {
+            return commonParent;
+        }
+
+        String firstTitle = group.units().get(0).title();
+        String lastTitle = group.units().get(group.units().size() - 1).title();
+        if (Objects.equals(firstTitle, lastTitle)) {
+            return firstTitle;
+        }
+        return firstTitle + " - " + lastTitle;
+    }
+
+    private String buildRangeTitle(UnitGroup group, String parentTitle, String label) {
+        String firstNumber = extractTrailingNumber(group.units().get(0).title());
+        String lastNumber = extractTrailingNumber(group.units().get(group.units().size() - 1).title());
+        if (firstNumber == null || lastNumber == null) {
+            return parentTitle;
+        }
+        if (parentTitle == null || parentTitle.isBlank()) {
+            return label + " " + firstNumber + "-" + lastNumber;
+        }
+        return parentTitle + " (" + label + " " + firstNumber + "-" + lastNumber + ")";
+    }
+
+    private String extractTrailingNumber(String title) {
+        if (title == null) {
+            return null;
+        }
+        Matcher matcher = NUMBER_AT_END.matcher(title.trim());
+        return matcher.find() ? matcher.group(1) : null;
+    }
+
+    private String closestAncestorMatching(SplitUnit unit, String tokenPrefix) {
+        List<String> path = unit.tocNodePath();
+        if (path == null || path.isEmpty()) {
+            return null;
+        }
+
+        for (int i = path.size() - 2; i >= 0; i--) {
+            String title = path.get(i);
+            String normalized = title.toLowerCase(Locale.ROOT);
+            if (normalized.startsWith(tokenPrefix) && !isPlaceholderTitle(normalized)) {
+                return title;
+            }
+        }
+        return null;
+    }
+
+    private String nearestMeaningfulAncestorTitle(SplitUnit unit) {
+        List<String> path = unit.tocNodePath();
+        if (path == null || path.size() < 2) {
+            return null;
+        }
+
+        for (int i = path.size() - 2; i >= 0; i--) {
+            String title = path.get(i);
+            if (title == null || title.isBlank()) {
+                continue;
+            }
+            String normalized = title.toLowerCase(Locale.ROOT).replaceAll("\\s+", " ").trim();
+            if (!isPlaceholderTitle(normalized)) {
+                return title;
+            }
+        }
+        return null;
+    }
+
+    private boolean isPlaceholderTitle(String normalizedTitle) {
+        return PLACEHOLDER_TITLES.stream().anyMatch(placeholder ->
+                normalizedTitle.equals(placeholder) || normalizedTitle.startsWith(placeholder + " "));
+    }
+
+    private List<String> orderedSourceDocHrefs(List<SplitUnit> units) {
+        Set<String> ordered = new LinkedHashSet<>();
+        for (SplitUnit unit : units) {
+            ordered.add(unit.sourceDocHref());
+        }
+        return List.copyOf(ordered);
+    }
+
+    private record UnitGroup(
+            List<SplitUnit> units,
+            CanonicalMergeReason reason,
+            String promotedTitle
+    ) {
+
+        int totalCodePoints() {
+            return units.stream().mapToInt(SplitUnit::totalCodePoints).sum();
+        }
+
+        UnitGroup merge(UnitGroup other, CanonicalMergeReason mergeReason) {
+            List<SplitUnit> mergedUnits = new ArrayList<>(units);
+            mergedUnits.addAll(other.units);
+            return new UnitGroup(List.copyOf(mergedUnits), mergeReason, promotedTitle != null ? promotedTitle : other.promotedTitle);
+        }
+    }
+}

--- a/src/main/java/com/kw/readwith/service/normalization/CanonicalChapterRenderer.java
+++ b/src/main/java/com/kw/readwith/service/normalization/CanonicalChapterRenderer.java
@@ -1,0 +1,111 @@
+package com.kw.readwith.service.normalization;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class CanonicalChapterRenderer {
+
+    List<NormalizedChapterArtifact> render(List<CanonicalChapterPlan> plans) {
+        List<NormalizedChapterArtifact> artifacts = new ArrayList<>();
+        int cumulativeOffset = 0;
+
+        for (CanonicalChapterPlan plan : plans) {
+            List<SplitBlock> blocks = plan.sourceUnits().stream()
+                    .flatMap(unit -> unit.blocks().stream())
+                    .toList();
+            if (blocks.isEmpty()) {
+                continue;
+            }
+
+            List<Integer> paragraphStarts = new ArrayList<>();
+            List<Integer> paragraphLengths = new ArrayList<>();
+            List<String> blockSourceDocHrefs = new ArrayList<>();
+            StringBuilder rawTextBuilder = new StringBuilder();
+            int chapterOffset = 0;
+
+            for (SplitBlock block : blocks) {
+                paragraphStarts.add(chapterOffset);
+                int paragraphLength = block.text().codePointCount(0, block.text().length());
+                paragraphLengths.add(paragraphLength);
+                blockSourceDocHrefs.add(block.sourceDocHref());
+                rawTextBuilder.append(block.text());
+                chapterOffset += paragraphLength;
+            }
+
+            int startPos = cumulativeOffset;
+            int endPos = chapterOffset == 0 ? cumulativeOffset : cumulativeOffset + chapterOffset - 1;
+            String representativeSpineHref = plan.sourceDocHrefs().isEmpty() ? null : plan.sourceDocHrefs().get(0);
+
+            artifacts.add(NormalizedChapterArtifact.builder()
+                    .chapterIndex(plan.chapterIndex())
+                    .title(plan.title())
+                    .spineHref(representativeSpineHref)
+                    .sourceDocHrefs(plan.sourceDocHrefs())
+                    .blockSourceDocHrefs(blockSourceDocHrefs)
+                    .paragraphStarts(paragraphStarts)
+                    .paragraphLengths(paragraphLengths)
+                    .totalCodePoints(chapterOffset)
+                    .startPos(startPos)
+                    .endPos(endPos)
+                    .rawText(rawTextBuilder.toString())
+                    .normalizedXhtml(buildChapterXhtml(plan.chapterIndex(), plan.title(), representativeSpineHref, blocks))
+                    .build());
+            cumulativeOffset += chapterOffset;
+        }
+
+        return artifacts;
+    }
+
+    String buildCombinedXhtml(List<NormalizedChapterArtifact> chapters) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        builder.append("<html xmlns=\"http://www.w3.org/1999/xhtml\"><head>");
+        builder.append("<meta charset=\"UTF-8\"/>");
+        builder.append("<title>ReadWith Normalized Reader</title>");
+        builder.append("</head><body>");
+        for (NormalizedChapterArtifact chapter : chapters) {
+            builder.append(chapter.getNormalizedXhtml());
+        }
+        builder.append("</body></html>");
+        return builder.toString();
+    }
+
+    private String buildChapterXhtml(
+            int chapterIndex,
+            String title,
+            String representativeSpineHref,
+            List<SplitBlock> blocks
+    ) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("<section data-chapter-index=\"").append(chapterIndex).append("\"");
+        if (representativeSpineHref != null && !representativeSpineHref.isBlank()) {
+            builder.append(" data-representative-spine-href=\"").append(escapeXml(representativeSpineHref)).append("\"");
+        }
+        builder.append(">");
+        builder.append("<h2>").append(escapeXml(title)).append("</h2>");
+        for (int i = 0; i < blocks.size(); i++) {
+            SplitBlock block = blocks.get(i);
+            builder.append("<p data-block-index=\"").append(i).append("\"");
+            if (block.sourceDocHref() != null && !block.sourceDocHref().isBlank()) {
+                builder.append(" data-spine-href=\"").append(escapeXml(block.sourceDocHref())).append("\"");
+            }
+            if (block.sourceUnitId() != null && !block.sourceUnitId().isBlank()) {
+                builder.append(" data-source-unit-id=\"").append(escapeXml(block.sourceUnitId())).append("\"");
+            }
+            builder.append(">")
+                    .append(escapeXml(block.text()))
+                    .append("</p>");
+        }
+        builder.append("</section>");
+        return builder.toString();
+    }
+
+    private String escapeXml(String value) {
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
+    }
+}

--- a/src/main/java/com/kw/readwith/service/normalization/CanonicalMergeReason.java
+++ b/src/main/java/com/kw/readwith/service/normalization/CanonicalMergeReason.java
@@ -1,0 +1,10 @@
+package com.kw.readwith.service.normalization;
+
+enum CanonicalMergeReason {
+    KEEP_AS_IS,
+    PROMOTE_SCENE_TO_ACT,
+    MERGE_SHORT_SIBLINGS,
+    GROUP_CANTOS,
+    GROUP_SMALL_UNITS,
+    PROMOTE_TO_PARENT
+}

--- a/src/main/java/com/kw/readwith/service/normalization/EpubManifestItem.java
+++ b/src/main/java/com/kw/readwith/service/normalization/EpubManifestItem.java
@@ -1,0 +1,22 @@
+package com.kw.readwith.service.normalization;
+
+record EpubManifestItem(
+        String id,
+        String href,
+        String mediaType,
+        String properties
+) {
+
+    boolean hasProperty(String property) {
+        if (properties == null || properties.isBlank()) {
+            return false;
+        }
+
+        for (String token : properties.split("\\s+")) {
+            if (property.equalsIgnoreCase(token)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/kw/readwith/service/normalization/NormalizationPipelineService.java
+++ b/src/main/java/com/kw/readwith/service/normalization/NormalizationPipelineService.java
@@ -9,9 +9,9 @@ import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.parser.Parser;
-import org.springframework.stereotype.Service;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.springframework.stereotype.Service;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.IOException;
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -34,10 +35,14 @@ import java.util.zip.ZipFile;
 @RequiredArgsConstructor
 public class NormalizationPipelineService {
 
-    private static final Set<String> BLOCK_TAGS = Set.of("p", "li", "blockquote", "h1", "h2", "h3", "h4", "h5", "h6");
+    private static final int MAX_CANONICAL_CHAPTER_COUNT = 20;
     private static final Set<String> TEXT_MEDIA_TYPES = Set.of("application/xhtml+xml", "text/html");
 
     private final ObjectMapper objectMapper;
+    private final TocTreeBuilder tocTreeBuilder = new TocTreeBuilder();
+    private final SplitUnitExtractor splitUnitExtractor = new SplitUnitExtractor(new SplitUnitClassifier());
+    private final CanonicalChapterPlanner canonicalChapterPlanner = new CanonicalChapterPlanner();
+    private final CanonicalChapterRenderer canonicalChapterRenderer = new CanonicalChapterRenderer();
 
     public NormalizationPipelineResult normalize(
             Path epubFile,
@@ -48,8 +53,8 @@ public class NormalizationPipelineService {
     ) {
         try (ZipFile zipFile = new ZipFile(epubFile.toFile())) {
             String packagePath = resolvePackagePath(zipFile);
-            List<String> spineHrefs = resolveSpineHrefs(zipFile, packagePath);
-            if (spineHrefs.isEmpty()) {
+            PackageDocumentData packageDocument = readPackageDocument(zipFile, packagePath);
+            if (packageDocument.spineHrefs().isEmpty()) {
                 throw failure(
                         NormalizationFailureCode.SPINE_RESOLVE_FAILED,
                         "resolve_spine",
@@ -57,26 +62,10 @@ public class NormalizationPipelineService {
                 );
             }
 
-            List<NormalizedChapterArtifact> chapters = new ArrayList<>();
-            int cumulativeOffset = 0;
-
-            for (String spineHref : spineHrefs) {
-                Document chapterDocument = readXhtml(zipFile, spineHref);
-                sanitize(chapterDocument);
-                NormalizedChapterArtifact artifact = buildChapterArtifact(
-                        chapters.size() + 1,
-                        spineHref,
-                        chapterDocument,
-                        cumulativeOffset
-                );
-                if (artifact == null) {
-                    continue;
-                }
-                chapters.add(artifact);
-                cumulativeOffset += artifact.getTotalCodePoints();
-            }
-
-            if (chapters.isEmpty()) {
+            TocTree tocTree = tocTreeBuilder.build(zipFile, packagePath, packageDocument.manifestById());
+            Map<String, Document> documentsByHref = loadSanitizedDocuments(zipFile, packageDocument.spineHrefs(), tocTree);
+            List<SplitUnit> splitUnits = splitUnitExtractor.extract(tocTree, packageDocument.spineHrefs(), documentsByHref);
+            if (splitUnits.isEmpty()) {
                 throw failure(
                         NormalizationFailureCode.NO_TEXT_CHAPTERS,
                         "extract_chapters",
@@ -84,8 +73,19 @@ public class NormalizationPipelineService {
                 );
             }
 
+            List<CanonicalChapterPlan> chapterPlans = canonicalChapterPlanner.plan(splitUnits);
+            List<NormalizedChapterArtifact> chapters = canonicalChapterRenderer.render(chapterPlans);
+            if (chapters.isEmpty()) {
+                throw failure(
+                        NormalizationFailureCode.NO_TEXT_CHAPTERS,
+                        "plan_chapters",
+                        "No canonical chapters were produced from EPUB."
+                );
+            }
+
+            String combinedXhtml = canonicalChapterRenderer.buildCombinedXhtml(chapters);
             NormalizationMetaDocument metaDocument = buildMetaDocument(bookId, runId, ruleVersion, locatorVersion, chapters);
-            ValidationReport validationReport = buildValidationReport(bookId, runId, ruleVersion, locatorVersion, chapters);
+            ValidationReport validationReport = buildValidationReport(bookId, runId, ruleVersion, locatorVersion, chapters, combinedXhtml);
             if (validationReport.roundTripFailures() > 0) {
                 throw failure(
                         NormalizationFailureCode.VALIDATION_FAILED,
@@ -95,7 +95,7 @@ public class NormalizationPipelineService {
             }
 
             return NormalizationPipelineResult.builder()
-                    .combinedXhtml(buildCombinedXhtml(chapters))
+                    .combinedXhtml(combinedXhtml)
                     .metaJson(writeJson(metaDocument))
                     .validationReportJson(validationReport.reportJson())
                     .chapters(chapters)
@@ -149,7 +149,7 @@ public class NormalizationPipelineService {
         }
     }
 
-    private List<String> resolveSpineHrefs(ZipFile zipFile, String packagePath) throws IOException {
+    private PackageDocumentData readPackageDocument(ZipFile zipFile, String packagePath) throws IOException {
         ZipEntry packageEntry = findEntry(zipFile, packagePath);
         if (packageEntry == null) {
             throw failure(NormalizationFailureCode.PACKAGE_NOT_FOUND, "resolve_package", "EPUB package document is missing.");
@@ -157,30 +157,29 @@ public class NormalizationPipelineService {
 
         try (InputStream inputStream = zipFile.getInputStream(packageEntry)) {
             org.w3c.dom.Document document = newSecureDocumentBuilderFactory().newDocumentBuilder().parse(inputStream);
-            Map<String, ManifestItem> manifest = new LinkedHashMap<>();
             String baseDir = parentPath(packagePath);
 
+            Map<String, EpubManifestItem> manifestById = new LinkedHashMap<>();
             NodeList nodes = document.getElementsByTagName("*");
             for (int i = 0; i < nodes.getLength(); i++) {
                 Node node = nodes.item(i);
-                if (!matchesLocalName(node, "item")) {
+                if (!matchesLocalName(node, "item") || node.getAttributes() == null) {
                     continue;
                 }
+
                 Node idNode = node.getAttributes().getNamedItem("id");
                 Node hrefNode = node.getAttributes().getNamedItem("href");
                 Node mediaTypeNode = node.getAttributes().getNamedItem("media-type");
                 Node propertiesNode = node.getAttributes().getNamedItem("properties");
-                if (idNode == null || hrefNode == null || mediaTypeNode == null) {
+                if (idNode == null || hrefNode == null) {
                     continue;
                 }
 
-                String mediaType = mediaTypeNode.getNodeValue().toLowerCase(Locale.ROOT);
-                if (!TEXT_MEDIA_TYPES.contains(mediaType)) {
-                    continue;
-                }
-
-                manifest.put(idNode.getNodeValue(), new ManifestItem(
-                        resolvePath(baseDir, hrefNode.getNodeValue()),
+                String href = resolvePath(baseDir, hrefNode.getNodeValue());
+                manifestById.put(idNode.getNodeValue(), new EpubManifestItem(
+                        idNode.getNodeValue(),
+                        href,
+                        mediaTypeNode != null ? mediaTypeNode.getNodeValue() : null,
                         propertiesNode != null ? propertiesNode.getNodeValue() : null
                 ));
             }
@@ -188,21 +187,28 @@ public class NormalizationPipelineService {
             List<String> spineHrefs = new ArrayList<>();
             for (int i = 0; i < nodes.getLength(); i++) {
                 Node node = nodes.item(i);
-                if (!matchesLocalName(node, "itemref")) {
+                if (!matchesLocalName(node, "itemref") || node.getAttributes() == null) {
                     continue;
                 }
+
                 Node idRefNode = node.getAttributes().getNamedItem("idref");
                 if (idRefNode == null) {
                     continue;
                 }
 
-                ManifestItem manifestItem = manifest.get(idRefNode.getNodeValue());
-                if (manifestItem != null && !manifestItem.isAuxiliary()) {
-                    spineHrefs.add(manifestItem.href());
+                EpubManifestItem manifestItem = manifestById.get(idRefNode.getNodeValue());
+                if (manifestItem == null || manifestItem.mediaType() == null) {
+                    continue;
                 }
+                String mediaType = manifestItem.mediaType().toLowerCase(Locale.ROOT);
+                if (!TEXT_MEDIA_TYPES.contains(mediaType) || manifestItem.hasProperty("nav")) {
+                    continue;
+                }
+
+                spineHrefs.add(manifestItem.href());
             }
 
-            return spineHrefs;
+            return new PackageDocumentData(manifestById, spineHrefs);
         } catch (NormalizationProcessingException e) {
             throw e;
         } catch (Exception e) {
@@ -213,6 +219,25 @@ public class NormalizationPipelineService {
                     e
             );
         }
+    }
+
+    private Map<String, Document> loadSanitizedDocuments(ZipFile zipFile, List<String> spineHrefs, TocTree tocTree) throws IOException {
+        LinkedHashSet<String> docHrefs = new LinkedHashSet<>(spineHrefs);
+        if (tocTree != null) {
+            for (TocNode leaf : tocTree.leafNodes()) {
+                if (leaf.sourceDocHref() != null && !leaf.sourceDocHref().isBlank()) {
+                    docHrefs.add(leaf.sourceDocHref());
+                }
+            }
+        }
+
+        Map<String, Document> documents = new LinkedHashMap<>();
+        for (String docHref : docHrefs) {
+            Document document = readXhtml(zipFile, docHref);
+            sanitize(document);
+            documents.put(docHref, document);
+        }
+        return documents;
     }
 
     private Document readXhtml(ZipFile zipFile, String entryPath) throws IOException {
@@ -251,109 +276,12 @@ public class NormalizationPipelineService {
         }
     }
 
-    private NormalizedChapterArtifact buildChapterArtifact(
-            int chapterIndex,
-            String spineHref,
-            Document document,
-            int cumulativeOffset
-    ) {
-        Element body = document.body();
-        if (body == null) {
-            return null;
-        }
-
-        List<String> paragraphs = extractParagraphs(body);
-        if (paragraphs.isEmpty()) {
-            return null;
-        }
-
-        List<Integer> paragraphStarts = new ArrayList<>();
-        List<Integer> paragraphLengths = new ArrayList<>();
-        StringBuilder rawTextBuilder = new StringBuilder();
-        int chapterOffset = 0;
-
-        for (String paragraph : paragraphs) {
-            paragraphStarts.add(chapterOffset);
-            int paragraphLength = paragraph.codePointCount(0, paragraph.length());
-            paragraphLengths.add(paragraphLength);
-            rawTextBuilder.append(paragraph);
-            chapterOffset += paragraphLength;
-        }
-
-        String title = resolveChapterTitle(document, chapterIndex);
-        int startPos = cumulativeOffset;
-        int endPos = chapterOffset == 0 ? cumulativeOffset : cumulativeOffset + chapterOffset - 1;
-
-        return NormalizedChapterArtifact.builder()
-                .chapterIndex(chapterIndex)
-                .title(title)
-                .spineHref(spineHref)
-                .paragraphStarts(paragraphStarts)
-                .paragraphLengths(paragraphLengths)
-                .totalCodePoints(chapterOffset)
-                .startPos(startPos)
-                .endPos(endPos)
-                .rawText(rawTextBuilder.toString())
-                .normalizedXhtml(buildChapterXhtml(chapterIndex, title, spineHref, paragraphs))
-                .build();
-    }
-
-    private List<String> extractParagraphs(Element body) {
-        List<String> paragraphs = new ArrayList<>();
-        for (Element candidate : body.select(String.join(",", BLOCK_TAGS))) {
-            String text = normalizeWhitespace(candidate.text());
-            if (!text.isBlank()) {
-                paragraphs.add(text);
-            }
-        }
-        if (paragraphs.isEmpty()) {
-            String bodyText = normalizeWhitespace(body.text());
-            if (!bodyText.isBlank()) {
-                paragraphs.add(bodyText);
-            }
-        }
-        return paragraphs;
-    }
-
-    private String resolveChapterTitle(Document document, int chapterIndex) {
-        for (String selector : List.of("h1", "h2", "title")) {
-            Element element = document.selectFirst(selector);
-            if (element != null) {
-                String text = normalizeWhitespace(element.text());
-                if (!text.isBlank()) {
-                    return text;
-                }
-            }
-        }
-        return "Chapter " + chapterIndex;
-    }
-
-    private String buildChapterXhtml(int chapterIndex, String title, String spineHref, List<String> paragraphs) {
-        StringBuilder builder = new StringBuilder();
-        builder.append("<section data-chapter-index=\"").append(chapterIndex).append("\"");
-        builder.append(" data-spine-href=\"").append(escapeXml(spineHref)).append("\">");
-        builder.append("<h2>").append(escapeXml(title)).append("</h2>");
-        for (int i = 0; i < paragraphs.size(); i++) {
-            builder.append("<p data-block-index=\"").append(i).append("\">")
-                    .append(escapeXml(paragraphs.get(i)))
-                    .append("</p>");
-        }
-        builder.append("</section>");
-        return builder.toString();
-    }
-
-    private String buildCombinedXhtml(List<NormalizedChapterArtifact> chapters) {
-        StringBuilder builder = new StringBuilder();
-        builder.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-        builder.append("<html xmlns=\"http://www.w3.org/1999/xhtml\"><head>");
-        builder.append("<meta charset=\"UTF-8\"/>");
-        builder.append("<title>ReadWith Normalized Reader</title>");
-        builder.append("</head><body>");
-        for (NormalizedChapterArtifact chapter : chapters) {
-            builder.append(chapter.getNormalizedXhtml());
-        }
-        builder.append("</body></html>");
-        return builder.toString();
+    private boolean isRemoteReference(String value) {
+        String normalized = value.toLowerCase(Locale.ROOT);
+        return normalized.startsWith("http://")
+                || normalized.startsWith("https://")
+                || normalized.startsWith("//")
+                || normalized.startsWith("data:");
     }
 
     private NormalizationMetaDocument buildMetaDocument(
@@ -397,10 +325,12 @@ public class NormalizationPipelineService {
             String runId,
             String ruleVersion,
             String locatorVersion,
-            List<NormalizedChapterArtifact> chapters
+            List<NormalizedChapterArtifact> chapters,
+            String combinedXhtml
     ) {
         List<Map<String, Object>> chapterReports = new ArrayList<>();
         int roundTripFailures = 0;
+        List<Integer> invalidTitleChapters = new ArrayList<>();
 
         for (NormalizedChapterArtifact chapter : chapters) {
             int chapterFailures = 0;
@@ -413,25 +343,56 @@ public class NormalizationPipelineService {
             }
 
             roundTripFailures += chapterFailures;
+            if (isInvalidCanonicalTitle(chapter.getTitle())) {
+                invalidTitleChapters.add(chapter.getChapterIndex());
+            }
 
             Map<String, Object> chapterReport = new LinkedHashMap<>();
             chapterReport.put("chapterIndex", chapter.getChapterIndex());
+            chapterReport.put("title", chapter.getTitle());
             chapterReport.put("paragraphCount", chapter.getParagraphStarts().size());
             chapterReport.put("totalCodePoints", chapter.getTotalCodePoints());
             chapterReport.put("roundTripFailures", chapterFailures);
             chapterReports.add(chapterReport);
         }
 
+        int combinedSectionCount = countCombinedSections(combinedXhtml);
         Map<String, Object> report = new LinkedHashMap<>();
         report.put("bookId", bookId);
         report.put("runId", runId);
         report.put("ruleVersion", ruleVersion);
         report.put("locatorVersion", locatorVersion);
         report.put("chapterCount", chapters.size());
+        report.put("chapterCountLimit", MAX_CANONICAL_CHAPTER_COUNT);
+        report.put("chapterCountWithinLimit", chapters.size() <= MAX_CANONICAL_CHAPTER_COUNT);
+        report.put("combinedSectionCount", combinedSectionCount);
+        report.put("combinedSectionCountMatchesChapterCount", combinedSectionCount == chapters.size());
+        report.put("invalidTitleChapterIndexes", invalidTitleChapters);
+        report.put("invalidTitleCount", invalidTitleChapters.size());
         report.put("roundTripFailures", roundTripFailures);
         report.put("status", roundTripFailures == 0 ? "PASS" : "FAIL");
         report.put("chapters", chapterReports);
         return new ValidationReport(writeJson(report), roundTripFailures);
+    }
+
+    private boolean isInvalidCanonicalTitle(String title) {
+        if (title == null || title.isBlank()) {
+            return true;
+        }
+        String normalized = title.toLowerCase(Locale.ROOT).replaceAll("\\s+", " ").trim();
+        return normalized.equals("contents")
+                || normalized.startsWith("contents ")
+                || normalized.contains("project gutenberg license")
+                || normalized.equals("index")
+                || normalized.startsWith("index ");
+    }
+
+    private int countCombinedSections(String combinedXhtml) {
+        if (combinedXhtml == null || combinedXhtml.isBlank()) {
+            return 0;
+        }
+        Document document = Jsoup.parse(combinedXhtml, "", Parser.xmlParser());
+        return document.select("section[data-chapter-index]").size();
     }
 
     private String writeJson(Object value) {
@@ -480,18 +441,6 @@ public class NormalizationPipelineService {
         return Path.of(baseDir).resolve(href).normalize().toString().replace("\\", "/");
     }
 
-    private boolean isRemoteReference(String value) {
-        String normalized = value.toLowerCase(Locale.ROOT);
-        return normalized.startsWith("http://")
-                || normalized.startsWith("https://")
-                || normalized.startsWith("//")
-                || normalized.startsWith("data:");
-    }
-
-    private String normalizeWhitespace(String text) {
-        return text == null ? "" : text.replaceAll("\\s+", " ").trim();
-    }
-
     private DocumentBuilderFactory newSecureDocumentBuilderFactory() throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
@@ -503,28 +452,14 @@ public class NormalizationPipelineService {
         return factory;
     }
 
-    private String escapeXml(String value) {
-        return value
-                .replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;")
-                .replace("\"", "&quot;")
-                .replace("'", "&apos;");
-    }
-
     private NormalizationProcessingException failure(NormalizationFailureCode code, String step, String message) {
         return new NormalizationProcessingException(code, step, message);
     }
 
-    private record ManifestItem(String href, String properties) {
-
-        private boolean isAuxiliary() {
-            if (properties == null || properties.isBlank()) {
-                return false;
-            }
-            List<String> tokens = List.of(properties.split("\\s+"));
-            return tokens.contains("nav") || tokens.contains("svg");
-        }
+    private record PackageDocumentData(
+            Map<String, EpubManifestItem> manifestById,
+            List<String> spineHrefs
+    ) {
     }
 
     private record ValidationReport(String reportJson, int roundTripFailures) {

--- a/src/main/java/com/kw/readwith/service/normalization/NormalizedChapterArtifact.java
+++ b/src/main/java/com/kw/readwith/service/normalization/NormalizedChapterArtifact.java
@@ -12,6 +12,8 @@ public class NormalizedChapterArtifact {
     private final int chapterIndex;
     private final String title;
     private final String spineHref;
+    private final List<String> sourceDocHrefs;
+    private final List<String> blockSourceDocHrefs;
     private final List<Integer> paragraphStarts;
     private final List<Integer> paragraphLengths;
     private final int totalCodePoints;

--- a/src/main/java/com/kw/readwith/service/normalization/SplitBlock.java
+++ b/src/main/java/com/kw/readwith/service/normalization/SplitBlock.java
@@ -1,0 +1,8 @@
+package com.kw.readwith.service.normalization;
+
+record SplitBlock(
+        String sourceDocHref,
+        String sourceUnitId,
+        String text
+) {
+}

--- a/src/main/java/com/kw/readwith/service/normalization/SplitUnit.java
+++ b/src/main/java/com/kw/readwith/service/normalization/SplitUnit.java
@@ -1,0 +1,34 @@
+package com.kw.readwith.service.normalization;
+
+import java.util.List;
+
+record SplitUnit(
+        String unitId,
+        String title,
+        SplitUnitRole role,
+        String sourceDocHref,
+        String startAnchorId,
+        String endAnchorId,
+        List<String> tocNodePath,
+        int depth,
+        List<SplitBlock> blocks,
+        List<Integer> paragraphStarts,
+        List<Integer> paragraphLengths,
+        int totalCodePoints
+) {
+
+    String rawText() {
+        StringBuilder builder = new StringBuilder();
+        for (SplitBlock block : blocks) {
+            builder.append(block.text());
+        }
+        return builder.toString();
+    }
+
+    String nearestAncestorTitle() {
+        if (tocNodePath == null || tocNodePath.size() < 2) {
+            return null;
+        }
+        return tocNodePath.get(tocNodePath.size() - 2);
+    }
+}

--- a/src/main/java/com/kw/readwith/service/normalization/SplitUnitClassifier.java
+++ b/src/main/java/com/kw/readwith/service/normalization/SplitUnitClassifier.java
@@ -1,0 +1,98 @@
+package com.kw.readwith.service.normalization;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+class SplitUnitClassifier {
+
+    private static final Pattern ROMAN_NUMERAL = Pattern.compile("^(?i)[IVXLCDM]+$");
+    private static final Pattern CHAPTER_TITLE = Pattern.compile("^(?i)(chapter|letter|prologue|epilogue)\\b.*");
+    private static final Pattern BOOK_TITLE = Pattern.compile("^(?i)book\\b.*");
+    private static final Pattern PART_TITLE = Pattern.compile("^(?i)part\\b.*");
+    private static final Pattern ACT_TITLE = Pattern.compile("^(?i)act\\b.*");
+    private static final Pattern SCENE_TITLE = Pattern.compile("^(?i)scene\\b.*");
+    private static final Pattern CANTO_TITLE = Pattern.compile("^(?i)canto\\b.*");
+    private static final Pattern POEM_TITLE = Pattern.compile("^(?i)(poem|sonnet)\\b.*");
+    private static final Pattern STORY_TITLE = Pattern.compile("^(?i)(story|tale)\\b.*");
+    private static final Pattern ESSAY_TITLE = Pattern.compile("^(?i)(essay|lecture|sermon)\\b.*");
+    private static final Pattern APPENDIX_TITLE = Pattern.compile("^(?i)(appendix|appendices|afterword|epilogue|conclusion)\\b.*");
+    private static final Pattern NOTES_TITLE = Pattern.compile("^(?i)(notes?|footnotes?)\\b.*");
+
+    SplitUnitRole classify(String title, List<String> tocNodePath) {
+        String normalizedTitle = normalize(title);
+        String pathText = normalize(String.join(" / ", tocNodePath == null ? List.of() : tocNodePath));
+
+        if (normalizedTitle.isBlank()) {
+            return SplitUnitRole.UNKNOWN;
+        }
+        if (containsAny(normalizedTitle, "contents", "table of contents")) {
+            return SplitUnitRole.CONTENTS;
+        }
+        if (containsAny(normalizedTitle, "project gutenberg license", "full project gutenberg")) {
+            return SplitUnitRole.LICENSE;
+        }
+        if (normalizedTitle.equals("index") || normalizedTitle.startsWith("index ")) {
+            return SplitUnitRole.INDEX;
+        }
+        if (containsAny(normalizedTitle, "preface", "foreword", "introduction")) {
+            return SplitUnitRole.FRONTMATTER;
+        }
+        if (APPENDIX_TITLE.matcher(normalizedTitle).matches()) {
+            return SplitUnitRole.APPENDIX;
+        }
+        if (NOTES_TITLE.matcher(normalizedTitle).matches()) {
+            return SplitUnitRole.NOTES;
+        }
+        if (ACT_TITLE.matcher(normalizedTitle).matches()) {
+            return SplitUnitRole.ACT;
+        }
+        if (SCENE_TITLE.matcher(normalizedTitle).matches()) {
+            return SplitUnitRole.SCENE;
+        }
+        if (CANTO_TITLE.matcher(normalizedTitle).matches()) {
+            return SplitUnitRole.CANTO;
+        }
+        if (BOOK_TITLE.matcher(normalizedTitle).matches()) {
+            return SplitUnitRole.BOOK;
+        }
+        if (PART_TITLE.matcher(normalizedTitle).matches()) {
+            return SplitUnitRole.PART;
+        }
+        if (POEM_TITLE.matcher(normalizedTitle).matches()) {
+            return SplitUnitRole.POEM;
+        }
+        if (STORY_TITLE.matcher(normalizedTitle).matches()) {
+            return SplitUnitRole.STORY;
+        }
+        if (ESSAY_TITLE.matcher(normalizedTitle).matches()) {
+            return SplitUnitRole.ESSAY;
+        }
+        if (CHAPTER_TITLE.matcher(normalizedTitle).matches()) {
+            return SplitUnitRole.CHAPTER;
+        }
+        if (ROMAN_NUMERAL.matcher(normalizedTitle).matches()) {
+            if (pathText.contains("act ")) {
+                return SplitUnitRole.SCENE;
+            }
+            if (pathText.contains("book ") || pathText.contains("part ")) {
+                return SplitUnitRole.CHAPTER;
+            }
+            return SplitUnitRole.CHAPTER;
+        }
+        return SplitUnitRole.UNKNOWN;
+    }
+
+    private boolean containsAny(String text, String... candidates) {
+        for (String candidate : candidates) {
+            if (text.contains(candidate)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String normalize(String value) {
+        return value == null ? "" : value.toLowerCase(Locale.ROOT).replaceAll("\\s+", " ").trim();
+    }
+}

--- a/src/main/java/com/kw/readwith/service/normalization/SplitUnitExtractor.java
+++ b/src/main/java/com/kw/readwith/service/normalization/SplitUnitExtractor.java
@@ -1,0 +1,314 @@
+package com.kw.readwith.service.normalization;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.select.NodeTraversor;
+import org.jsoup.select.NodeVisitor;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+class SplitUnitExtractor {
+
+    private static final Set<String> BLOCK_TAGS = Set.of("p", "li", "blockquote", "h1", "h2", "h3", "h4", "h5", "h6");
+    private static final Pattern HEADING_SPLIT = Pattern.compile(
+            "^(?i)(chapter\\b.*|book\\b.*|part\\b.*|act\\b.*|scene\\b.*|canto\\b.*|letter\\b.*|[IVXLCDM]+)$"
+    );
+
+    private final SplitUnitClassifier classifier;
+
+    SplitUnitExtractor(SplitUnitClassifier classifier) {
+        this.classifier = classifier;
+    }
+
+    List<SplitUnit> extract(TocTree tocTree, List<String> spineHrefs, Map<String, Document> documentsByHref) {
+        int[] sequence = {1};
+        if (tocTree != null && !tocTree.leafNodes().isEmpty()) {
+            List<SplitUnit> tocUnits = extractFromToc(tocTree, spineHrefs, documentsByHref, sequence);
+            if (!tocUnits.isEmpty()) {
+                return tocUnits;
+            }
+        }
+        return extractHeuristically(spineHrefs, documentsByHref, sequence);
+    }
+
+    private List<SplitUnit> extractFromToc(TocTree tocTree, List<String> spineHrefs, Map<String, Document> documentsByHref, int[] sequence) {
+        Map<String, List<TocNode>> leavesByDoc = new LinkedHashMap<>();
+        for (TocNode leaf : tocTree.leafNodes()) {
+            if (!leaf.hasHref()) {
+                continue;
+            }
+            leavesByDoc.computeIfAbsent(leaf.sourceDocHref(), ignored -> new ArrayList<>()).add(leaf);
+        }
+
+        LinkedHashSet<String> orderedDocs = new LinkedHashSet<>(spineHrefs);
+        orderedDocs.addAll(leavesByDoc.keySet());
+
+        List<SplitUnit> units = new ArrayList<>();
+        for (String docHref : orderedDocs) {
+            Document document = documentsByHref.get(docHref);
+            if (document == null || document.body() == null) {
+                continue;
+            }
+
+            List<TocNode> docLeaves = leavesByDoc.get(docHref);
+            if (docLeaves == null || docLeaves.isEmpty()) {
+                units.addAll(extractHeuristicUnitsForDocument(docHref, document, TocSource.SPINE, sequence));
+                continue;
+            }
+
+            List<DocumentBlock> blocks = collectBlocks(document.body(), docLeaves.stream()
+                    .map(TocNode::fragmentId)
+                    .filter(fragment -> fragment != null && !fragment.isBlank())
+                    .toList());
+            if (blocks.isEmpty()) {
+                continue;
+            }
+
+            int previousEnd = 0;
+            for (int i = 0; i < docLeaves.size(); i++) {
+                TocNode leaf = docLeaves.get(i);
+                int startIndex = resolveStartIndex(leaf, blocks, previousEnd);
+                int endIndex = i + 1 < docLeaves.size()
+                        ? resolveStartIndex(docLeaves.get(i + 1), blocks, blocks.size())
+                        : blocks.size();
+                if (endIndex <= startIndex) {
+                    continue;
+                }
+
+                SplitUnit unit = buildSplitUnit(
+                        "unit-" + sequence[0]++,
+                        leaf.title(),
+                        leaf.titlePath(),
+                        leaf.depth(),
+                        docHref,
+                        leaf.fragmentId(),
+                        i + 1 < docLeaves.size() ? docLeaves.get(i + 1).fragmentId() : null,
+                        blocks.subList(startIndex, endIndex)
+                );
+                units.add(unit);
+                previousEnd = endIndex;
+            }
+        }
+        return units;
+    }
+
+    private List<SplitUnit> extractHeuristically(List<String> spineHrefs, Map<String, Document> documentsByHref, int[] sequence) {
+        List<SplitUnit> units = new ArrayList<>();
+        for (String docHref : spineHrefs) {
+            Document document = documentsByHref.get(docHref);
+            if (document == null || document.body() == null) {
+                continue;
+            }
+            units.addAll(extractHeuristicUnitsForDocument(docHref, document, TocSource.HEURISTIC, sequence));
+        }
+        return units;
+    }
+
+    private List<SplitUnit> extractHeuristicUnitsForDocument(String docHref, Document document, TocSource source, int[] sequence) {
+        List<DocumentBlock> blocks = collectBlocks(document.body(), List.of());
+        if (blocks.isEmpty()) {
+            return List.of();
+        }
+
+        List<Integer> splitIndexes = new ArrayList<>();
+        for (int i = 0; i < blocks.size(); i++) {
+            DocumentBlock block = blocks.get(i);
+            if (block.tagName() != null
+                    && block.tagName().matches("h[1-3]")
+                    && HEADING_SPLIT.matcher(block.text()).matches()) {
+                splitIndexes.add(i);
+            }
+        }
+
+        List<SplitUnit> units = new ArrayList<>();
+        if (splitIndexes.size() >= 2) {
+            for (int i = 0; i < splitIndexes.size(); i++) {
+                int start = splitIndexes.get(i);
+                int end = i + 1 < splitIndexes.size() ? splitIndexes.get(i + 1) : blocks.size();
+                units.add(buildSplitUnit(
+                        "unit-" + sequence[0]++,
+                        blocks.get(start).text(),
+                        List.of(blocks.get(start).text()),
+                        1,
+                        docHref,
+                        null,
+                        null,
+                        blocks.subList(start, end)
+                ));
+            }
+            return units;
+        }
+
+        String title = resolveDocumentTitle(document);
+        return List.of(buildSplitUnit(
+                "unit-" + sequence[0]++,
+                title,
+                List.of(title),
+                1,
+                docHref,
+                null,
+                null,
+                blocks
+        ));
+    }
+
+    private SplitUnit buildSplitUnit(
+            String unitId,
+            String title,
+            List<String> tocNodePath,
+            int depth,
+            String docHref,
+            String startAnchorId,
+            String endAnchorId,
+            List<DocumentBlock> blocks
+    ) {
+        List<SplitBlock> splitBlocks = new ArrayList<>();
+        List<Integer> paragraphStarts = new ArrayList<>();
+        List<Integer> paragraphLengths = new ArrayList<>();
+        int totalCodePoints = 0;
+
+        for (DocumentBlock block : blocks) {
+            splitBlocks.add(new SplitBlock(docHref, unitId, block.text()));
+            paragraphStarts.add(totalCodePoints);
+            int paragraphLength = block.text().codePointCount(0, block.text().length());
+            paragraphLengths.add(paragraphLength);
+            totalCodePoints += paragraphLength;
+        }
+
+        String resolvedTitle = title == null || title.isBlank() ? "Untitled Section" : title;
+        return new SplitUnit(
+                unitId,
+                resolvedTitle,
+                classifier.classify(resolvedTitle, tocNodePath),
+                docHref,
+                startAnchorId,
+                endAnchorId,
+                List.copyOf(tocNodePath),
+                depth,
+                List.copyOf(splitBlocks),
+                List.copyOf(paragraphStarts),
+                List.copyOf(paragraphLengths),
+                totalCodePoints
+        );
+    }
+
+    private int resolveStartIndex(TocNode leaf, List<DocumentBlock> blocks, int defaultIndex) {
+        if (leaf.fragmentId() == null || leaf.fragmentId().isBlank()) {
+            return defaultIndex == blocks.size() ? 0 : defaultIndex;
+        }
+        Integer index = blocks.stream()
+                .filter(block -> block.anchorMappings().containsKey(leaf.fragmentId()))
+                .map(DocumentBlock::index)
+                .findFirst()
+                .orElse(null);
+        return index == null ? Math.min(defaultIndex, blocks.size()) : index;
+    }
+
+    private List<DocumentBlock> collectBlocks(Element body, List<String> targetFragments) {
+        Set<String> remainingFragments = new LinkedHashSet<>(targetFragments);
+        List<DocumentBlock> blocks = new ArrayList<>();
+        List<String> pendingFragments = new ArrayList<>();
+
+        NodeTraversor.traverse(new NodeVisitor() {
+            @Override
+            public void head(Node node, int depth) {
+                if (!(node instanceof Element element)) {
+                    return;
+                }
+
+                List<String> matchedFragments = matchedFragments(element, remainingFragments);
+                if (isBlockElement(element)) {
+                    String text = normalizeWhitespace(element.text());
+                    if (!text.isBlank()) {
+                        int blockIndex = blocks.size();
+                        Map<String, Integer> anchorMappings = new LinkedHashMap<>();
+                        for (String pendingFragment : pendingFragments) {
+                            anchorMappings.put(pendingFragment, blockIndex);
+                            remainingFragments.remove(pendingFragment);
+                        }
+                        pendingFragments.clear();
+                        for (String matchedFragment : matchedFragments) {
+                            anchorMappings.put(matchedFragment, blockIndex);
+                            remainingFragments.remove(matchedFragment);
+                        }
+                        blocks.add(new DocumentBlock(blockIndex, element.tagName(), text, anchorMappings));
+                    }
+                    return;
+                }
+
+                if (!matchedFragments.isEmpty()) {
+                    pendingFragments.addAll(matchedFragments);
+                }
+            }
+
+            @Override
+            public void tail(Node node, int depth) {
+            }
+        }, body);
+
+        if (!blocks.isEmpty()) {
+            return blocks;
+        }
+
+        String bodyText = normalizeWhitespace(body.text());
+        if (bodyText.isBlank()) {
+            return List.of();
+        }
+
+        Map<String, Integer> anchorMappings = new LinkedHashMap<>();
+        for (String fragment : targetFragments) {
+            anchorMappings.put(fragment, 0);
+        }
+        return List.of(new DocumentBlock(0, "p", bodyText, anchorMappings));
+    }
+
+    private List<String> matchedFragments(Element element, Set<String> remainingFragments) {
+        List<String> matched = new ArrayList<>();
+        String id = element.id();
+        if (id != null && !id.isBlank() && remainingFragments.contains(id)) {
+            matched.add(id);
+        }
+        String name = element.attr("name");
+        if (name != null && !name.isBlank() && remainingFragments.contains(name) && !matched.contains(name)) {
+            matched.add(name);
+        }
+        return matched;
+    }
+
+    private String resolveDocumentTitle(Document document) {
+        for (String selector : List.of("h1", "h2", "title")) {
+            Element element = document.selectFirst(selector);
+            if (element != null) {
+                String text = normalizeWhitespace(element.text());
+                if (!text.isBlank()) {
+                    return text;
+                }
+            }
+        }
+        return "Untitled Chapter";
+    }
+
+    private boolean isBlockElement(Element element) {
+        return BLOCK_TAGS.contains(element.tagName().toLowerCase(Locale.ROOT));
+    }
+
+    private String normalizeWhitespace(String value) {
+        return value == null ? "" : value.replaceAll("\\s+", " ").trim();
+    }
+
+    private record DocumentBlock(
+            int index,
+            String tagName,
+            String text,
+            Map<String, Integer> anchorMappings
+    ) {
+    }
+}

--- a/src/main/java/com/kw/readwith/service/normalization/SplitUnitRole.java
+++ b/src/main/java/com/kw/readwith/service/normalization/SplitUnitRole.java
@@ -1,0 +1,20 @@
+package com.kw.readwith.service.normalization;
+
+enum SplitUnitRole {
+    FRONTMATTER,
+    CONTENTS,
+    LICENSE,
+    INDEX,
+    CHAPTER,
+    BOOK,
+    PART,
+    ACT,
+    SCENE,
+    CANTO,
+    POEM,
+    STORY,
+    ESSAY,
+    APPENDIX,
+    NOTES,
+    UNKNOWN
+}

--- a/src/main/java/com/kw/readwith/service/normalization/TocNode.java
+++ b/src/main/java/com/kw/readwith/service/normalization/TocNode.java
@@ -1,0 +1,22 @@
+package com.kw.readwith.service.normalization;
+
+import java.util.List;
+
+record TocNode(
+        String nodeId,
+        String title,
+        String href,
+        String sourceDocHref,
+        String fragmentId,
+        int depth,
+        String parentNodeId,
+        List<TocNode> children,
+        String landmarkType,
+        TocSource tocSource,
+        List<String> titlePath
+) {
+
+    boolean hasHref() {
+        return href != null && !href.isBlank() && sourceDocHref != null && !sourceDocHref.isBlank();
+    }
+}

--- a/src/main/java/com/kw/readwith/service/normalization/TocSource.java
+++ b/src/main/java/com/kw/readwith/service/normalization/TocSource.java
@@ -1,0 +1,8 @@
+package com.kw.readwith.service.normalization;
+
+enum TocSource {
+    NAV,
+    NCX,
+    HEURISTIC,
+    SPINE
+}

--- a/src/main/java/com/kw/readwith/service/normalization/TocTree.java
+++ b/src/main/java/com/kw/readwith/service/normalization/TocTree.java
@@ -1,0 +1,34 @@
+package com.kw.readwith.service.normalization;
+
+import java.util.ArrayList;
+import java.util.List;
+
+record TocTree(
+        TocSource source,
+        List<TocNode> roots
+) {
+
+    List<TocNode> leafNodes() {
+        List<TocNode> leaves = new ArrayList<>();
+        for (TocNode root : roots) {
+            collectLeaves(root, leaves);
+        }
+        return leaves;
+    }
+
+    private void collectLeaves(TocNode node, List<TocNode> leaves) {
+        boolean hasHrefChild = node.children().stream().anyMatch(child -> child.hasHref() || !child.children().isEmpty());
+        if (node.hasHref() && !hasHrefChild) {
+            leaves.add(node);
+            return;
+        }
+
+        for (TocNode child : node.children()) {
+            collectLeaves(child, leaves);
+        }
+
+        if (node.hasHref() && node.children().isEmpty()) {
+            leaves.add(node);
+        }
+    }
+}

--- a/src/main/java/com/kw/readwith/service/normalization/TocTreeBuilder.java
+++ b/src/main/java/com/kw/readwith/service/normalization/TocTreeBuilder.java
@@ -1,0 +1,341 @@
+package com.kw.readwith.service.normalization;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+class TocTreeBuilder {
+
+    TocTree build(ZipFile zipFile, String packagePath, Map<String, EpubManifestItem> manifestById) throws IOException {
+        TocTree navTree = buildFromNav(zipFile, manifestById);
+        if (navTree != null && !navTree.leafNodes().isEmpty()) {
+            return navTree;
+        }
+
+        TocTree ncxTree = buildFromNcx(zipFile, manifestById);
+        if (ncxTree != null && !ncxTree.leafNodes().isEmpty()) {
+            return ncxTree;
+        }
+
+        return null;
+    }
+
+    private TocTree buildFromNav(ZipFile zipFile, Map<String, EpubManifestItem> manifestById) throws IOException {
+        EpubManifestItem navItem = manifestById.values().stream()
+                .filter(item -> item.hasProperty("nav"))
+                .findFirst()
+                .orElse(null);
+        if (navItem == null) {
+            return null;
+        }
+
+        ZipEntry navEntry = findEntry(zipFile, navItem.href());
+        if (navEntry == null) {
+            return null;
+        }
+
+        try (InputStream inputStream = zipFile.getInputStream(navEntry)) {
+            Document document = Jsoup.parse(inputStream, null, "", Parser.xmlParser());
+            Element tocNav = findTocNav(document);
+            if (tocNav == null) {
+                return null;
+            }
+
+            Element rootList = firstChildTag(tocNav, "ol");
+            if (rootList == null) {
+                return null;
+            }
+
+            AtomicInteger sequence = new AtomicInteger(1);
+            List<TocNode> roots = readNavList(
+                    rootList,
+                    1,
+                    null,
+                    parentPath(navItem.href()),
+                    TocSource.NAV,
+                    sequence,
+                    List.of()
+            );
+            return new TocTree(TocSource.NAV, roots);
+        }
+    }
+
+    private TocTree buildFromNcx(ZipFile zipFile, Map<String, EpubManifestItem> manifestById) throws IOException {
+        EpubManifestItem ncxItem = manifestById.values().stream()
+                .filter(item -> "application/x-dtbncx+xml".equalsIgnoreCase(item.mediaType()))
+                .findFirst()
+                .orElse(null);
+        if (ncxItem == null) {
+            return null;
+        }
+
+        ZipEntry ncxEntry = findEntry(zipFile, ncxItem.href());
+        if (ncxEntry == null) {
+            return null;
+        }
+
+        try (InputStream inputStream = zipFile.getInputStream(ncxEntry)) {
+            org.w3c.dom.Document document = newDocumentBuilderFactory().newDocumentBuilder().parse(inputStream);
+            Node navMap = findFirstByLocalName(document.getDocumentElement().getChildNodes(), "navMap");
+            if (navMap == null) {
+                return null;
+            }
+
+            AtomicInteger sequence = new AtomicInteger(1);
+            List<TocNode> roots = readNcxNavPoints(
+                    navMap.getChildNodes(),
+                    1,
+                    null,
+                    parentPath(ncxItem.href()),
+                    sequence,
+                    List.of()
+            );
+            return new TocTree(TocSource.NCX, roots);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private List<TocNode> readNavList(
+            Element listElement,
+            int depth,
+            String parentNodeId,
+            String baseDir,
+            TocSource source,
+            AtomicInteger sequence,
+            List<String> parentPath
+    ) {
+        List<TocNode> nodes = new ArrayList<>();
+        for (Element child : listElement.children()) {
+            if (!"li".equalsIgnoreCase(child.tagName())) {
+                continue;
+            }
+
+            Element link = firstChildTag(child, "a");
+            Element labelElement = link != null ? link : firstChildTag(child, "span");
+            Element nestedList = firstChildTag(child, "ol");
+            String title = normalizeWhitespace(labelElement != null ? labelElement.text() : child.ownText());
+            String href = link != null ? normalizeWhitespace(link.attr("href")) : null;
+
+            String nodeId = source.name().toLowerCase(Locale.ROOT) + "-" + sequence.getAndIncrement();
+            List<String> titlePath = extendPath(parentPath, title);
+            List<TocNode> children = nestedList == null
+                    ? List.of()
+                    : readNavList(nestedList, depth + 1, nodeId, baseDir, source, sequence, titlePath);
+
+            if ((title == null || title.isBlank()) && children.isEmpty()) {
+                continue;
+            }
+
+            nodes.add(new TocNode(
+                    nodeId,
+                    title,
+                    href,
+                    resolveSourceDocHref(baseDir, href),
+                    extractFragmentId(href),
+                    depth,
+                    parentNodeId,
+                    children,
+                    attributeValue(child, "epub:type"),
+                    source,
+                    titlePath
+            ));
+        }
+        return nodes;
+    }
+
+    private List<TocNode> readNcxNavPoints(
+            NodeList nodeList,
+            int depth,
+            String parentNodeId,
+            String baseDir,
+            AtomicInteger sequence,
+            List<String> parentPath
+    ) {
+        List<TocNode> nodes = new ArrayList<>();
+        for (int i = 0; i < nodeList.getLength(); i++) {
+            Node node = nodeList.item(i);
+            if (!matchesLocalName(node, "navPoint")) {
+                continue;
+            }
+
+            String title = resolveNcxTitle(node);
+            String href = resolveNcxHref(node);
+            String nodeId = "ncx-" + sequence.getAndIncrement();
+            List<String> titlePath = extendPath(parentPath, title);
+            List<TocNode> children = readNcxNavPoints(node.getChildNodes(), depth + 1, nodeId, baseDir, sequence, titlePath);
+            nodes.add(new TocNode(
+                    nodeId,
+                    title,
+                    href,
+                    resolveSourceDocHref(baseDir, href),
+                    extractFragmentId(href),
+                    depth,
+                    parentNodeId,
+                    children,
+                    null,
+                    TocSource.NCX,
+                    titlePath
+            ));
+        }
+        return nodes;
+    }
+
+    private Element findTocNav(Document document) {
+        for (Element nav : document.select("nav")) {
+            if (containsToken(attributeValue(nav, "epub:type"), "toc") || containsToken(attributeValue(nav, "type"), "toc")) {
+                return nav;
+            }
+        }
+        return document.selectFirst("nav");
+    }
+
+    private String resolveNcxTitle(Node navPoint) {
+        Node navLabel = findFirstByLocalName(navPoint.getChildNodes(), "navLabel");
+        if (navLabel == null) {
+            return null;
+        }
+        Node textNode = findFirstByLocalName(navLabel.getChildNodes(), "text");
+        return textNode == null ? null : normalizeWhitespace(textNode.getTextContent());
+    }
+
+    private String resolveNcxHref(Node navPoint) {
+        Node content = findFirstByLocalName(navPoint.getChildNodes(), "content");
+        if (content == null || content.getAttributes() == null || content.getAttributes().getNamedItem("src") == null) {
+            return null;
+        }
+        return normalizeWhitespace(content.getAttributes().getNamedItem("src").getNodeValue());
+    }
+
+    private Node findFirstByLocalName(NodeList nodeList, String localName) {
+        for (int i = 0; i < nodeList.getLength(); i++) {
+            Node node = nodeList.item(i);
+            if (matchesLocalName(node, localName)) {
+                return node;
+            }
+        }
+        return null;
+    }
+
+    private boolean matchesLocalName(Node node, String localName) {
+        return localName.equalsIgnoreCase(node.getLocalName()) || localName.equalsIgnoreCase(node.getNodeName());
+    }
+
+    private DocumentBuilderFactory newDocumentBuilderFactory() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        factory.setNamespaceAware(true);
+        return factory;
+    }
+
+    private Element firstChildTag(Element parent, String tagName) {
+        for (Element child : parent.children()) {
+            if (tagName.equalsIgnoreCase(child.tagName())) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    private String attributeValue(Element element, String key) {
+        if (element.hasAttr(key)) {
+            return element.attr(key);
+        }
+        return element.attributes().asList().stream()
+                .filter(attribute -> key.equalsIgnoreCase(attribute.getKey()) || attribute.getKey().endsWith(":" + key))
+                .map(org.jsoup.nodes.Attribute::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private boolean containsToken(String value, String token) {
+        if (value == null || value.isBlank()) {
+            return false;
+        }
+        for (String candidate : value.split("\\s+")) {
+            if (token.equalsIgnoreCase(candidate)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<String> extendPath(List<String> parentPath, String title) {
+        List<String> path = new ArrayList<>(parentPath);
+        if (title != null && !title.isBlank()) {
+            path.add(title);
+        }
+        return List.copyOf(path);
+    }
+
+    private String resolveSourceDocHref(String baseDir, String href) {
+        if (href == null || href.isBlank()) {
+            return null;
+        }
+        String withoutFragment = href.contains("#") ? href.substring(0, href.indexOf('#')) : href;
+        if (withoutFragment.isBlank()) {
+            return null;
+        }
+        return resolvePath(baseDir, withoutFragment);
+    }
+
+    private String extractFragmentId(String href) {
+        if (href == null || href.isBlank() || !href.contains("#")) {
+            return null;
+        }
+        return href.substring(href.indexOf('#') + 1);
+    }
+
+    private String resolvePath(String baseDir, String href) {
+        if (baseDir == null || baseDir.isBlank()) {
+            return href.replace("\\", "/");
+        }
+        return Path.of(baseDir).resolve(href).normalize().toString().replace("\\", "/");
+    }
+
+    private String parentPath(String path) {
+        int idx = path.lastIndexOf('/');
+        return idx < 0 ? "" : path.substring(0, idx);
+    }
+
+    private ZipEntry findEntry(ZipFile zipFile, String normalizedPath) {
+        ZipEntry direct = zipFile.getEntry(normalizedPath);
+        if (direct != null) {
+            return direct;
+        }
+
+        Enumeration<? extends ZipEntry> entries = zipFile.entries();
+        while (entries.hasMoreElements()) {
+            ZipEntry entry = entries.nextElement();
+            if (normalizedPath.equals(entry.getName())) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    private String normalizeWhitespace(String value) {
+        return value == null ? null : value.replaceAll("\\s+", " ").trim();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,7 +71,7 @@ spring:
 epub:
   normalization:
     enabled: ${EPUB_NORMALIZATION_ENABLED:true}
-    rule-version: ${EPUB_NORMALIZATION_RULE_VERSION:v1}
+    rule-version: ${EPUB_NORMALIZATION_RULE_VERSION:v2}
     locator-version: ${EPUB_NORMALIZATION_LOCATOR_VERSION:v2}
 
 artifact:

--- a/src/test/java/com/kw/readwith/service/GutenbergNormalizationRegressionTest.java
+++ b/src/test/java/com/kw/readwith/service/GutenbergNormalizationRegressionTest.java
@@ -23,6 +23,7 @@ class GutenbergNormalizationRegressionTest {
 
     private static final Path SAMPLE_DIR = Path.of("src", "main", "resources", "static", "books");
     private static final Path REPORT_PATH = Path.of("build", "reports", "normalization", "gutenberg-regression-report.json");
+    private static final int MAX_ALLOWED_CHAPTERS = 20;
 
     private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
     private final NormalizationPipelineService normalizationPipelineService =
@@ -47,6 +48,10 @@ class GutenbergNormalizationRegressionTest {
         List<Map<String, Object>> items = new ArrayList<>();
         int successCount = 0;
         int failureCount = 0;
+        List<String> chapterLimitViolations = new ArrayList<>();
+        List<String> invalidTitleViolations = new ArrayList<>();
+        List<String> sectionCountViolations = new ArrayList<>();
+        List<String> structuralViolations = new ArrayList<>();
 
         for (int i = 0; i < files.size(); i++) {
             Path file = files.get(i);
@@ -61,7 +66,7 @@ class GutenbergNormalizationRegressionTest {
                         file,
                         10_000L + i,
                         "regression-" + (i + 1),
-                        "rule-v1",
+                        "rule-v2",
                         "locator-v2"
                 );
 
@@ -69,11 +74,36 @@ class GutenbergNormalizationRegressionTest {
                 JsonNode report = objectMapper.readTree(result.getValidationReportJson());
 
                 item.put("success", true);
-                item.put("chapterCount", meta.path("chapters").size());
+                int chapterCount = meta.path("chapters").size();
+                int combinedSectionCount = countCombinedSections(result.getCombinedXhtml());
+                List<String> invalidTitles = invalidChapterTitles(meta);
+                List<String> structuralIssues = structuralIssues(meta);
+
+                item.put("chapterCount", chapterCount);
+                item.put("chapterCountLimit", MAX_ALLOWED_CHAPTERS);
+                item.put("chapterCountWithinLimit", chapterCount <= MAX_ALLOWED_CHAPTERS);
                 item.put("totalCodePoints", meta.path("totalCodePoints").asInt());
                 item.put("validationStatus", report.path("status").asText());
                 item.put("roundTripFailures", report.path("roundTripFailures").asInt());
                 item.put("combinedXhtmlLength", result.getCombinedXhtml().length());
+                item.put("combinedSectionCount", combinedSectionCount);
+                item.put("combinedSectionCountMatchesChapterCount", combinedSectionCount == chapterCount);
+                item.put("invalidChapterTitles", invalidTitles);
+                item.put("structurallyValid", structuralIssues.isEmpty());
+                item.put("structuralIssues", structuralIssues);
+
+                if (chapterCount > MAX_ALLOWED_CHAPTERS) {
+                    chapterLimitViolations.add(file.getFileName().toString() + "=" + chapterCount);
+                }
+                if (combinedSectionCount != chapterCount) {
+                    sectionCountViolations.add(file.getFileName().toString() + "=" + combinedSectionCount + "/" + chapterCount);
+                }
+                if (!invalidTitles.isEmpty()) {
+                    invalidTitleViolations.add(file.getFileName().toString() + "=" + invalidTitles);
+                }
+                if (!structuralIssues.isEmpty()) {
+                    structuralViolations.add(file.getFileName().toString() + "=" + structuralIssues);
+                }
                 successCount++;
             } catch (Exception e) {
                 item.put("success", false);
@@ -91,6 +121,18 @@ class GutenbergNormalizationRegressionTest {
         assertThat(failureCount)
                 .as("all Gutenberg EPUB samples should normalize successfully. report=%s", REPORT_PATH)
                 .isZero();
+        assertThat(chapterLimitViolations)
+                .as("all Gutenberg EPUB samples should produce at most %s canonical chapters. report=%s", MAX_ALLOWED_CHAPTERS, REPORT_PATH)
+                .isEmpty();
+        assertThat(sectionCountViolations)
+                .as("combined.xhtml section count must match meta.json chapter count. report=%s", REPORT_PATH)
+                .isEmpty();
+        assertThat(invalidTitleViolations)
+                .as("canonical chapter titles must not contain contents/license/index placeholders. report=%s", REPORT_PATH)
+                .isEmpty();
+        assertThat(structuralViolations)
+                .as("canonical chapter structure must be contiguous and internally consistent. report=%s", REPORT_PATH)
+                .isEmpty();
     }
 
     private void writeReport(int totalCount,
@@ -150,5 +192,79 @@ class GutenbergNormalizationRegressionTest {
         }
         StackTraceElement top = e.getStackTrace()[0];
         return top.getClassName() + ":" + top.getLineNumber();
+    }
+
+    private int countCombinedSections(String combinedXhtml) {
+        return combinedXhtml.split("<section data-chapter-index=\"", -1).length - 1;
+    }
+
+    private List<String> invalidChapterTitles(JsonNode meta) {
+        List<String> invalidTitles = new ArrayList<>();
+        for (JsonNode chapterNode : meta.path("chapters")) {
+            String title = chapterNode.path("title").asText();
+            String normalized = title == null ? "" : title.toLowerCase().replaceAll("\\s+", " ").trim();
+            if (normalized.isBlank()
+                    || normalized.equals("contents")
+                    || normalized.startsWith("contents ")
+                    || normalized.contains("project gutenberg license")
+                    || normalized.equals("index")
+                    || normalized.startsWith("index ")) {
+                invalidTitles.add(title);
+            }
+        }
+        return invalidTitles;
+    }
+
+    private List<String> structuralIssues(JsonNode meta) {
+        List<String> issues = new ArrayList<>();
+        int expectedStartPos = 0;
+
+        for (JsonNode chapterNode : meta.path("chapters")) {
+            int chapterIndex = chapterNode.path("chapterIndex").asInt();
+            int startPos = chapterNode.path("startPos").asInt();
+            int endPos = chapterNode.path("endPos").asInt();
+            int totalCodePoints = chapterNode.path("totalCodePoints").asInt();
+            JsonNode starts = chapterNode.path("paragraphStarts");
+            JsonNode lengths = chapterNode.path("paragraphLengths");
+            int paragraphCount = chapterNode.path("paragraphCount").asInt();
+
+            if (paragraphCount <= 0 || totalCodePoints <= 0) {
+                issues.add("chapter " + chapterIndex + " is empty");
+            }
+            if (paragraphCount != starts.size() || paragraphCount != lengths.size()) {
+                issues.add("chapter " + chapterIndex + " paragraph count mismatch");
+            }
+            if (startPos != expectedStartPos) {
+                issues.add("chapter " + chapterIndex + " startPos mismatch: expected " + expectedStartPos + " but was " + startPos);
+            }
+            if (endPos != startPos + totalCodePoints - 1) {
+                issues.add("chapter " + chapterIndex + " endPos mismatch");
+            }
+
+            int expectedParagraphStart = 0;
+            int paragraphTotal = 0;
+            for (int i = 0; i < Math.min(starts.size(), lengths.size()); i++) {
+                int actualParagraphStart = starts.get(i).asInt();
+                int paragraphLength = lengths.get(i).asInt();
+                if (actualParagraphStart != expectedParagraphStart) {
+                    issues.add("chapter " + chapterIndex + " paragraph start mismatch at index " + i);
+                    break;
+                }
+                if (paragraphLength < 0) {
+                    issues.add("chapter " + chapterIndex + " paragraph length is negative at index " + i);
+                    break;
+                }
+                expectedParagraphStart += paragraphLength;
+                paragraphTotal += paragraphLength;
+            }
+
+            if (paragraphTotal != totalCodePoints) {
+                issues.add("chapter " + chapterIndex + " paragraph total mismatch");
+            }
+
+            expectedStartPos = endPos + 1;
+        }
+
+        return issues;
     }
 }

--- a/src/test/java/com/kw/readwith/service/NormalizationPipelineServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/NormalizationPipelineServiceTest.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -25,14 +27,58 @@ class NormalizationPipelineServiceTest {
     @Test
     @DisplayName("normalize builds sanitized chapter artifacts and validation report")
     void normalizeEpubBuildsArtifacts() throws Exception {
-        Path epubFile = createSampleEpub();
+        Path epubFile = createEpub(Map.of(
+                "META-INF/container.xml", """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+                          <rootfiles>
+                            <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+                          </rootfiles>
+                        </container>
+                        """,
+                "OEBPS/content.opf", """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                          <manifest>
+                            <item id="chap1" href="chap1.xhtml" media-type="application/xhtml+xml"/>
+                            <item id="chap2" href="chap2.xhtml" media-type="application/xhtml+xml"/>
+                          </manifest>
+                          <spine>
+                            <itemref idref="chap1"/>
+                            <itemref idref="chap2"/>
+                          </spine>
+                        </package>
+                        """,
+                "OEBPS/chap1.xhtml", """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <html xmlns="http://www.w3.org/1999/xhtml">
+                          <head><title>Chapter One</title></head>
+                          <body>
+                            <h1>Chapter One</h1>
+                            <p>First paragraph.</p>
+                            <p onclick="alert('x')">Second paragraph. <a href="https://evil.example">bad link</a></p>
+                            <script>alert('x')</script>
+                          </body>
+                        </html>
+                        """,
+                "OEBPS/chap2.xhtml", """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <html xmlns="http://www.w3.org/1999/xhtml">
+                          <head><title>Chapter Two</title></head>
+                          <body>
+                            <h1>Chapter Two</h1>
+                            <p>Last paragraph.</p>
+                          </body>
+                        </html>
+                        """
+        ));
 
         try {
             NormalizationPipelineResult result = normalizationPipelineService.normalize(
                     epubFile,
                     42L,
                     "run-1",
-                    "rule-v1",
+                    "rule-v2",
                     "locator-v2"
             );
 
@@ -51,63 +97,284 @@ class NormalizationPipelineServiceTest {
             JsonNode report = objectMapper.readTree(result.getValidationReportJson());
             assertThat(report.get("status").asText()).isEqualTo("PASS");
             assertThat(report.get("roundTripFailures").asInt()).isZero();
+            assertThat(report.get("chapterCountWithinLimit").asBoolean()).isTrue();
+            assertThat(report.get("combinedSectionCountMatchesChapterCount").asBoolean()).isTrue();
+            assertThat(report.get("invalidTitleCount").asInt()).isZero();
         } finally {
             Files.deleteIfExists(epubFile);
         }
     }
 
-    private Path createSampleEpub() throws IOException {
-        Path epubFile = Files.createTempFile("normalization-pipeline-test-", ".epub");
+    @Test
+    @DisplayName("normalize splits multiple fragments in a single XHTML document into canonical chapters")
+    void normalizeSplitsNavFragmentsWithinSingleDocument() throws Exception {
+        Path epubFile = createEpub(Map.of(
+                "META-INF/container.xml", containerXml(),
+                "OEBPS/content.opf", """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                          <manifest>
+                            <item id="nav" href="toc.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+                            <item id="book" href="book.xhtml" media-type="application/xhtml+xml"/>
+                          </manifest>
+                          <spine>
+                            <itemref idref="book"/>
+                          </spine>
+                        </package>
+                        """,
+                "OEBPS/toc.xhtml", """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+                          <body>
+                            <nav epub:type="toc">
+                              <ol>
+                                <li><a href="book.xhtml#chapter-1">CHAPTER I</a></li>
+                                <li><a href="book.xhtml#chapter-2">CHAPTER II</a></li>
+                              </ol>
+                            </nav>
+                          </body>
+                        </html>
+                        """,
+                "OEBPS/book.xhtml", """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <html xmlns="http://www.w3.org/1999/xhtml">
+                          <head><title>Novel</title></head>
+                          <body>
+                            <section id="chapter-1">
+                              <h2>CHAPTER I</h2>
+                              <p>Alpha one.</p>
+                              <p>Alpha two.</p>
+                            </section>
+                            <section id="chapter-2">
+                              <h2>CHAPTER II</h2>
+                              <p>Beta one.</p>
+                              <p>Beta two.</p>
+                            </section>
+                          </body>
+                        </html>
+                        """
+        ));
 
-        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(epubFile))) {
-            writeZipEntry(zipOutputStream, "META-INF/container.xml", """
-                    <?xml version="1.0" encoding="UTF-8"?>
-                    <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
-                      <rootfiles>
-                        <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
-                      </rootfiles>
-                    </container>
-                    """);
+        try {
+            NormalizationPipelineResult result = normalizationPipelineService.normalize(
+                    epubFile,
+                    7L,
+                    "run-fragments",
+                    "rule-v2",
+                    "locator-v2"
+            );
 
-            writeZipEntry(zipOutputStream, "OEBPS/content.opf", """
-                    <?xml version="1.0" encoding="UTF-8"?>
-                    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
-                      <manifest>
-                        <item id="chap1" href="chap1.xhtml" media-type="application/xhtml+xml"/>
-                        <item id="chap2" href="chap2.xhtml" media-type="application/xhtml+xml"/>
-                      </manifest>
-                      <spine>
-                        <itemref idref="chap1"/>
-                        <itemref idref="chap2"/>
-                      </spine>
-                    </package>
-                    """);
+            assertThat(result.getChapters()).hasSize(2);
+            assertThat(result.getChapters().get(0).getTitle()).isEqualTo("CHAPTER I");
+            assertThat(result.getChapters().get(1).getTitle()).isEqualTo("CHAPTER II");
+            assertThat(result.getChapters().get(0).getSpineHref()).isEqualTo("OEBPS/book.xhtml");
+            assertThat(result.getCombinedXhtml()).contains("data-spine-href=\"OEBPS/book.xhtml\"");
 
-            writeZipEntry(zipOutputStream, "OEBPS/chap1.xhtml", """
-                    <?xml version="1.0" encoding="UTF-8"?>
-                    <html xmlns="http://www.w3.org/1999/xhtml">
-                      <head><title>Chapter One</title></head>
-                      <body>
-                        <h1>Chapter One</h1>
-                        <p>First paragraph.</p>
-                        <p onclick="alert('x')">Second paragraph. <a href="https://evil.example">bad link</a></p>
-                        <script>alert('x')</script>
-                      </body>
-                    </html>
-                    """);
+            JsonNode meta = objectMapper.readTree(result.getMetaJson());
+            assertThat(meta.get("chapters")).hasSize(2);
+            assertThat(meta.get("chapters").get(0).get("title").asText()).isEqualTo("CHAPTER I");
+            assertThat(meta.get("chapters").get(1).get("title").asText()).isEqualTo("CHAPTER II");
 
-            writeZipEntry(zipOutputStream, "OEBPS/chap2.xhtml", """
-                    <?xml version="1.0" encoding="UTF-8"?>
-                    <html xmlns="http://www.w3.org/1999/xhtml">
-                      <head><title>Chapter Two</title></head>
-                      <body>
-                        <h1>Chapter Two</h1>
-                        <p>Last paragraph.</p>
-                      </body>
-                    </html>
-                    """);
+            JsonNode report = objectMapper.readTree(result.getValidationReportJson());
+            assertThat(report.get("chapterCountWithinLimit").asBoolean()).isTrue();
+            assertThat(report.get("combinedSectionCountMatchesChapterCount").asBoolean()).isTrue();
+        } finally {
+            Files.deleteIfExists(epubFile);
         }
+    }
 
+    @Test
+    @DisplayName("normalize promotes scenes to acts for canonical chapters")
+    void normalizePromotesScenesToActs() throws Exception {
+        Path epubFile = createEpub(Map.of(
+                "META-INF/container.xml", containerXml(),
+                "OEBPS/content.opf", """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                          <manifest>
+                            <item id="nav" href="toc.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+                            <item id="play" href="play.xhtml" media-type="application/xhtml+xml"/>
+                          </manifest>
+                          <spine>
+                            <itemref idref="play"/>
+                          </spine>
+                        </package>
+                        """,
+                "OEBPS/toc.xhtml", """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+                          <body>
+                            <nav epub:type="toc">
+                              <ol>
+                                <li>
+                                  <span>PLAY</span>
+                                  <ol>
+                                    <li>
+                                      <span>ACT I</span>
+                                      <ol>
+                                        <li><a href="play.xhtml#scene-1">SCENE I</a></li>
+                                        <li><a href="play.xhtml#scene-2">SCENE II</a></li>
+                                      </ol>
+                                    </li>
+                                    <li>
+                                      <span>ACT II</span>
+                                      <ol>
+                                        <li><a href="play.xhtml#scene-3">SCENE I</a></li>
+                                      </ol>
+                                    </li>
+                                  </ol>
+                                </li>
+                              </ol>
+                            </nav>
+                          </body>
+                        </html>
+                        """,
+                "OEBPS/play.xhtml", """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <html xmlns="http://www.w3.org/1999/xhtml">
+                          <head><title>Play</title></head>
+                          <body>
+                            <div id="scene-1">
+                              <h2>SCENE I</h2>
+                              <p>Scene one opening.</p>
+                              <p>Scene one continues with enough text to be treated as dramatic content.</p>
+                            </div>
+                            <div id="scene-2">
+                              <h2>SCENE II</h2>
+                              <p>Scene two opening.</p>
+                              <p>Scene two continues with enough text to remain in the same canonical act.</p>
+                            </div>
+                            <div id="scene-3">
+                              <h2>SCENE I</h2>
+                              <p>Act two begins.</p>
+                              <p>Act two continues with its own dramatic content.</p>
+                            </div>
+                          </body>
+                        </html>
+                        """
+        ));
+
+        try {
+            NormalizationPipelineResult result = normalizationPipelineService.normalize(
+                    epubFile,
+                    8L,
+                    "run-drama",
+                    "rule-v2",
+                    "locator-v2"
+            );
+
+            assertThat(result.getChapters()).hasSize(2);
+            assertThat(result.getChapters().get(0).getTitle()).isEqualTo("ACT I");
+            assertThat(result.getChapters().get(1).getTitle()).isEqualTo("ACT II");
+
+            JsonNode report = objectMapper.readTree(result.getValidationReportJson());
+            assertThat(report.get("chapterCountWithinLimit").asBoolean()).isTrue();
+            assertThat(report.get("invalidTitleCount").asInt()).isZero();
+        } finally {
+            Files.deleteIfExists(epubFile);
+        }
+    }
+
+    @Test
+    @DisplayName("normalize excludes contents and project gutenberg license from canonical chapters")
+    void normalizeExcludesContentsAndLicense() throws Exception {
+        Path epubFile = createEpub(Map.of(
+                "META-INF/container.xml", containerXml(),
+                "OEBPS/content.opf", """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                          <manifest>
+                            <item id="nav" href="toc.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+                            <item id="contents" href="contents.xhtml" media-type="application/xhtml+xml"/>
+                            <item id="book" href="book.xhtml" media-type="application/xhtml+xml"/>
+                            <item id="license" href="license.xhtml" media-type="application/xhtml+xml"/>
+                          </manifest>
+                          <spine>
+                            <itemref idref="contents"/>
+                            <itemref idref="book"/>
+                            <itemref idref="license"/>
+                          </spine>
+                        </package>
+                        """,
+                "OEBPS/toc.xhtml", """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+                          <body>
+                            <nav epub:type="toc">
+                              <ol>
+                                <li><a href="contents.xhtml">Contents</a></li>
+                                <li><a href="book.xhtml#chapter-1">CHAPTER I</a></li>
+                                <li><a href="book.xhtml#chapter-2">CHAPTER II</a></li>
+                                <li><a href="license.xhtml">THE FULL PROJECT GUTENBERG LICENSE</a></li>
+                              </ol>
+                            </nav>
+                          </body>
+                        </html>
+                        """,
+                "OEBPS/contents.xhtml", """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <html xmlns="http://www.w3.org/1999/xhtml">
+                          <head><title>Contents</title></head>
+                          <body><h1>Contents</h1><p>Skip me.</p></body>
+                        </html>
+                        """,
+                "OEBPS/book.xhtml", """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <html xmlns="http://www.w3.org/1999/xhtml">
+                          <head><title>Book</title></head>
+                          <body>
+                            <section id="chapter-1"><h2>CHAPTER I</h2><p>Start.</p></section>
+                            <section id="chapter-2"><h2>CHAPTER II</h2><p>Next.</p></section>
+                          </body>
+                        </html>
+                        """,
+                "OEBPS/license.xhtml", """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <html xmlns="http://www.w3.org/1999/xhtml">
+                          <head><title>THE FULL PROJECT GUTENBERG LICENSE</title></head>
+                          <body><h1>THE FULL PROJECT GUTENBERG LICENSE</h1><p>Skip me too.</p></body>
+                        </html>
+                        """
+        ));
+
+        try {
+            NormalizationPipelineResult result = normalizationPipelineService.normalize(
+                    epubFile,
+                    9L,
+                    "run-filtered",
+                    "rule-v2",
+                    "locator-v2"
+            );
+
+            assertThat(result.getChapters()).hasSize(2);
+            assertThat(result.getChapters().get(0).getTitle()).isEqualTo("CHAPTER I");
+            assertThat(result.getChapters().get(1).getTitle()).isEqualTo("CHAPTER II");
+
+            JsonNode report = objectMapper.readTree(result.getValidationReportJson());
+            assertThat(report.get("invalidTitleCount").asInt()).isZero();
+        } finally {
+            Files.deleteIfExists(epubFile);
+        }
+    }
+
+    private String containerXml() {
+        return """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+                  <rootfiles>
+                    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+                  </rootfiles>
+                </container>
+                """;
+    }
+
+    private Path createEpub(Map<String, String> entries) throws IOException {
+        Path epubFile = Files.createTempFile("normalization-pipeline-test-", ".epub");
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(epubFile))) {
+            for (Map.Entry<String, String> entry : new LinkedHashMap<>(entries).entrySet()) {
+                writeZipEntry(zipOutputStream, entry.getKey(), entry.getValue());
+            }
+        }
         return epubFile;
     }
 

--- a/src/test/java/com/kw/readwith/service/normalization/CanonicalChapterPlannerTest.java
+++ b/src/test/java/com/kw/readwith/service/normalization/CanonicalChapterPlannerTest.java
@@ -1,0 +1,110 @@
+package com.kw.readwith.service.normalization;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CanonicalChapterPlannerTest {
+
+    @Test
+    @DisplayName("planner promotes scenes under the same act into one canonical chapter")
+    void plannerPromotesScenesToActs() {
+        CanonicalChapterPlanner planner = new CanonicalChapterPlanner();
+
+        List<CanonicalChapterPlan> plans = planner.plan(List.of(
+                scene("unit-1", "SCENE I", List.of("PLAY", "ACT I", "SCENE I"), 5000),
+                scene("unit-2", "SCENE II", List.of("PLAY", "ACT I", "SCENE II"), 4000),
+                scene("unit-3", "SCENE I", List.of("PLAY", "ACT II", "SCENE I"), 4500)
+        ));
+
+        assertThat(plans).hasSize(2);
+        assertThat(plans.get(0).title()).isEqualTo("ACT I");
+        assertThat(plans.get(1).title()).isEqualTo("ACT II");
+    }
+
+    @Test
+    @DisplayName("planner groups many short cantos into fewer canonical chapters when chapter count exceeds the soft cap")
+    void plannerGroupsShortCantosWhenTooMany() {
+        CanonicalChapterPlanner planner = new CanonicalChapterPlanner(3000, 3000, 6000, 8000, 2);
+
+        List<CanonicalChapterPlan> plans = planner.plan(List.of(
+                canto("unit-1", "Canto 1", List.of("Book I", "Canto 1"), 1200),
+                canto("unit-2", "Canto 2", List.of("Book I", "Canto 2"), 1100),
+                canto("unit-3", "Canto 3", List.of("Book I", "Canto 3"), 1300),
+                canto("unit-4", "Canto 4", List.of("Book I", "Canto 4"), 1250),
+                canto("unit-5", "Canto 5", List.of("Book I", "Canto 5"), 1280)
+        ));
+
+        assertThat(plans.size()).isLessThan(5);
+        assertThat(plans.get(0).title()).contains("Book I");
+    }
+
+    @Test
+    @DisplayName("planner forces large chapter sets into twenty or fewer canonical chapters")
+    void plannerForcesLargeChapterSetsIntoTwentyOrFewerChapters() {
+        CanonicalChapterPlanner planner = new CanonicalChapterPlanner();
+
+        List<SplitUnit> units = java.util.stream.IntStream.rangeClosed(1, 75)
+                .mapToObj(index -> unit(
+                        "unit-" + index,
+                        "Chapter " + index,
+                        SplitUnitRole.CHAPTER,
+                        List.of("Novel", "Chapter " + index),
+                        2500
+                ))
+                .toList();
+
+        List<CanonicalChapterPlan> plans = planner.plan(units);
+
+        assertThat(plans).hasSizeLessThanOrEqualTo(20);
+    }
+
+    @Test
+    @DisplayName("planner does not reuse contents as the canonical title when grouping sibling units")
+    void plannerSkipsContentsPlaceholderWhenResolvingGroupedTitle() {
+        CanonicalChapterPlanner planner = new CanonicalChapterPlanner(3000, 3000, 6000, 8000, 1);
+
+        List<CanonicalChapterPlan> plans = planner.plan(List.of(
+                unit("unit-1", "ACT I", SplitUnitRole.ACT, List.of("Contents", "PLAY", "ACT I"), 2500),
+                unit("unit-2", "ACT II", SplitUnitRole.ACT, List.of("Contents", "PLAY", "ACT II"), 2500)
+        ));
+
+        assertThat(plans).hasSize(1);
+        assertThat(plans.get(0).title()).isEqualTo("PLAY");
+    }
+
+    private SplitUnit scene(String unitId, String title, List<String> path, int totalCodePoints) {
+        return unit(unitId, title, SplitUnitRole.SCENE, path, totalCodePoints);
+    }
+
+    private SplitUnit canto(String unitId, String title, List<String> path, int totalCodePoints) {
+        return unit(unitId, title, SplitUnitRole.CANTO, path, totalCodePoints);
+    }
+
+    private SplitUnit unit(
+            String unitId,
+            String title,
+            SplitUnitRole role,
+            List<String> path,
+            int totalCodePoints
+    ) {
+        String text = "a".repeat(totalCodePoints);
+        return new SplitUnit(
+                unitId,
+                title,
+                role,
+                "OEBPS/book.xhtml",
+                null,
+                null,
+                path,
+                path.size(),
+                List.of(new SplitBlock("OEBPS/book.xhtml", unitId, text)),
+                List.of(0),
+                List.of(totalCodePoints),
+                totalCodePoints
+        );
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약

> 정규화 엔진 교체

EPUB 정규화 규칙을 v1의 `spine item 1개 = chapter 1개` 방식에서,
`TOC fragment 기반 분할 -> canonical chapter 병합` 방식의 v2로 교체했습니다.

이번 변경의 목적은 두 가지입니다.
1. 같은 XHTML 안에 여러 장이 들어 있는 EPUB에서 chapter가 과도하게 뭉치는 문제를 해결합니다.
2. 전집/희곡/장시처럼 TOC leaf가 지나치게 많은 EPUB에서 chapter가 과도하게 잘게 쪼개지는 문제를 해결합니다.

최종적으로는 reader, locator, AI 분석 입력이 모두 같은 `canonical chapter` 체계를 보도록 맞췄고,
AI 분석 운영 제약을 반영해 canonical chapter 수가 20개 이하가 되도록 강하게 병합하는 정책을 적용했습니다.

## 📋 변경 사항
- `NormalizationPipelineService`를 TOC 기반 v2 파이프라인으로 교체했습니다.
- `nav` 우선, `ncx` fallback, `heading heuristic` fallback 구조를 도입했습니다.
- `SplitUnitExtractor`, `SplitUnitClassifier`, `CanonicalChapterPlanner`, `CanonicalChapterRenderer`를 추가했습니다.
- 같은 XHTML 내부 fragment를 기준으로 split unit을 만들고, 이를 다시 canonical chapter로 병합하도록 변경했습니다.
- `scene -> act` 승격, `contents/license/index/frontmatter` 제외, 짧은 unit 병합, chapter 수 20 이하 강제 병합 규칙을 추가했습니다.
- `combined.xhtml`, `meta.json`, DB projection이 모두 동일한 canonical chapter 기준으로 생성되도록 맞췄습니다.
- `NormalizedChapterArtifact`에 source provenance를 담을 수 있도록 확장했습니다.
- 기본 `ruleVersion`을 `v2`로 변경했습니다.
- 단위 테스트를 추가해 fragment 분할, scene->act 승격, placeholder 제거, chapter 수 제한 동작을 검증했습니다.
- Project Gutenberg 회귀 테스트를 보강해 배포 전 아래 조건을 확인하도록 했습니다.
  - 모든 샘플 EPUB 정규화 성공
  - canonical chapter 수 20 이하
  - `combined.xhtml` section 수와 `meta.json` chapter 수 일치
  - `Contents/License/Index` placeholder title 미포함
  - `startPos/endPos`, `paragraphStarts/paragraphLengths` 구조 일관성 유지

의사결정 배경:
- `spine = chapter`는 `Moby-Dick`, `Pride and Prejudice` 같은 책에서 과소분할을 만듭니다.
- 반대로 `TOC leaf = chapter`를 그대로 쓰면 Shakespeare/Byron/Ramayan 같은 전집류에서 수백 개 chapter가 생깁니다.
- 따라서 `정확한 경계는 TOC fragment에서 잡고`, `실제 저장 단위는 canonical chapter로 다시 병합`하는 2단계 구조가 필요했습니다.
- 이번 서비스 목적은 원작 chapter 보존보다 reader/AI가 같은 분석 단위를 공유하는 쪽이 더 중요하므로, 20개 이하 강한 병합 정책을 채택했습니다.

로컬 추가 검증:
- Project Gutenberg 실제 EPUB 17개를 기준으로 회귀 검증했습니다.
- 대형 샘플 결과:
  - Shakespeare: 20 chapters
  - Moby-Dick: 19 chapters
  - Pride and Prejudice: 14 chapters
  - Byron Vol. 2: 11 chapters
  - Rámáyan: 7 chapters
- 이 대형 샘플 EPUB 파일 자체는 저장소에 포함하지 않았고, 로컬 검증용으로만 사용했습니다.

## 🔍 Code Review
- canonical chapter를 원작 chapter가 아니라 reader/AI 공통 분석 단위로 보는 현재 정책이 서비스 의도와 맞는지
- `20개 이하 강한 병합`이 UX와 AI 처리량 관점에서 적절한지 확인 (현재 로컬 체크중 완성도 높음!)
- `ruleVersion=v2` 전환 후 기존 v1 책이 `OUTDATED`로 표시되는 현재 상태가 운영 정책과 맞는지
- 배포 전 회귀 게이트는 아래 명령으로 확인
  - `.\gradlew.bat test --tests "com.kw.readwith.service.GutenbergNormalizationRegressionTest"`
- 생성 리포트:
  - `build/reports/normalization/gutenberg-regression-report.json`

## 📸 ScreenShot
- 없음