### PR TITLE
feat: 캐릭터 이미지 base style prompt를 환경변수로 외부화

### DIFF
--- a/src/main/java/com/kw/readwith/config/CharacterImageProperties.java
+++ b/src/main/java/com/kw/readwith/config/CharacterImageProperties.java
@@ -22,7 +22,7 @@ public class CharacterImageProperties {
     /**
      * DALL-E 프롬프트에 공통적으로 적용할 아트 스타일
      */
-    private String commonStyle;
+    private String baseStylePrompt;
 
     /**
      * S3에 이미지를 저장할 경로 (버킷 내 디렉토리)

--- a/src/main/java/com/kw/readwith/service/CharacterImageService.java
+++ b/src/main/java/com/kw/readwith/service/CharacterImageService.java
@@ -31,12 +31,11 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CharacterImageService {
 
-    private static final String BASE_STYLE_PROMPT =
-            "A consistent character profile portrait in a mature storybook editorial illustration style, " +
-            "chest-up bust portrait, centered composition, plain soft background, soft textured brushwork, " +
-            "low-saturation color palette, calm and literary mood, semi-flat illustration, clean silhouette, " +
-            "gentle facial details, natural proportions, not childish, not cartoonish, not anime, " +
-            "not exaggerated, designed as a book character profile image";
+    private static final String DEFAULT_BASE_STYLE_PROMPT =
+            "A single centered chest-up character portrait in a mature editorial gouache illustration style, " +
+            "flat matte gouache rendering, clean silhouette, minimal linework, soft paper texture, plain muted background, " +
+            "low-saturation palette, restrained literary mood, natural facial proportions, not cartoonish, not anime, " +
+            "not painterly, not photorealistic";
 
     private static final String PROFILE_FORMAT_ENFORCEMENT =
             "exactly one character, single centered chest-up bust portrait, one subject filling most of the frame, " +
@@ -189,7 +188,7 @@ public class CharacterImageService {
     private String buildDallePrompt(Character character) {
         StringBuilder prompt = new StringBuilder();
 
-        appendPromptSegment(prompt, BASE_STYLE_PROMPT);
+        appendPromptSegment(prompt, resolveBaseStylePrompt());
         appendPromptSegment(prompt, PROFILE_FORMAT_ENFORCEMENT);
         appendPromptSegment(prompt, sanitizePromptSegment(resolveBookPrompt(character.getBook())));
         appendPromptSegment(prompt, sanitizePromptSegment(resolvePortraitPrompt(character)));
@@ -208,6 +207,11 @@ public class CharacterImageService {
             return portraitPrompt;
         }
         return "single centered chest-up bust portrait of " + character.getName();
+    }
+
+    private String resolveBaseStylePrompt() {
+        String configured = normalizePromptSegment(imageProperties.getBaseStylePrompt());
+        return configured != null ? configured : DEFAULT_BASE_STYLE_PROMPT;
     }
 
     private String sanitizePromptSegment(String value) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -118,6 +118,7 @@ cloud:
 # 캐릭터 이미지 생성 설정
 character-image:
   fallback-url: https://readwith-s3-bucket.s3.ap-northeast-2.amazonaws.com/character-images/default-character.jpg
+  base-style-prompt: ${CHARACTER_IMAGE_BASE_STYLE_PROMPT:A single centered chest-up character portrait in a mature editorial gouache illustration style, flat matte gouache rendering, clean silhouette, minimal linework, soft paper texture, plain muted background, low-saturation palette, restrained literary mood, natural facial proportions, not cartoonish, not anime, not painterly, not photorealistic}
 
   # 극강 통제 프롬프트 (얼굴만 나오도록)
   common-style: "CRITICAL: FACE PORTRAIT ONLY - NO OTHER ELEMENTS ALLOWED

--- a/src/test/java/com/kw/readwith/service/CharacterImageServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/CharacterImageServiceTest.java
@@ -81,23 +81,35 @@ class CharacterImageServiceTest {
                 .build();
 
         when(imageProperties.getFallbackUrl()).thenReturn("https://cdn.readwith.store/character/default.png");
+        when(imageProperties.getBaseStylePrompt()).thenReturn("Configured editorial gouache base style");
         when(imageProperties.getS3Path()).thenReturn("character-images");
         when(imageProperties.getBatchSize()).thenReturn(10);
         when(imageProperties.getDelayBetweenRequestsMs()).thenReturn(0L);
     }
 
     @Test
-    @DisplayName("buildDallePrompt composes base style, bookPrompt, portraitPrompt, and single-subject enforcement")
+    @DisplayName("buildDallePrompt uses configured base style prompt and composes the remaining sections")
     void buildDallePrompt_composesStructuredPrompt() {
         String prompt = (String) ReflectionTestUtils.invokeMethod(characterImageService, "buildDallePrompt", testCharacter);
 
-        assertThat(prompt).contains("A consistent character profile portrait in a mature storybook editorial illustration style");
+        assertThat(prompt).contains("Configured editorial gouache base style");
         assertThat(prompt).contains("exactly one character, single centered chest-up bust portrait");
         assertThat(prompt).contains("Victorian urban gothic, muted sepia and deep green palette");
         assertThat(prompt).contains("middle-aged man, pale complexion, neatly combed dark hair touched with gray");
         assertThat(prompt).contains("no split composition");
-        assertThat(prompt.indexOf("A consistent character profile portrait")).isLessThan(prompt.indexOf("Victorian urban gothic"));
+        assertThat(prompt.indexOf("Configured editorial gouache base style")).isLessThan(prompt.indexOf("Victorian urban gothic"));
         assertThat(prompt.indexOf("Victorian urban gothic")).isLessThan(prompt.indexOf("middle-aged man"));
+    }
+
+    @Test
+    @DisplayName("buildDallePrompt falls back to default base style prompt when configuration is missing")
+    void buildDallePrompt_fallsBackToDefaultBaseStylePrompt() {
+        when(imageProperties.getBaseStylePrompt()).thenReturn(null);
+
+        String prompt = (String) ReflectionTestUtils.invokeMethod(characterImageService, "buildDallePrompt", testCharacter);
+
+        assertThat(prompt).contains("A single centered chest-up character portrait in a mature editorial gouache illustration style");
+        assertThat(prompt).contains("flat matte gouache rendering");
     }
 
     @Test


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
캐릭터 이미지 생성의 `base style prompt`를 코드 상수에서 운영 설정으로 외부화했습니다.

이제 이미지 생성 기본 스타일은 환경변수 `CHARACTER_IMAGE_BASE_STYLE_PROMPT`로 주입할 수 있고,
설정이 없을 경우에는 A안 스타일 문구를 폴백으로 사용합니다.
이를 통해 코드 수정 없이도 운영 중 base style을 빠르게 교체할 수 있습니다.

## 📋 변경 사항
- `CharacterImageProperties`에 `baseStylePrompt` 설정 필드를 추가했습니다.
- `CharacterImageService`가 코드 상수 대신 설정값을 우선 사용하도록 변경했습니다.
- 설정값이 비어 있으면 A안 base style prompt를 기본값으로 사용하도록 폴백 로직을 추가했습니다.
- `application.yml`에 `character-image.base-style-prompt` 설정 바인딩을 추가했습니다.
- 환경변수 이름은 `CHARACTER_IMAGE_BASE_STYLE_PROMPT`로 고정했습니다.
- 테스트를 보강해 아래를 검증했습니다.
  - 설정된 base style prompt가 최종 프롬프트에 반영되는지
  - 설정이 없을 때 A안 폴백이 적용되는지

A안 폴백값:
`A single centered chest-up character portrait in a mature editorial gouache illustration style, flat matte gouache rendering, clean silhouette, minimal linework, soft paper texture, plain muted background, low-saturation palette, restrained literary mood, natural facial proportions, not cartoonish, not anime, not painterly, not photorealistic`

## 🔍 Code Review
- `CHARACTER_IMAGE_BASE_STYLE_PROMPT`를 운영 환경에서 직접 조정하는 방식이 현재 운영 정책과 맞는지 확인 부탁드립니다.
- 설정값 우선, 코드 폴백 보조 구조가 의도한 운영 방식과 맞는지 확인 부탁드립니다.
- A안 폴백 문구가 기본 base style로 적절한지 확인 부탁드립니다.

## 📸 ScreenShot
- 없음