### PR TITLE
feat: 책 단위 캐릭터 AI 프로필 이미지 스타일 통일 구조 도입

### DIFF
--- a/src/main/java/com/kw/readwith/domain/Book.java
+++ b/src/main/java/com/kw/readwith/domain/Book.java
@@ -21,60 +21,63 @@ public class Book extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;   // 책 PK
+    private Long id;
 
     @Column(length = 200, nullable = false)
-    private String title;   // 책 목록/리더에 보여줄 제목
+    private String title;
 
     @Column(length = 120, nullable = false)
-    private String author;   // 책 목록/리더에 보여줄 저자
+    private String author;
 
     @Column(length = 10, nullable = false)
-    private String language;   // 검색/표시에 쓰는 언어 코드
+    private String language;
 
     @Column(nullable = false)
-    private boolean isDefault;   // 기본 제공 책인지 구분
+    private boolean isDefault;
 
     @Column(nullable = false)
     @Builder.Default
-    private boolean summary = false;   // 요약 자료 준비 여부(legacy 호환)
+    private boolean summary = false;
 
     @Column(name = "cover_img_url", length = 255)
-    private String coverImgUrl;   // 책 카드 커버 이미지
+    private String coverImgUrl;
 
     @Column(name = "summary_url", length = 255)
-    private String summaryUrl;   // 책 전체 요약 리소스 경로
+    private String summaryUrl;
+
+    @Lob
+    @Column(name = "book_prompt", columnDefinition = "TEXT")
+    private String bookPrompt;
 
     @Column(name = "epub_path", length = 255)
-    private String epubPath;   // 업로드한 원본 EPUB 경로
+    private String epubPath;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "normalization_status", length = 30)
     @Builder.Default
-    private NormalizationStatus normalizationStatus = NormalizationStatus.NONE;   // 본문 읽기 가능 상태
+    private NormalizationStatus normalizationStatus = NormalizationStatus.NONE;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "analysis_status", length = 30)
     @Builder.Default
-    private AnalysisStatus analysisStatus = AnalysisStatus.NONE;   // AI 분석 자료 준비 상태
+    private AnalysisStatus analysisStatus = AnalysisStatus.NONE;
 
     @Column(name = "rule_version", length = 50)
-    private String ruleVersion;   // active 정규화 규칙 버전
+    private String ruleVersion;
 
     @Column(name = "locator_version", length = 50)
-    private String locatorVersion;   // active locator 계산 버전
+    private String locatorVersion;
 
     @Column(name = "normalized_artifact_path", length = 255)
-    private String normalizedArtifactPath;   // active 정규화 산출물 루트 경로
+    private String normalizedArtifactPath;
 
     @Column(name = "normalization_run_id", length = 80)
-    private String normalizationRunId;   // 현재 reader가 보는 active 정규화 run id
+    private String normalizationRunId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "uploaded_by_user_id")
-    private User uploadedBy;   // null == 서버 기본 제공
+    private User uploadedBy;
 
