### PR TITLE
fix: boolean 필드 직렬화/역직렬화 계약 불일치로 값이 누락되는 문제 수정

### DIFF
--- a/src/main/java/com/kw/readwith/dto/admin/CharacterDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/CharacterDTO.java
@@ -14,10 +14,12 @@ import java.util.Map;
 @Schema(description = "인물 1명에 대한 업로드 항목")
 public class CharacterDTO {
 
+    @JsonProperty("characterId")
     @JsonAlias("id")
     @Schema(description = "책 내부 characterId. 숫자 문자열을 사용합니다.", example = "7")
     private String characterId;
 
+    @JsonProperty("commonName")
     @JsonAlias("common_name")
     @Schema(description = "대표 이름", example = "셜록 홈즈")
     private String commonName;
@@ -25,7 +27,8 @@ public class CharacterDTO {
     @Schema(description = "이름/별칭 목록")
     private List<String> names;
 
-    @JsonAlias("main_character")
+    @JsonProperty("isMainCharacter")
+    @JsonAlias({"main_character", "mainCharacter"})
     @Schema(description = "주요 인물 여부")
     private boolean isMainCharacter;
 
@@ -36,6 +39,7 @@ public class CharacterDTO {
     @Schema(description = "legacy 한국어 설명 필드", deprecated = true, nullable = true)
     private String legacyDescriptionKo;
 
+    @JsonProperty("portraitPrompt")
     @JsonAlias("portrait_prompt")
     @Schema(description = "이미지 생성용 프롬프트 또는 프로필 텍스트")
     private String portraitPrompt;

--- a/src/main/java/com/kw/readwith/dto/book/BookDetailDTO.java
+++ b/src/main/java/com/kw/readwith/dto/book/BookDetailDTO.java
@@ -1,6 +1,8 @@
 package com.kw.readwith.dto.book;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -22,6 +24,7 @@ public class BookDetailDTO {
     private String language;
 
     @Schema(description = "기본 제공 도서 여부")
+    @Getter(AccessLevel.NONE)
     private boolean isDefault;
 
     @Schema(description = "표지 이미지 URL", nullable = true)
@@ -55,8 +58,19 @@ public class BookDetailDTO {
     private String normalizedArtifactPath;
 
     @Schema(description = "현재 사용자 기준 즐겨찾기 여부")
+    @Getter(AccessLevel.NONE)
     private boolean isFavorite;
 
     @Schema(description = "요약 준비 완료 여부")
     private boolean summary;
+
+    @JsonProperty("isDefault")
+    public boolean isDefault() {
+        return isDefault;
+    }
+
+    @JsonProperty("isFavorite")
+    public boolean isFavorite() {
+        return isFavorite;
+    }
 }

--- a/src/main/java/com/kw/readwith/dto/book/BookSummaryDTO.java
+++ b/src/main/java/com/kw/readwith/dto/book/BookSummaryDTO.java
@@ -1,6 +1,8 @@
 package com.kw.readwith.dto.book;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -51,9 +53,11 @@ public class BookSummaryDTO {
     private String normalizedArtifactPath;
 
     @Schema(description = "현재 사용자 기준 즐겨찾기 여부")
+    @Getter(AccessLevel.NONE)
     private boolean isFavorite;
 
     @Schema(description = "기본 제공 도서 여부")
+    @Getter(AccessLevel.NONE)
     private boolean isDefault;
 
     @Schema(description = "요약 준비 완료 여부")
@@ -61,4 +65,14 @@ public class BookSummaryDTO {
 
     @Schema(description = "마지막 수정 시각")
     private LocalDateTime updatedAt;
+
+    @JsonProperty("isFavorite")
+    public boolean isFavorite() {
+        return isFavorite;
+    }
+
+    @JsonProperty("isDefault")
+    public boolean isDefault() {
+        return isDefault;
+    }
 }

--- a/src/main/java/com/kw/readwith/dto/book/ChapterPovSummaryDTO.java
+++ b/src/main/java/com/kw/readwith/dto/book/ChapterPovSummaryDTO.java
@@ -1,6 +1,8 @@
 package com.kw.readwith.dto.book;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,5 +23,11 @@ public class ChapterPovSummaryDTO {
     private String summaryText;
 
     @Schema(description = "주요 인물 여부")
+    @Getter(AccessLevel.NONE)
     private boolean isMainCharacter;
+
+    @JsonProperty("isMainCharacter")
+    public boolean isMainCharacter() {
+        return isMainCharacter;
+    }
 }

--- a/src/main/java/com/kw/readwith/dto/bookmark/BookmarkResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/bookmark/BookmarkResponseDTO.java
@@ -1,7 +1,9 @@
 package com.kw.readwith.dto.bookmark;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.kw.readwith.dto.common.LocatorDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -40,6 +42,7 @@ public class BookmarkResponseDTO {
     private String memo;
 
     @Schema(description = "범위 북마크 여부", example = "true")
+    @Getter(AccessLevel.NONE)
     private boolean isRangeBookmark;
 
     @Schema(description = "생성 시각")
@@ -47,4 +50,9 @@ public class BookmarkResponseDTO {
 
     @Schema(description = "수정 시각")
     private LocalDateTime updatedAt;
+
+    @JsonProperty("isRangeBookmark")
+    public boolean isRangeBookmark() {
+        return isRangeBookmark;
+    }
 }

--- a/src/main/java/com/kw/readwith/dto/graph/GraphNodeDTO.java
+++ b/src/main/java/com/kw/readwith/dto/graph/GraphNodeDTO.java
@@ -2,6 +2,7 @@ package com.kw.readwith.dto.graph;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,36 +10,41 @@ import java.util.List;
 
 @Getter
 @Builder
-@Schema(description = "그래프의 인물 노드")
+@Schema(description = "Graph character node")
 public class GraphNodeDTO {
 
-    @Schema(description = "책 내부 characterId", example = "7")
+    @Schema(description = "Character ID", example = "7")
     private Long id;
 
     @JsonProperty("common_name")
-    @Schema(description = "대표 이름")
+    @Schema(description = "Common character name")
     private String label;
 
-    @JsonProperty("main_character")
-    @Schema(description = "주요 인물 여부")
+    @Getter(AccessLevel.NONE)
+    @Schema(description = "Whether the character is a main character")
     private Boolean isMainCharacter;
 
-    @Schema(description = "프로필 이미지 URL", nullable = true)
+    @Schema(description = "Profile image URL", nullable = true)
     private String profileImage;
 
-    @Schema(description = "인물 설명", nullable = true)
+    @Schema(description = "Character description", nullable = true)
     private String description;
 
     @JsonProperty("portrait_prompt")
-    @Schema(description = "프로필/프롬프트 텍스트", nullable = true)
+    @Schema(description = "Portrait prompt text", nullable = true)
     private String portraitPrompt;
 
-    @Schema(description = "이름/별칭 목록")
+    @Schema(description = "Character names and aliases")
     private List<String> names;
 
-    @Schema(description = "현재 이벤트 또는 누적 시점에서의 node weight", nullable = true)
+    @Schema(description = "Node weight in the current event or cumulative view", nullable = true)
     private Float weight;
 
-    @Schema(description = "누적 그래프에서 등장 횟수", nullable = true)
+    @Schema(description = "Occurrence count in the cumulative graph", nullable = true)
     private Integer count;
+
+    @JsonProperty("isMainCharacter")
+    public Boolean getIsMainCharacter() {
+        return isMainCharacter;
+    }
 }

--- a/src/main/java/com/kw/readwith/dto/manifest/BookManifestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/manifest/BookManifestDTO.java
@@ -1,6 +1,8 @@
 package com.kw.readwith.dto.manifest;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -22,6 +24,7 @@ public class BookManifestDTO {
     private String language;
 
     @Schema(description = "기본 제공 도서 여부")
+    @Getter(AccessLevel.NONE)
     private Boolean isDefault;
 
     @Schema(description = "요약 준비 완료 여부")
@@ -59,4 +62,9 @@ public class BookManifestDTO {
 
     @Schema(description = "정규화 산출물 루트 경로", nullable = true)
     private String normalizedArtifactPath;
+
+    @JsonProperty("isDefault")
+    public Boolean getIsDefault() {
+        return isDefault;
+    }
 }

--- a/src/main/java/com/kw/readwith/dto/manifest/CharacterManifestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/manifest/CharacterManifestDTO.java
@@ -1,6 +1,8 @@
 package com.kw.readwith.dto.manifest;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -22,6 +24,7 @@ public class CharacterManifestDTO {
     private String profileImage;
 
     @Schema(description = "주요 인물 여부")
+    @Getter(AccessLevel.NONE)
     private Boolean isMainCharacter;
 
     @Schema(description = "처음 등장한 챕터 인덱스", nullable = true)
@@ -32,4 +35,9 @@ public class CharacterManifestDTO {
 
     @Schema(description = "이미지 생성용 프롬프트 또는 프로필 텍스트", nullable = true)
     private String profileText;
+
+    @JsonProperty("isMainCharacter")
+    public Boolean getIsMainCharacter() {
+        return isMainCharacter;
+    }
 }

--- a/src/test/java/com/kw/readwith/dto/BooleanDtoContractTest.java
+++ b/src/test/java/com/kw/readwith/dto/BooleanDtoContractTest.java
@@ -1,0 +1,167 @@
+package com.kw.readwith.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kw.readwith.dto.admin.CharacterDTO;
+import com.kw.readwith.dto.book.BookDetailDTO;
+import com.kw.readwith.dto.book.BookSummaryDTO;
+import com.kw.readwith.dto.book.ChapterPovSummaryDTO;
+import com.kw.readwith.dto.bookmark.BookmarkResponseDTO;
+import com.kw.readwith.dto.graph.GraphNodeDTO;
+import com.kw.readwith.dto.manifest.BookManifestDTO;
+import com.kw.readwith.dto.manifest.CharacterManifestDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BooleanDtoContractTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @Test
+    @DisplayName("character upload DTO accepts camelCase and legacy aliases for isMainCharacter")
+    void characterDtoAcceptsMainCharacterKeys() throws Exception {
+        CharacterDTO camelCase = objectMapper.readValue("""
+                {
+                  "characterId": "1",
+                  "commonName": "Victor",
+                  "isMainCharacter": true,
+                  "descriptions": {
+                    "ko": "wizard"
+                  },
+                  "portraitPrompt": "prompt"
+                }
+                """, CharacterDTO.class);
+
+        CharacterDTO snakeCase = objectMapper.readValue("""
+                {
+                  "characterId": "1",
+                  "commonName": "Victor",
+                  "main_character": true,
+                  "descriptions": {
+                    "ko": "wizard"
+                  },
+                  "portraitPrompt": "prompt"
+                }
+                """, CharacterDTO.class);
+
+        CharacterDTO plainCamel = objectMapper.readValue("""
+                {
+                  "characterId": "1",
+                  "commonName": "Victor",
+                  "mainCharacter": true,
+                  "descriptions": {
+                    "ko": "wizard"
+                  },
+                  "portraitPrompt": "prompt"
+                }
+                """, CharacterDTO.class);
+
+        assertThat(camelCase.isMainCharacter()).isTrue();
+        assertThat(snakeCase.isMainCharacter()).isTrue();
+        assertThat(plainCamel.isMainCharacter()).isTrue();
+    }
+
+    @Test
+    @DisplayName("response DTOs serialize boolean fields with stable camelCase keys")
+    void responseDtosSerializeStableBooleanKeys() throws Exception {
+        BookSummaryDTO bookSummary = BookSummaryDTO.builder()
+                .id(1L)
+                .title("Book")
+                .author("Author")
+                .normalizationStatus("READY")
+                .analysisStatus("NONE")
+                .ruleVersion("v2")
+                .locatorVersion("v2")
+                .normalizationRunId("run")
+                .normalizationVersionStatus("CURRENT")
+                .needsRenormalization(false)
+                .isFavorite(true)
+                .isDefault(true)
+                .summary(false)
+                .build();
+        BookDetailDTO bookDetail = BookDetailDTO.builder()
+                .id(1L)
+                .title("Book")
+                .author("Author")
+                .language("en")
+                .isDefault(true)
+                .normalizationStatus("READY")
+                .analysisStatus("NONE")
+                .ruleVersion("v2")
+                .locatorVersion("v2")
+                .normalizationRunId("run")
+                .normalizationVersionStatus("CURRENT")
+                .needsRenormalization(false)
+                .isFavorite(true)
+                .summary(false)
+                .build();
+        BookManifestDTO bookManifest = BookManifestDTO.builder()
+                .id(1L)
+                .title("Book")
+                .author("Author")
+                .language("en")
+                .isDefault(true)
+                .summary(false)
+                .normalizationStatus("READY")
+                .analysisStatus("NONE")
+                .ruleVersion("v2")
+                .locatorVersion("v2")
+                .normalizationRunId("run")
+                .normalizationVersionStatus("CURRENT")
+                .needsRenormalization(false)
+                .build();
+        CharacterManifestDTO characterManifest = CharacterManifestDTO.builder()
+                .id(1L)
+                .name("Victor")
+                .isMainCharacter(true)
+                .build();
+        ChapterPovSummaryDTO chapterPovSummary = new ChapterPovSummaryDTO(1L, "Victor", "summary", true);
+        GraphNodeDTO graphNode = GraphNodeDTO.builder()
+                .id(1L)
+                .label("Victor")
+                .isMainCharacter(true)
+                .portraitPrompt("prompt")
+                .build();
+        BookmarkResponseDTO bookmark = BookmarkResponseDTO.builder()
+                .id(1L)
+                .bookId(1L)
+                .isRangeBookmark(true)
+                .build();
+
+        JsonNode bookSummaryJson = objectMapper.readTree(objectMapper.writeValueAsBytes(bookSummary));
+        JsonNode bookDetailJson = objectMapper.readTree(objectMapper.writeValueAsBytes(bookDetail));
+        JsonNode bookManifestJson = objectMapper.readTree(objectMapper.writeValueAsBytes(bookManifest));
+        JsonNode characterManifestJson = objectMapper.readTree(objectMapper.writeValueAsBytes(characterManifest));
+        JsonNode chapterPovSummaryJson = objectMapper.readTree(objectMapper.writeValueAsBytes(chapterPovSummary));
+        JsonNode graphNodeJson = objectMapper.readTree(objectMapper.writeValueAsBytes(graphNode));
+        JsonNode bookmarkJson = objectMapper.readTree(objectMapper.writeValueAsBytes(bookmark));
+
+        assertThat(bookSummaryJson.has("isFavorite")).isTrue();
+        assertThat(bookSummaryJson.has("favorite")).isFalse();
+        assertThat(bookSummaryJson.has("isDefault")).isTrue();
+        assertThat(bookSummaryJson.has("default")).isFalse();
+
+        assertThat(bookDetailJson.has("isFavorite")).isTrue();
+        assertThat(bookDetailJson.has("favorite")).isFalse();
+        assertThat(bookDetailJson.has("isDefault")).isTrue();
+        assertThat(bookDetailJson.has("default")).isFalse();
+
+        assertThat(bookManifestJson.has("isDefault")).isTrue();
+        assertThat(bookManifestJson.has("default")).isFalse();
+
+        assertThat(characterManifestJson.has("isMainCharacter")).isTrue();
+        assertThat(characterManifestJson.has("mainCharacter")).isFalse();
+        assertThat(characterManifestJson.has("main_character")).isFalse();
+
+        assertThat(chapterPovSummaryJson.has("isMainCharacter")).isTrue();
+        assertThat(chapterPovSummaryJson.has("mainCharacter")).isFalse();
+
+        assertThat(graphNodeJson.has("isMainCharacter")).isTrue();
+        assertThat(graphNodeJson.has("main_character")).isFalse();
+
+        assertThat(bookmarkJson.has("isRangeBookmark")).isTrue();
+        assertThat(bookmarkJson.has("rangeBookmark")).isFalse();
+    }
+}

--- a/src/test/java/com/kw/readwith/service/AdminServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/AdminServiceTest.java
@@ -118,6 +118,7 @@ class AdminServiceTest {
                       "id": "1",
                       "common_name": "Harry Potter",
                       "names": ["The Boy Who Lived"],
+                      "isMainCharacter": true,
                       "descriptions": {
                         "ko": "wizard"
                       },
@@ -145,6 +146,7 @@ class AdminServiceTest {
         List<Character> savedCharacters = captor.getValue();
         assertThat(savedCharacters).hasSize(1);
         assertThat(savedCharacters.get(0).getName()).isEqualTo("Harry Potter");
+        assertThat(savedCharacters.get(0).isMainCharacter()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
boolean 필드의 JSON 계약이 DTO마다 달라서 값이 누락되거나, 같은 의미가 서로 다른 key 이름으로 내려가던 문제를 정리했습니다.

가장 직접적인 문제는 character 업로드에서 `isMainCharacter: true`가 들어와도 DTO에 바인딩되지 않아 DB에 전부 `false`로 저장되던 것이었습니다.
이번 PR에서는 입력 DTO의 역직렬화 계약을 명시하고, 응답 DTO도 프론트에 내려가는 boolean key를 camelCase `isXxx` 기준으로 고정했습니다.

## 📋 변경 사항
- `CharacterDTO`에 `@JsonProperty("isMainCharacter")`를 추가해 `isMainCharacter`를 명시적으로 역직렬화하도록 수정했습니다.
- legacy 호환을 위해 `main_character`, `mainCharacter`는 alias로 허용하도록 정리했습니다.
- `characterId`, `commonName`, `portraitPrompt`도 camelCase 계약을 명시적으로 고정했습니다.
- 응답 DTO의 boolean 필드를 `isXxx` 기준으로 통일했습니다.
- 대상:
  - `BookSummaryDTO`
  - `BookDetailDTO`
  - `BookManifestDTO`
  - `CharacterManifestDTO`
  - `ChapterPovSummaryDTO`
  - `BookmarkResponseDTO`
  - `GraphNodeDTO`
- Lombok 기본 getter 때문에 `favorite/default/mainCharacter/rangeBookmark` 같은 추가 key가 같이 노출되지 않도록, 해당 boolean 필드는 수동 getter + `@JsonProperty`로 고정했습니다.
- `AdminServiceTest`에 `isMainCharacter=true` 업로드 후 실제 저장 엔티티가 `true`인지 확인하는 회귀 테스트를 추가했습니다.
- `BooleanDtoContractTest`를 추가해 입력 alias 허용과 응답 key 이름을 JSON 기준으로 검증하도록 했습니다.

## 🔍 Code Review
- 외부 계약의 boolean 응답 key를 앞으로 `isXxx` camelCase로 유지하는 방향이 프론트 계약과 맞는지 확인 부탁드립니다.
- `CharacterDTO`에서 허용한 legacy alias(`main_character`, `mainCharacter`) 범위가 적절한지 확인 부탁드립니다.
- `GraphNodeDTO`도 이제 `main_character` 대신 `isMainCharacter`로 내려가므로, 그래프 소비 클라이언트 영향 여부 확인 부탁드립니다.
- 이번 PR은 DTO 계약 안정화에 집중했고, 컨트롤러 통합 테스트는 기존 DB schema validation 이슈 때문에 전체 확인은 못 했습니다.

## 📸 ScreenShot
- 없음