### PR TITLE
fix: 캐릭터 프로필 이미지 생성 시 복수 인물/프로필 구도 불안정 문제 완화

### DIFF
--- a/src/main/java/com/kw/readwith/service/CharacterImageService.java
+++ b/src/main/java/com/kw/readwith/service/CharacterImageService.java
@@ -22,7 +22,9 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -36,9 +38,38 @@ public class CharacterImageService {
             "gentle facial details, natural proportions, not childish, not cartoonish, not anime, " +
             "not exaggerated, designed as a book character profile image";
 
-    private static final String SINGLE_SUBJECT_ENFORCEMENT =
-            "single person only, exactly one subject, no additional people, no duo, no group, " +
-            "no crowd, no background characters, no interaction scene, no props, no scenery";
+    private static final String PROFILE_FORMAT_ENFORCEMENT =
+            "exactly one character, single centered chest-up bust portrait, one subject filling most of the frame, " +
+            "front-facing or slight three-quarter view, plain soft background, simple profile-card composition";
+
+    private static final String NEGATIVE_LAYOUT_ENFORCEMENT =
+            "no additional people, no duo, no pair, no group, no crowd, no background characters, " +
+            "no split composition, no diptych, no mirrored duplicate, no reflected second face, no twin, " +
+            "no interaction scene, no full body, no wide shot, no props, no scenery, no ornate background";
+
+    private static final List<String> DISALLOWED_PROMPT_SEGMENTS = List.of(
+            "duo portrait",
+            "pair portrait",
+            "group portrait",
+            "double portrait",
+            "multiple people",
+            "multiple characters",
+            "multiple figures",
+            "two people",
+            "two characters",
+            "two figures",
+            "crowd behind",
+            "background characters",
+            "split composition",
+            "diptych",
+            "mirrored second portrait",
+            "mirror image",
+            "reflected second face",
+            "scene with another character",
+            "interaction scene",
+            "standing beside another character",
+            "next to another character"
+    );
 
     private final OpenAiImageModel imageModel;
     private final AmazonS3Manager s3Manager;
@@ -159,9 +190,10 @@ public class CharacterImageService {
         StringBuilder prompt = new StringBuilder();
 
         appendPromptSegment(prompt, BASE_STYLE_PROMPT);
-        appendPromptSegment(prompt, normalizePromptSegment(resolveBookPrompt(character.getBook())));
-        appendPromptSegment(prompt, normalizePromptSegment(resolvePortraitPrompt(character)));
-        appendPromptSegment(prompt, SINGLE_SUBJECT_ENFORCEMENT);
+        appendPromptSegment(prompt, PROFILE_FORMAT_ENFORCEMENT);
+        appendPromptSegment(prompt, sanitizePromptSegment(resolveBookPrompt(character.getBook())));
+        appendPromptSegment(prompt, sanitizePromptSegment(resolvePortraitPrompt(character)));
+        appendPromptSegment(prompt, NEGATIVE_LAYOUT_ENFORCEMENT);
 
         return prompt.toString();
     }
@@ -175,7 +207,31 @@ public class CharacterImageService {
         if (portraitPrompt != null) {
             return portraitPrompt;
         }
-        return "single character portrait of " + character.getName();
+        return "single centered chest-up bust portrait of " + character.getName();
+    }
+
+    private String sanitizePromptSegment(String value) {
+        String normalized = normalizePromptSegment(value);
+        if (normalized == null) {
+            return null;
+        }
+
+        List<String> sanitizedSegments = List.of(normalized.split("\\s*[,;]+\\s*")).stream()
+                .map(this::normalizePromptSegment)
+                .filter(segment -> segment != null && !containsDisallowedPromptSegment(segment))
+                .collect(Collectors.toList());
+
+        if (sanitizedSegments.isEmpty()) {
+            return null;
+        }
+
+        return String.join(", ", sanitizedSegments);
+    }
+
+    private boolean containsDisallowedPromptSegment(String segment) {
+        String lowerSegment = segment.toLowerCase(Locale.ROOT);
+        return DISALLOWED_PROMPT_SEGMENTS.stream()
+                .anyMatch(lowerSegment::contains);
     }
 
     private String normalizePromptSegment(String value) {

--- a/src/test/java/com/kw/readwith/service/CharacterImageServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/CharacterImageServiceTest.java
@@ -92,9 +92,44 @@ class CharacterImageServiceTest {
         String prompt = (String) ReflectionTestUtils.invokeMethod(characterImageService, "buildDallePrompt", testCharacter);
 
         assertThat(prompt).contains("A consistent character profile portrait in a mature storybook editorial illustration style");
+        assertThat(prompt).contains("exactly one character, single centered chest-up bust portrait");
         assertThat(prompt).contains("Victorian urban gothic, muted sepia and deep green palette");
         assertThat(prompt).contains("middle-aged man, pale complexion, neatly combed dark hair touched with gray");
-        assertThat(prompt).contains("single person only");
+        assertThat(prompt).contains("no split composition");
+        assertThat(prompt.indexOf("A consistent character profile portrait")).isLessThan(prompt.indexOf("Victorian urban gothic"));
+        assertThat(prompt.indexOf("Victorian urban gothic")).isLessThan(prompt.indexOf("middle-aged man"));
+    }
+
+    @Test
+    @DisplayName("buildDallePrompt removes multi-subject and scene-driving prompt segments")
+    void buildDallePrompt_sanitizesRiskyPromptSegments() {
+        Book riskyBook = Book.builder()
+                .id(2L)
+                .title("Risky Book")
+                .author("Author")
+                .language("en")
+                .bookPrompt("Victorian urban gothic, scene with another character, muted sepia palette")
+                .isDefault(false)
+                .build();
+
+        Character riskyCharacter = Character.builder()
+                .id(11L)
+                .book(riskyBook)
+                .characterId(2L)
+                .name("MR. HYDE")
+                .profileText("middle-aged man, duo portrait, formal black suit, crowd behind him")
+                .imageGenerationStatus(ImageGenerationStatus.PENDING)
+                .build();
+
+        String prompt = (String) ReflectionTestUtils.invokeMethod(characterImageService, "buildDallePrompt", riskyCharacter);
+
+        assertThat(prompt).contains("Victorian urban gothic");
+        assertThat(prompt).contains("muted sepia palette");
+        assertThat(prompt).contains("middle-aged man");
+        assertThat(prompt).contains("formal black suit");
+        assertThat(prompt).doesNotContain("scene with another character");
+        assertThat(prompt).doesNotContain("duo portrait");
+        assertThat(prompt).doesNotContain("crowd behind him");
     }
 
     @Test


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
캐릭터 프로필 이미지 생성 시 한 이미지에 두 명 이상의 인물이 생성되거나, 프로필 카드가 아니라 장면 일러스트처럼 생성되는 문제를 줄이기 위해 프롬프트 조합 방식을 보강했습니다.

이번 변경에서는 단순히 `single person only` 문구를 뒤에 붙이는 수준에서 끝내지 않고,
단일 인물/프로필 포맷 제약을 프롬프트 앞쪽으로 끌어올리고,
`bookPrompt` / `portraitPrompt` 안에 섞여 들어오는 복수 인물·장면 유발 문구를 정제하도록 수정했습니다.

## 📋 변경 사항
- `CharacterImageService`의 프롬프트 조합 순서를 아래처럼 보강했습니다.
  - `base style prompt`
  - `profile format enforcement`
  - 정제된 `bookPrompt`
  - 정제된 `portraitPrompt`
  - `negative layout enforcement`
- 단일 인물/프로필 포맷을 더 강하게 고정하는 문구를 추가했습니다.
  - `exactly one character`
  - `single centered chest-up bust portrait`
  - `one subject filling most of the frame`
  - `front-facing or slight three-quarter view`
  - `plain soft background`
- 복수 인물/분할 구도/장면 유발 문구를 차단하는 문구를 추가했습니다.
  - `no split composition`
  - `no diptych`
  - `no mirrored duplicate`
  - `no reflected second face`
  - `no full body`
  - `no wide shot`
  - `no ornate background`
- `bookPrompt`, `portraitPrompt`에 포함된 위험 세그먼트를 정제하는 로직을 추가했습니다.
- 현재 차단 대상 예시:
  - `duo portrait`
  - `pair portrait`
  - `group portrait`
  - `multiple characters`
  - `scene with another character`
  - `crowd behind`
  - `interaction scene`
  - `next to another character`
- `portraitPrompt` fallback도 일반적인 `single character portrait`가 아니라 `single centered chest-up bust portrait` 기준으로 맞췄습니다.
- 테스트를 보강해 아래를 검증하도록 했습니다.
  - 프롬프트 조합 순서
  - 단일 인물/프로필 포맷 제약 포함 여부
  - 위험 문구 정제 여부

## 🔍 Code Review
- 현재 차단 대상 문구 목록이 실제 운영 데이터 기준으로 충분한지 확인 부탁드립니다.
- `bookPrompt` / `portraitPrompt`를 쉼표/세미콜론 단위로 분리해 정제하는 현재 방식이 과도하지 않은지 확인 부탁드립니다.
- 프로필 포맷 제약을 강화하면서도 캐릭터 개별 외형 표현력은 충분히 남아 있는지 확인 부탁드립니다.
- 이 PR은 프롬프트 안정화 중심이며, 생성 결과물 자체의 후처리 검수/재시도 정책은 포함하지 않았습니다.

## 📸 ScreenShot
- 없음