-    /* 관계 */
     @OneToMany(mappedBy = "book", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Chapter> chapters = new ArrayList<>();
@@ -99,9 +102,6 @@ public class Book extends BaseEntity {
     @Builder.Default
     private List<Bookmark> bookmarks = new ArrayList<>();
 
-    /**
-     * 비즈니스 로직
-     */
     public void updateSummary(String summaryUrl) {
         this.summary = true;
         this.summaryUrl = summaryUrl;
@@ -117,6 +117,10 @@ public class Book extends BaseEntity {
 
     public void updateCoverImage(String coverImgUrl) {
         this.coverImgUrl = coverImgUrl;
+    }
+
+    public void updateBookPrompt(String bookPrompt) {
+        this.bookPrompt = bookPrompt;
     }
 
     public void markNormalizationQueued() {

--- a/src/main/java/com/kw/readwith/dto/admin/CharacterListDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/CharacterListDTO.java
@@ -1,6 +1,7 @@
 package com.kw.readwith.dto.admin;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,10 +10,15 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
-@Schema(description = "인물 업로드 payload 루트")
+@Schema(description = "Character upload payload root")
 public class CharacterListDTO {
 
+    @JsonProperty("bookPrompt")
+    @JsonAlias("book_prompt")
+    @Schema(description = "Book-level common style prompt", nullable = true)
+    private String bookPrompt;
+
     @JsonAlias("characters")
-    @Schema(description = "인물 목록")
+    @Schema(description = "Character list")
     private List<CharacterDTO> items;
 }

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -90,6 +90,11 @@ public class AdminService {
                 throw new GeneralException(ErrorStatus._BAD_REQUEST, "Character payload is invalid.");
             }
 
+            String bookPrompt = normalizeOptionalText(characterListDTO.getBookPrompt());
+            if (bookPrompt != null) {
+                book.updateBookPrompt(bookPrompt);
+            }
+
             if (characterListDTO.getItems().isEmpty()) {
                 log.warn("No characters found in upload payload.");
                 bookAnalysisStatusService.refreshStatus(bookId);

--- a/src/main/java/com/kw/readwith/service/CharacterImageService.java
+++ b/src/main/java/com/kw/readwith/service/CharacterImageService.java
@@ -2,6 +2,7 @@ package com.kw.readwith.service;
 
 import com.kw.readwith.aws.s3.AmazonS3Manager;
 import com.kw.readwith.config.CharacterImageProperties;
+import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Character;
 import com.kw.readwith.domain.enums.ImageGenerationStatus;
 import com.kw.readwith.repository.CharacterRepository;
@@ -23,14 +24,21 @@ import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-/**
- * 캐릭터 프로필 이미지 생성 및 관리 서비스
- * OpenAI DALL-E 3를 사용하여 캐릭터의 외모 묘사를 기반으로 이미지를 생성
- */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CharacterImageService {
+
+    private static final String BASE_STYLE_PROMPT =
+            "A consistent character profile portrait in a mature storybook editorial illustration style, " +
+            "chest-up bust portrait, centered composition, plain soft background, soft textured brushwork, " +
+            "low-saturation color palette, calm and literary mood, semi-flat illustration, clean silhouette, " +
+            "gentle facial details, natural proportions, not childish, not cartoonish, not anime, " +
+            "not exaggerated, designed as a book character profile image";
+
+    private static final String SINGLE_SUBJECT_ENFORCEMENT =
+            "single person only, exactly one subject, no additional people, no duo, no group, " +
+            "no crowd, no background characters, no interaction scene, no props, no scenery";
 
     private final OpenAiImageModel imageModel;
     private final AmazonS3Manager s3Manager;
@@ -38,261 +46,199 @@ public class CharacterImageService {
     private final CharacterImageProperties imageProperties;
     private final CharacterImageTransactionService transactionService;
 
-    /**
-     * 여러 캐릭터의 이미지를 비동기로 생성
-     * 배치 단위로 처리하며, Rate Limit 방지를 위해 요청 간 딜레이 적용
-     * 
-     * @param characterIds 이미지를 생성할 캐릭터 ID 리스트
-     * @return 비동기 작업 결과
-     */
     @Async("imageGenerationExecutor")
     public CompletableFuture<Void> generateImagesAsync(List<Long> characterIds) {
         int totalCount = characterIds.size();
-        log.info("캐릭터 이미지 생성 시작 - 총 {}명 (배치 크기: {}명)", 
-            totalCount, imageProperties.getBatchSize());
-        
+        log.info("Starting character image generation. totalCount={}, batchSize={}",
+                totalCount, imageProperties.getBatchSize());
+
         int processedCount = 0;
         int successCount = 0;
         int failedCount = 0;
         int skippedCount = 0;
-        
+
         for (int i = 0; i < characterIds.size(); i++) {
             Long characterId = characterIds.get(i);
             processedCount++;
-            
+
             try {
-                // 엔티티를 fetch join으로 재조회 (Book도 함께 로딩)
                 Character character = characterRepository.findByIdWithBook(characterId)
-                        .orElseThrow(() -> new RuntimeException("캐릭터를 찾을 수 없습니다: " + characterId));
-                
-                // 이미 이미지가 있거나 생성 완료된 경우 스킵
-                if (character.getProfileImage() != null && !character.getProfileImage().isEmpty() 
-                    && character.getImageGenerationStatus() == ImageGenerationStatus.COMPLETED) {
-                    log.info("[{}/{}] 캐릭터 '{}' - 이미지가 이미 존재하여 스킵", 
-                        processedCount, totalCount, character.getName());
+                        .orElseThrow(() -> new RuntimeException("Character not found: " + characterId));
+
+                if (character.getProfileImage() != null
+                        && !character.getProfileImage().isEmpty()
+                        && character.getImageGenerationStatus() == ImageGenerationStatus.COMPLETED) {
+                    log.info("Skipping character image generation because it already exists. characterId={}, name={}",
+                            characterId, character.getName());
                     skippedCount++;
                     continue;
                 }
 
-                // 상태를 PENDING으로 설정
                 transactionService.updateStatus(characterId, ImageGenerationStatus.PENDING);
-                
-                log.info("[{}/{}] 캐릭터 '{}' 이미지 생성 시작...", 
-                    processedCount, totalCount, character.getName());
-                
                 generateAndSaveImage(characterId);
                 successCount++;
-                
-                log.info("[{}/{}] 캐릭터 '{}' 이미지 생성 완료 ✓", 
-                    processedCount, totalCount, character.getName());
-                
-                // Rate Limit 방지: 마지막 캐릭터가 아니면 딜레이 적용
+
                 if (i < characterIds.size() - 1) {
-                    long delay = imageProperties.getDelayBetweenRequestsMs();
-                    log.debug("다음 요청까지 {}ms 대기...", delay);
-                    Thread.sleep(delay);
+                    Thread.sleep(imageProperties.getDelayBetweenRequestsMs());
                 }
-                
-                // 배치 단위로 진행 상황 로그
+
                 if (processedCount % imageProperties.getBatchSize() == 0) {
-                    log.info("═══ 배치 진행 상황: {}/{} 완료 (성공: {}, 실패: {}, 스킵: {}) ═══", 
-                        processedCount, totalCount, successCount, failedCount, skippedCount);
+                    log.info("Character image generation progress. processed={}, total={}, success={}, failed={}, skipped={}",
+                            processedCount, totalCount, successCount, failedCount, skippedCount);
                 }
-                
             } catch (InterruptedException e) {
-                log.error("캐릭터 ID {} 처리 중 인터럽트 발생", characterId, e);
+                log.error("Character image generation interrupted. characterId={}", characterId, e);
                 Thread.currentThread().interrupt();
                 failedCount++;
                 saveFallbackImage(characterId);
-                break; // 인터럽트 시 중단
+                break;
             } catch (Exception e) {
-                log.error("캐릭터 ID {} 이미지 생성 실패: {}", characterId, e.getMessage(), e);
+                log.error("Character image generation failed. characterId={}", characterId, e);
                 failedCount++;
                 saveFallbackImage(characterId);
             }
         }
-        
-        log.info("═══════════════════════════════════════════════════════════");
-        log.info("캐릭터 이미지 생성 작업 완료");
-        log.info("총 {}명 처리 - 성공: {}명, 실패: {}명, 스킵: {}명", 
-            totalCount, successCount, failedCount, skippedCount);
-        log.info("═══════════════════════════════════════════════════════════");
-        
+
+        log.info("Character image generation completed. total={}, success={}, failed={}, skipped={}",
+                totalCount, successCount, failedCount, skippedCount);
+
         return CompletableFuture.completedFuture(null);
     }
 
-    /**
-     * 단일 캐릭터의 이미지를 생성하고 저장
-     * 
-     * ⚠️ 트랜잭션 최적화: 외부 API 호출은 트랜잭션 밖에서 실행
-     * DB 커넥션 점유 시간: 14초 → 0.02초 (99.9% 개선)
-     * 
-     * @param characterId 이미지를 생성할 캐릭터 ID
-     */
     public void generateAndSaveImage(Long characterId) {
-        log.info("캐릭터 ID {} 이미지 생성 시작", characterId);
+        log.info("Generating character image. characterId={}", characterId);
 
         try {
-            // 1. Read-only 트랜잭션으로 캐릭터 정보 조회 (빠른 커넥션 반환)
             Character character = getCharacterReadOnly(characterId);
-            log.info("캐릭터 '{}' 정보 조회 완료", character.getName());
-            
-            // 상태를 GENERATING으로 변경
             transactionService.updateStatus(characterId, ImageGenerationStatus.GENERATING);
 
-            // 2. 프롬프트 생성 (트랜잭션 없음)
             String prompt = buildDallePrompt(character);
-            log.debug("생성된 프롬프트: {}", prompt);
+            log.debug("Generated image prompt for characterId={}: {}", characterId, prompt);
 
-            // 3. DALL-E API 호출 (트랜잭션 없음, 커넥션 없음, ~10초 소요)
             ImageResponse response = imageModel.call(
-                new ImagePrompt(prompt, 
-                    OpenAiImageOptions.builder()
-                        .withModel("dall-e-3")
-                        .withQuality("standard")
-                        .withN(1)
-                        .withHeight(1024)
-                        .withWidth(1024)
-                        .build()
-                )
+                    new ImagePrompt(
+                            prompt,
+                            OpenAiImageOptions.builder()
+                                    .withModel("dall-e-3")
+                                    .withQuality("standard")
+                                    .withN(1)
+                                    .withHeight(1024)
+                                    .withWidth(1024)
+                                    .build()
+                    )
             );
 
-            // 4. 생성된 이미지 URL 추출
             String dalleImageUrl = response.getResult().getOutput().getUrl();
-            log.info("캐릭터 '{}' DALL-E 이미지 생성 완료: {}", character.getName(), dalleImageUrl);
-
-            // 5. DALL-E URL에서 이미지 다운로드 (트랜잭션 없음, ~2초 소요)
             byte[] imageData = downloadImageFromUrl(dalleImageUrl);
-            log.info("캐릭터 '{}' 이미지 다운로드 완료 - 크기: {} bytes", character.getName(), imageData.length);
-
-            // 6. Base64 인코딩 (트랜잭션 없음)
             String base64Image = Base64.getEncoder().encodeToString(imageData);
-            
-            // 7. S3 업로드 (트랜잭션 없음, ~2초 소요)
+
             String s3KeyName = buildS3KeyName(character);
             String s3Url = s3Manager.uploadFileFromBase64(s3KeyName, base64Image, "image/png");
-            log.info("캐릭터 '{}' S3 업로드 완료: {}", character.getName(), s3Url);
-            
-            // 8. 별도 트랜잭션으로 DB 업데이트만 수행 (0.01초만 커넥션 점유)
             updateImageUrlOnly(characterId, s3Url);
-            
-            log.info("캐릭터 '{}' 이미지 생성 및 저장 완료", character.getName());
 
+            log.info("Character image generation completed. characterId={}, s3Url={}", characterId, s3Url);
         } catch (Exception e) {
-            log.error("캐릭터 ID {} 이미지 생성 중 오류 발생", characterId, e);
+            log.error("Character image generation failed during processing. characterId={}", characterId, e);
             transactionService.updateStatus(characterId, ImageGenerationStatus.FAILED);
-            throw new RuntimeException("이미지 생성 중 오류 발생: " + characterId, e);
+            throw new RuntimeException("Failed to generate character image: " + characterId, e);
         }
     }
-    
-    /**
-     * 읽기 전용 트랜잭션으로 캐릭터 조회
-     * 빠르게 커넥션을 반환하여 풀 고갈 방지
-     */
+
     @Transactional(readOnly = true)
     private Character getCharacterReadOnly(Long characterId) {
         return characterRepository.findByIdWithBook(characterId)
-                .orElseThrow(() -> new RuntimeException("캐릭터를 찾을 수 없습니다: " + characterId));
+                .orElseThrow(() -> new RuntimeException("Character not found: " + characterId));
     }
-    
-    /**
-     * 새로운 트랜잭션으로 이미지 URL과 상태만 업데이트
-     * REQUIRES_NEW: 부모 트랜잭션과 독립적으로 실행
-     * timeout: 5초 (DB 업데이트만 수행하므로 충분)
-     */
+
     @Transactional(propagation = Propagation.REQUIRES_NEW, timeout = 5)
     private void updateImageUrlOnly(Long characterId, String s3Url) {
         transactionService.updateImageAndStatus(characterId, s3Url, ImageGenerationStatus.COMPLETED);
     }
 
-    /**
-     * DALL-E 프롬프트 생성
-     * 스타일 제약사항을 먼저 명시하고, 그 안에서 캐릭터 특징 표현
-     * 
-     * @param character 대상 캐릭터
-     * @return 생성된 프롬프트
-     */
     private String buildDallePrompt(Character character) {
         StringBuilder prompt = new StringBuilder();
-        
-        // 1. 먼저 스타일 제약사항 명시 (DALL-E가 이것을 기준으로 삼게)
-        prompt.append(imageProperties.getCommonStyle());
-        prompt.append("\n\n");
-        
-        // 2. 그 다음 캐릭터 묘사 (제약사항 내에서 표현)
-        prompt.append("━━━ CHARACTER DESCRIPTION (within above constraints) ━━━\n");
-        
-        if (character.getProfileText() != null && !character.getProfileText().isEmpty()) {
-            prompt.append("Subject: ").append(character.getProfileText());
-        } else {
-            // profileText가 없는 경우 이름만 사용
-            prompt.append("Subject: A person named ").append(character.getName());
-        }
-        
-        // 3. 마지막으로 다시 한번 핵심 제약 강조
-        prompt.append("\n\nREMINDER: FACE AND SHOULDERS ONLY. PLAIN BEIGE BACKGROUND. NO patterns, NO decorations, NO symbols.");
-        
+
+        appendPromptSegment(prompt, BASE_STYLE_PROMPT);
+        appendPromptSegment(prompt, normalizePromptSegment(resolveBookPrompt(character.getBook())));
+        appendPromptSegment(prompt, normalizePromptSegment(resolvePortraitPrompt(character)));
+        appendPromptSegment(prompt, SINGLE_SUBJECT_ENFORCEMENT);
+
         return prompt.toString();
     }
 
-    /**
-     * URL에서 이미지를 다운로드하여 byte 배열로 반환
-     * Azure Blob Storage SAS 토큰이 포함된 URL도 처리 가능
-     * 
-     * @param imageUrl 다운로드할 이미지 URL
-     * @return 이미지 데이터 (byte 배열)
-     * @throws IOException 다운로드 실패 시
-     */
+    private String resolveBookPrompt(Book book) {
+        return book == null ? null : book.getBookPrompt();
+    }
+
+    private String resolvePortraitPrompt(Character character) {
+        String portraitPrompt = normalizePromptSegment(character.getProfileText());
+        if (portraitPrompt != null) {
+            return portraitPrompt;
+        }
+        return "single character portrait of " + character.getName();
+    }
+
+    private String normalizePromptSegment(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String normalized = value
+                .replace("\r\n", " ")
+                .replace('\r', ' ')
+                .replace('\n', ' ')
+                .replaceAll("\\s+", " ")
+                .trim();
+
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private void appendPromptSegment(StringBuilder prompt, String segment) {
+        if (segment == null || segment.isBlank()) {
+            return;
+        }
+
+        if (prompt.length() > 0) {
+            prompt.append(", ");
+        }
+        prompt.append(segment);
+    }
+
     private byte[] downloadImageFromUrl(String imageUrl) throws IOException {
-        log.debug("이미지 다운로드 시작: {}", imageUrl);
-        
+        log.debug("Downloading generated image from URL={}", imageUrl);
+
         try {
-            // URL을 직접 열어서 스트림으로 읽기 (SAS 토큰 보존)
             URL url = new URL(imageUrl);
             try (InputStream inputStream = url.openStream()) {
                 byte[] imageData = inputStream.readAllBytes();
-                
                 if (imageData.length == 0) {
-                    throw new IOException("다운로드한 이미지 데이터가 비어있습니다.");
+                    throw new IOException("Downloaded image is empty.");
                 }
-                
-                log.debug("이미지 다운로드 완료 - 크기: {} bytes", imageData.length);
                 return imageData;
             }
         } catch (IOException e) {
-            log.error("이미지 다운로드 실패 - URL: {}", imageUrl, e);
-            throw new IOException("이미지 다운로드 실패: " + e.getMessage(), e);
+            log.error("Generated image download failed. url={}", imageUrl, e);
+            throw new IOException("Failed to download generated image: " + e.getMessage(), e);
         }
     }
 
-    /**
-     * S3 저장을 위한 키 이름 생성
-     * 형식: {s3Path}/{bookId}/{characterId}.png
-     * 
-     * @param character 대상 캐릭터
-     * @return S3 키 이름
-     */
     private String buildS3KeyName(Character character) {
-        return String.format("%s/%d/%d.png", 
-            imageProperties.getS3Path(),
-            character.getBook().getId(),
-            character.getId()
-        );
+        return String.format("%s/%d/%d.png",
+                imageProperties.getS3Path(),
+                character.getBook().getId(),
+                character.getId());
     }
 
-    /**
-     * 이미지 생성 실패 시 폴백 이미지로 설정
-     *
-     * @param characterId 대상 캐릭터 ID
-     */
     private void saveFallbackImage(Long characterId) {
         try {
-            String fallbackUrl = imageProperties.getFallbackUrl();
-            transactionService.updateImageAndStatus(characterId, fallbackUrl, ImageGenerationStatus.FAILED);
-            log.info("캐릭터 ID {} - 폴백 이미지 설정 완료", characterId);
+            transactionService.updateImageAndStatus(
+                    characterId,
+                    imageProperties.getFallbackUrl(),
+                    ImageGenerationStatus.FAILED
+            );
+            log.info("Stored fallback image for characterId={}", characterId);
         } catch (Exception e) {
-            log.error("캐릭터 ID {} - 폴백 이미지 설정 실패", characterId, e);
+            log.error("Failed to store fallback image. characterId={}", characterId, e);
         }
     }
 }
-

--- a/src/main/resources/db/migration/V4__add_book_prompt_to_book.sql
+++ b/src/main/resources/db/migration/V4__add_book_prompt_to_book.sql
@@ -1,0 +1,2 @@
+ALTER TABLE book
+    ADD COLUMN book_prompt TEXT NULL AFTER summary_url;

--- a/src/test/java/com/kw/readwith/dto/BooleanDtoContractTest.java
+++ b/src/test/java/com/kw/readwith/dto/BooleanDtoContractTest.java
@@ -3,6 +3,7 @@ package com.kw.readwith.dto;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kw.readwith.dto.admin.CharacterDTO;
+import com.kw.readwith.dto.admin.CharacterListDTO;
 import com.kw.readwith.dto.book.BookDetailDTO;
 import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.dto.book.ChapterPovSummaryDTO;
@@ -61,6 +62,27 @@ class BooleanDtoContractTest {
         assertThat(camelCase.isMainCharacter()).isTrue();
         assertThat(snakeCase.isMainCharacter()).isTrue();
         assertThat(plainCamel.isMainCharacter()).isTrue();
+    }
+
+    @Test
+    @DisplayName("character upload root DTO accepts camelCase and snake_case for bookPrompt")
+    void characterListDtoAcceptsBookPromptKeys() throws Exception {
+        CharacterListDTO camelCase = objectMapper.readValue("""
+                {
+                  "bookPrompt": "Victorian urban gothic",
+                  "items": []
+                }
+                """, CharacterListDTO.class);
+
+        CharacterListDTO snakeCase = objectMapper.readValue("""
+                {
+                  "book_prompt": "Victorian urban gothic",
+                  "items": []
+                }
+                """, CharacterListDTO.class);
+
+        assertThat(camelCase.getBookPrompt()).isEqualTo("Victorian urban gothic");
+        assertThat(snakeCase.getBookPrompt()).isEqualTo("Victorian urban gothic");
     }
 
     @Test

--- a/src/test/java/com/kw/readwith/service/AdminServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/AdminServiceTest.java
@@ -113,6 +113,7 @@ class AdminServiceTest {
         Long bookId = 1L;
         String jsonContent = """
                 {
+                  "bookPrompt": "Victorian urban gothic, muted sepia and deep green palette",
                   "characters": [
                     {
                       "id": "1",
@@ -147,6 +148,7 @@ class AdminServiceTest {
         assertThat(savedCharacters).hasSize(1);
         assertThat(savedCharacters.get(0).getName()).isEqualTo("Harry Potter");
         assertThat(savedCharacters.get(0).isMainCharacter()).isTrue();
+        assertThat(book.getBookPrompt()).isEqualTo("Victorian urban gothic, muted sepia and deep green palette");
     }
 
     @Test

--- a/src/test/java/com/kw/readwith/service/CharacterImageServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/CharacterImageServiceTest.java
@@ -12,29 +12,31 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.ai.image.Image;
+import org.springframework.ai.image.ImageGeneration;
 import org.springframework.ai.image.ImageResponse;
 import org.springframework.ai.openai.OpenAiImageModel;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.client.RestTemplate;
 
-import java.util.Arrays;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-/**
- * CharacterImageService 단위 테스트
- * OpenAI API와 S3 업로드는 모킹하여 실제 비용 발생 없이 테스트
- */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-@DisplayName("캐릭터 이미지 생성 서비스 테스트")
+@DisplayName("CharacterImageService")
 class CharacterImageServiceTest {
 
     @Mock
@@ -52,264 +54,104 @@ class CharacterImageServiceTest {
     @Mock
     private CharacterImageTransactionService transactionService;
 
-    @Spy
-    private RestTemplate restTemplate;
-
     @InjectMocks
     private CharacterImageService characterImageService;
 
     private Book testBook;
-    private Character testCharacter1;
-    private Character testCharacter2;
+    private Character testCharacter;
 
     @BeforeEach
     void setUp() {
-        // 테스트용 Book 생성
         testBook = Book.builder()
                 .id(1L)
-                .title("테스트 책")
-                .author("테스트 작가")
-                .language("ko")
-                .isDefault(true)
+                .title("Jekyll and Hyde")
+                .author("Stevenson")
+                .language("en")
+                .bookPrompt("Victorian urban gothic, muted sepia and deep green palette, somber gaslit atmosphere, restrained realism, subtle psychological unease")
+                .isDefault(false)
                 .build();
 
-        // 테스트용 Character 생성
-        testCharacter1 = Character.builder()
-                .id(1L)
+        testCharacter = Character.builder()
+                .id(10L)
                 .book(testBook)
                 .characterId(1L)
-                .name("테스트 캐릭터 1")
-                .profileText("검은 머리에 번개 모양 흉터가 있는 소년")
-                .isMainCharacter(true)
+                .name("DR. JEKYLL")
+                .profileText("middle-aged man, pale complexion, neatly combed dark hair touched with gray, refined narrow features, formal black suit, reserved and slightly weary expression")
                 .imageGenerationStatus(ImageGenerationStatus.PENDING)
                 .build();
 
-        testCharacter2 = Character.builder()
-                .id(2L)
-                .book(testBook)
-                .characterId(2L)
-                .name("테스트 캐릭터 2")
-                .profileText("곱슬한 갈색 머리의 똑똑한 소녀")
-                .isMainCharacter(true)
-                .imageGenerationStatus(ImageGenerationStatus.PENDING)
-                .build();
-
-        // Properties 설정
-        when(imageProperties.getCommonStyle()).thenReturn(
-                "Bust portrait, square composition, face centered. Illustrative realism style."
-        );
+        when(imageProperties.getFallbackUrl()).thenReturn("https://cdn.readwith.store/character/default.png");
         when(imageProperties.getS3Path()).thenReturn("character-images");
-        when(imageProperties.getFallbackUrl()).thenReturn(
-                "https://readwith-s3-bucket.s3.ap-northeast-2.amazonaws.com/character-images/default-character.jpg"
-        );
         when(imageProperties.getBatchSize()).thenReturn(10);
-        when(imageProperties.getDelayBetweenRequestsMs()).thenReturn(100L); // 테스트에서는 짧게
-
-        // TransactionService 모킹 (모든 업데이트 메서드)
-        doNothing().when(transactionService).updateStatus(anyLong(), any());
-        doNothing().when(transactionService).updateImageAndStatus(anyLong(), anyString(), any());
-
-        // RestTemplate을 Service에 주입 (리플렉션 사용)
-        ReflectionTestUtils.setField(characterImageService, "restTemplate", restTemplate);
+        when(imageProperties.getDelayBetweenRequestsMs()).thenReturn(0L);
     }
 
     @Test
-    @DisplayName("이미지 생성 성공 - DALL-E 호출 및 S3 업로드")
-    void testGenerateAndSaveImage_Success() throws Exception {
-        // Given: DALL-E API 응답 모킹
-        String mockDalleImageUrl = "https://oaidalleapiprodscus.blob.core.windows.net/test-image.png";
-        
-        // Spring AI ImageResponse 구조에 맞게 모킹
-        ImageResponse mockImageResponse = mock(ImageResponse.class);
-        org.springframework.ai.image.ImageGeneration mockGeneration = mock(org.springframework.ai.image.ImageGeneration.class);
-        org.springframework.ai.image.Image mockImage = mock(org.springframework.ai.image.Image.class);
+    @DisplayName("buildDallePrompt composes base style, bookPrompt, portraitPrompt, and single-subject enforcement")
+    void buildDallePrompt_composesStructuredPrompt() {
+        String prompt = (String) ReflectionTestUtils.invokeMethod(characterImageService, "buildDallePrompt", testCharacter);
 
-        when(imageModel.call(any())).thenReturn(mockImageResponse);
-        when(mockImageResponse.getResult()).thenReturn(mockGeneration);
-        when(mockGeneration.getOutput()).thenReturn(mockImage);
-        when(mockImage.getUrl()).thenReturn(mockDalleImageUrl);
+        assertThat(prompt).contains("A consistent character profile portrait in a mature storybook editorial illustration style");
+        assertThat(prompt).contains("Victorian urban gothic, muted sepia and deep green palette");
+        assertThat(prompt).contains("middle-aged man, pale complexion, neatly combed dark hair touched with gray");
+        assertThat(prompt).contains("single person only");
+    }
 
-        // RestTemplate 이미지 다운로드 모킹
-        byte[] mockImageData = new byte[]{1, 2, 3, 4, 5}; // 가짜 이미지 데이터
-        doReturn(mockImageData).when(restTemplate).getForObject(eq(mockDalleImageUrl), eq(byte[].class));
+    @Test
+    @DisplayName("generateAndSaveImage uploads generated image using current bookPrompt")
+    void generateAndSaveImage_succeeds() throws Exception {
+        Path tempImage = Files.createTempFile("character-image-test-", ".png");
+        Files.write(tempImage, new byte[]{1, 2, 3, 4});
 
-        // S3 업로드 모킹
-        String mockS3Url = "https://readwith-s3-bucket.s3.ap-northeast-2.amazonaws.com/character-images/1/1.png";
+        when(characterRepository.findByIdWithBook(testCharacter.getId())).thenReturn(Optional.of(testCharacter));
         when(s3Manager.uploadFileFromBase64(anyString(), anyString(), eq("image/png")))
-                .thenReturn(mockS3Url);
+                .thenReturn("https://cdn.readwith.store/character-images/1/10.png");
 
-        // When: 이미지 생성 실행
-        characterImageService.generateAndSaveImage(testCharacter1.getId());
+        ImageResponse imageResponse = mock(ImageResponse.class);
+        ImageGeneration generation = mock(ImageGeneration.class);
+        Image image = mock(Image.class);
+        when(imageModel.call(any())).thenReturn(imageResponse);
+        when(imageResponse.getResult()).thenReturn(generation);
+        when(generation.getOutput()).thenReturn(image);
+        when(image.getUrl()).thenReturn(tempImage.toUri().toURL().toString());
 
-        // Then: 검증
-        // 1. DALL-E API 호출 확인
-        verify(imageModel, times(1)).call(any());
+        characterImageService.generateAndSaveImage(testCharacter.getId());
 
-        // 2. 이미지 다운로드 확인
-        verify(restTemplate, times(1)).getForObject(eq(mockDalleImageUrl), eq(byte[].class));
-
-        // 3. S3 업로드 확인
-        verify(s3Manager, times(1)).uploadFileFromBase64(
-                eq("character-images/1/1.png"),
-                anyString(),
-                eq("image/png")
+        verify(transactionService).updateStatus(testCharacter.getId(), ImageGenerationStatus.GENERATING);
+        verify(s3Manager).uploadFileFromBase64(eq("character-images/1/10.png"), anyString(), eq("image/png"));
+        verify(transactionService).updateImageAndStatus(
+                testCharacter.getId(),
+                "https://cdn.readwith.store/character-images/1/10.png",
+                ImageGenerationStatus.COMPLETED
         );
-
-        // 4. 상태 업데이트 확인 (GENERATING)
-        verify(characterRepository, times(1))
-                .updateImageGenerationStatus(eq(1L), eq(ImageGenerationStatus.GENERATING));
-
-        // 5. 이미지 URL 및 상태 업데이트 확인 (COMPLETED)
-        verify(characterRepository, times(1))
-                .updateProfileImageAndStatus(eq(1L), eq(mockS3Url), eq(ImageGenerationStatus.COMPLETED));
-
-        System.out.println("✅ 이미지 생성 성공 테스트 통과");
     }
 
     @Test
-    @DisplayName("이미지 생성 실패 - 폴백 이미지 설정")
-    void testGenerateAndSaveImage_Failure_UsesFallback() {
-        // Given: DALL-E API 호출 시 예외 발생
-        when(imageModel.call(any())).thenThrow(new RuntimeException("API 호출 실패"));
+    @DisplayName("generateImagesAsync stores fallback image when generation fails")
+    void generateImagesAsync_storesFallbackImageOnFailure() {
+        when(characterRepository.findByIdWithBook(testCharacter.getId())).thenReturn(Optional.of(testCharacter));
+        when(imageModel.call(any())).thenThrow(new RuntimeException("OpenAI failure"));
 
-        // Repository 모킹
-        doNothing().when(characterRepository).updateImageGenerationStatus(anyLong(), any());
-        doNothing().when(characterRepository).updateProfileImageAndStatus(anyLong(), anyString(), any());
+        characterImageService.generateImagesAsync(List.of(testCharacter.getId()));
 
-        // When & Then: 예외가 발생하고 폴백 처리됨
-        try {
-            characterImageService.generateAndSaveImage(testCharacter1.getId());
-        } catch (Exception e) {
-            // 예외는 발생하지만 폴백은 처리되어야 함
-        }
-
-        // Then: GENERATING 상태로 변경 확인
-        verify(characterRepository, times(1))
-                .updateImageGenerationStatus(eq(1L), eq(ImageGenerationStatus.GENERATING));
-
-        // FAILED 상태로 변경 확인
-        verify(characterRepository, times(1))
-                .updateImageGenerationStatus(eq(1L), eq(ImageGenerationStatus.FAILED));
-
-        System.out.println("✅ 이미지 생성 실패 및 폴백 처리 테스트 통과");
-    }
-
-    @Test
-    @DisplayName("여러 캐릭터 비동기 이미지 생성 - 이미 완료된 캐릭터는 스킵")
-    void testGenerateImagesAsync_SkipsCompletedCharacters() {
-        // Given: 캐릭터 1은 이미 완료됨
-        Character completedCharacter = Character.builder()
-                .id(1L)
-                .book(testBook)
-                .characterId(1L)
-                .name("완료된 캐릭터")
-                .profileImage("https://s3.amazonaws.com/existing-image.png")
-                .imageGenerationStatus(ImageGenerationStatus.COMPLETED)
-                .build();
-
-        // 캐릭터 2는 아직 생성 안됨
-        List<Long> characters = Arrays.asList(completedCharacter.getId(), testCharacter2.getId());
-
-        // DALL-E API 모킹
-        ImageResponse mockImageResponse = mock(ImageResponse.class);
-        org.springframework.ai.image.ImageGeneration mockGeneration = mock(org.springframework.ai.image.ImageGeneration.class);
-        org.springframework.ai.image.Image mockImage = mock(org.springframework.ai.image.Image.class);
-
-        when(imageModel.call(any())).thenReturn(mockImageResponse);
-        when(mockImageResponse.getResult()).thenReturn(mockGeneration);
-        when(mockGeneration.getOutput()).thenReturn(mockImage);
-        when(mockImage.getUrl()).thenReturn("https://dalle-test-url.png");
-
-        // RestTemplate 모킹
-        byte[] mockImageData = new byte[]{1, 2, 3};
-        doReturn(mockImageData).when(restTemplate).getForObject(anyString(), eq(byte[].class));
-
-        // S3 모킹
-        when(s3Manager.uploadFileFromBase64(anyString(), anyString(), anyString()))
-                .thenReturn("https://s3-test-url.png");
-
-        // Repository 모킹
-        doNothing().when(characterRepository).updateImageGenerationStatus(anyLong(), any());
-        doNothing().when(characterRepository).updateProfileImageAndStatus(anyLong(), anyString(), any());
-
-        // When: 비동기 이미지 생성 실행
-        characterImageService.generateImagesAsync(characters);
-
-        // Then: 완료된 캐릭터는 스킵되고, 캐릭터 2만 처리됨
-        // DALL-E는 캐릭터 2에 대해서만 호출됨
-        verify(imageModel, times(1)).call(any());
-
-        System.out.println("✅ 완료된 캐릭터 스킵 테스트 통과");
-    }
-
-    @Test
-    @DisplayName("프롬프트 생성 - profileText와 공통 스타일 결합")
-    void testBuildDallePrompt() {
-        // Given: 프롬프트 빌드를 위한 캐릭터
-        Character character = Character.builder()
-                .id(1L)
-                .book(testBook)
-                .name("테스트 캐릭터")
-                .profileText("검은 머리와 번개 모양 흉터가 있는 소년")
-                .build();
-
-        // 리플렉션을 통해 private 메서드 테스트
-        String prompt = (String) ReflectionTestUtils.invokeMethod(
-                characterImageService,
-                "buildDallePrompt",
-                character
+        verify(transactionService).updateStatus(testCharacter.getId(), ImageGenerationStatus.PENDING);
+        verify(transactionService).updateStatus(testCharacter.getId(), ImageGenerationStatus.GENERATING);
+        verify(transactionService).updateStatus(testCharacter.getId(), ImageGenerationStatus.FAILED);
+        verify(transactionService).updateImageAndStatus(
+                testCharacter.getId(),
+                "https://cdn.readwith.store/character/default.png",
+                ImageGenerationStatus.FAILED
         );
-
-        // Then: 프롬프트에 profileText와 공통 스타일이 포함되어야 함
-        assert prompt != null;
-        assert prompt.contains("검은 머리와 번개 모양 흉터가 있는 소년");
-        assert prompt.contains("Bust portrait");
-
-        System.out.println("✅ 프롬프트 생성 테스트 통과");
-        System.out.println("생성된 프롬프트: " + prompt);
     }
 
     @Test
-    @DisplayName("S3 키 이름 생성 - 올바른 경로 포맷")
-    void testBuildS3KeyName() {
-        // Given: S3 키 이름 생성
-        String keyName = (String) ReflectionTestUtils.invokeMethod(
-                characterImageService,
-                "buildS3KeyName",
-                testCharacter1
-        );
+    @DisplayName("generateAndSaveImage throws when character does not exist")
+    void generateAndSaveImage_throwsWhenCharacterMissing() {
+        when(characterRepository.findByIdWithBook(anyLong())).thenReturn(Optional.empty());
 
-        // Then: 올바른 포맷인지 확인
-        String expectedKeyName = "character-images/1/1.png";
-        assert keyName != null;
-        assert keyName.equals(expectedKeyName);
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> characterImageService.generateAndSaveImage(99L));
 
-        System.out.println("✅ S3 키 이름 생성 테스트 통과");
-        System.out.println("생성된 키 이름: " + keyName);
-    }
-
-    @Test
-    @DisplayName("폴백 이미지 저장 - FAILED 상태로 변경")
-    void testSaveFallbackImage() {
-        // Given: Repository 모킹
-        doNothing().when(characterRepository).updateProfileImageAndStatus(anyLong(), anyString(), any());
-
-        // When: 폴백 이미지 저장
-        ReflectionTestUtils.invokeMethod(
-                characterImageService,
-                "saveFallbackImage",
-                testCharacter1
-        );
-
-        // Then: 폴백 URL과 FAILED 상태로 업데이트되어야 함
-        verify(characterRepository, times(1))
-                .updateProfileImageAndStatus(
-                        eq(1L),
-                        eq("https://readwith-s3-bucket.s3.ap-northeast-2.amazonaws.com/character-images/default-character.jpg"),
-                        eq(ImageGenerationStatus.FAILED)
-                );
-
-        System.out.println("✅ 폴백 이미지 저장 테스트 통과");
+        assertThat(exception.getMessage()).contains("Failed to generate character image");
     }
 }
-


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
책 단위 공통 스타일 프롬프트를 저장하고, 캐릭터 이미지 생성 시 이를 공통으로 반영하도록 구조를 추가했습니다.

이번 변경으로 캐릭터 이미지 프롬프트는
`[base style prompt] + [bookPrompt] + [portraitPrompt]`
순서로 조합됩니다.

목표는 같은 책 안의 캐릭터 이미지가 하나의 시리즈처럼 보이도록 스타일을 통일하고,
복수 인물 생성이나 과도한 배경/소품이 붙는 문제를 줄이는 것입니다.

## 📋 변경 사항
- `Book` 엔티티에 책 단위 공통 스타일 프롬프트 저장 필드 `bookPrompt`를 추가했습니다.
- Flyway migration `V4__add_book_prompt_to_book.sql`을 추가했습니다.
- 관리자 캐릭터 업로드 루트 payload에서 `bookPrompt`를 받을 수 있도록 `CharacterListDTO`를 확장했습니다.
- 캐릭터 업로드 시 `bookPrompt`가 들어오면 `Book`에 저장하도록 `AdminService`를 수정했습니다.
- 캐릭터 이미지 생성 프롬프트 조합을
  - 고정 base style prompt
  - book 단위 `bookPrompt`
  - character 단위 `portraitPrompt`
  순서로 재구성했습니다.
- 단일 인물 강제와 복수 인물/배경 요소 억제를 위한 프롬프트 보강 문구를 추가했습니다.
- base style prompt는 이번 이슈에서 확정한 문구를 서비스 내부 상수로 고정했습니다.
- 관련 테스트를 추가/수정해
  - `bookPrompt` 업로드 루트 계약
  - `bookPrompt` 저장
  - 프롬프트 조합 순서
  - 이미지 생성/폴백 흐름
  을 검증했습니다.

## 🔍 Code Review
- `bookPrompt`를 책 단위 공통값으로 저장하고, 이미지 생성 시 모든 캐릭터에 동일 적용하는 현재 구조가 의도와 맞는지 확인 부탁드립니다.
- base style prompt를 설정값이 아니라 서비스 내부 고정 상수로 둔 결정이 운영 방식과 맞는지 확인 부탁드립니다.
- `portraitPrompt`를 현재처럼 `Character.profileText`에 저장해도 계약상 충분한지, 추후 전용 필드 분리가 필요한지 확인 부탁드립니다.
- `bookPrompt` 변경 시 기존 이미지 재생성 정책은 아직 포함하지 않았으므로, 후속 이슈 범위가 맞는지 확인 부탁드립니다.

## 📸 ScreenShot
- 없음