### PR TITLE
feat: 관리자용 전체 도서 및 인물 모니터링 API 구현

### DIFF
--- a/src/main/java/com/kw/readwith/dto/admin/BookAdminDetailDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/BookAdminDetailDTO.java
@@ -1,0 +1,59 @@
+package com.kw.readwith.dto.admin;
+
+import com.kw.readwith.domain.Book;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookAdminDetailDTO {
+    private Long id;
+    private String title;
+    private String author;
+    private String language;
+    private boolean isDefault;
+    private boolean summary;
+    private String coverImgUrl;
+    private String summaryUrl;
+    private String bookPrompt;
+    private String epubPath;
+    private String normalizationStatus;
+    private String analysisStatus;
+    private String ruleVersion;
+    private String locatorVersion;
+    private String normalizedArtifactPath;
+    private String normalizationRunId;
+    private Long uploadedById;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static BookAdminDetailDTO from(Book book) {
+        return BookAdminDetailDTO.builder()
+                .id(book.getId())
+                .title(book.getTitle())
+                .author(book.getAuthor())
+                .language(book.getLanguage())
+                .isDefault(book.isDefault())
+                .summary(book.isSummary())
+                .coverImgUrl(book.getCoverImgUrl())
+                .summaryUrl(book.getSummaryUrl())
+                .bookPrompt(book.getBookPrompt())
+                .epubPath(book.getEpubPath())
+                .normalizationStatus(book.getNormalizationStatus() != null ? book.getNormalizationStatus().name() : null)
+                .analysisStatus(book.getAnalysisStatus() != null ? book.getAnalysisStatus().name() : null)
+                .ruleVersion(book.getRuleVersion())
+                .locatorVersion(book.getLocatorVersion())
+                .normalizedArtifactPath(book.getNormalizedArtifactPath())
+                .normalizationRunId(book.getNormalizationRunId())
+                .uploadedById(book.getUploadedBy() != null ? book.getUploadedBy().getId() : null)
+                .createdAt(book.getCreatedAt())
+                .updatedAt(book.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/kw/readwith/dto/admin/CharacterDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/CharacterDTO.java
@@ -3,6 +3,8 @@ package com.kw.readwith.dto.admin;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,9 +12,15 @@ import java.util.List;
 import java.util.Map;
 
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
-@Schema(description = "인물 1명에 대한 업로드 항목")
+@Schema(description = "인물 1명에 대한 업로드 및 응답 항목")
 public class CharacterDTO {
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @Schema(description = "인물 DB 고유 ID (PK)", accessMode = Schema.AccessMode.READ_ONLY)
+    private Long id;
 
     @JsonAlias("id")
     @Schema(description = "책 내부 characterId. 숫자 문자열을 사용합니다.", example = "7")
@@ -39,4 +47,12 @@ public class CharacterDTO {
     @JsonAlias("portrait_prompt")
     @Schema(description = "이미지 생성용 프롬프트 또는 프로필 텍스트")
     private String portraitPrompt;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @Schema(description = "프로필 이미지 URL", accessMode = Schema.AccessMode.READ_ONLY)
+    private String profileImage;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @Schema(description = "이미지 생성 상태", accessMode = Schema.AccessMode.READ_ONLY)
+    private String imageGenerationStatus;
 }

--- a/src/main/java/com/kw/readwith/repository/CharacterRepository.java
+++ b/src/main/java/com/kw/readwith/repository/CharacterRepository.java
@@ -20,6 +20,10 @@ public interface CharacterRepository extends JpaRepository<Character, Long> {
 
     // Book과 name으로 Character를 찾는 메소드
     Optional<Character> findByBookAndName(Book book, String name);
+
+    // 책에 속한 모든 캐릭터 조회
+    List<Character> findByBook(Book book);
+
     /**
      * 특정 책의 모든 인물을 주요 인물 우선, 이름 순으로 조회
      */

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -590,6 +590,15 @@ public class AdminService {
      */
 
     /**
+     * book 테이블의 모든 데이터를 조회합니다. (관리자용)
+     */
+    public List<BookAdminDetailDTO> getAllBooks() {
+        return bookRepository.findAll().stream()
+                .map(BookAdminDetailDTO::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
      * ?袁⑷퍥 ?遺용튋???袁⑥┷??? ??? 筌?筌뤴뫖以??鈺곌퀬???몃빍??
      */
     public List<BookSummaryDTO> getUnsummarizedBooks() {

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -630,6 +630,24 @@ public class AdminService {
     }
 
     /**
+     * 특정 도서에 속한 캐릭터들의 기본 정보와 이미지 생성 상태를 조회합니다.
+     */
+    public List<CharacterDTO> getCharactersByBookId(Long bookId) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+
+        return characterRepository.findByBook(book).stream()
+                .map(character -> CharacterDTO.builder()
+                        .id(character.getId())
+                        .characterId(String.valueOf(character.getCharacterId()))
+                        .commonName(character.getName())
+                        .profileImage(character.getProfileImage())
+                        .imageGenerationStatus(character.getImageGenerationStatus() != null ? character.getImageGenerationStatus().name() : null)
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
      * ?諭??筌?Ŧ??怨쀬벥 ?袁⑥쨮?????筌왖????源?源딅???덈뼄.
      * ???筌왖 ??밴쉐????쎈솭??뉕탢????됱춳???ル뿭? ??? 野껋럩???????몃빍??
      * 

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -4,6 +4,7 @@ import com.kw.readwith.apiPayload.ApiResponse;
 import com.kw.readwith.dto.admin.AnalysisInputResponseDTO;
 import com.kw.readwith.dto.admin.UnsummarizedItemDTO;
 import com.kw.readwith.dto.book.BookSummaryDTO;
+import com.kw.readwith.dto.admin.CharacterDTO;
 import com.kw.readwith.service.AdminService;
 import com.kw.readwith.service.AnalysisInputExportService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -41,6 +42,14 @@ public class AdminController {
             @Parameter(description = "인물 JSON 파일", required = true) @RequestParam("file") MultipartFile file) {
         adminService.uploadCharacters(bookId, file);
         return ApiResponse.onSuccess("Characters have been successfully uploaded.");
+    }
+
+    @Operation(summary = "도서별 인물 목록 조회", description = "특정 도서에 속한 인물들의 기본 정보와 이미지 생성 상태를 조회합니다.")
+    @GetMapping("/books/{bookId}/characters")
+    public ApiResponse<List<CharacterDTO>> getCharactersByBookId(
+            @Parameter(description = "조회 대상 도서 ID", required = true) @PathVariable Long bookId) {
+        List<CharacterDTO> response = adminService.getCharactersByBookId(bookId);
+        return ApiResponse.onSuccess(response);
     }
 
     @Operation(summary = "인물 전체 삭제", description = "특정 도서에 적재된 인물 정보를 모두 삭제합니다.")

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.kw.readwith.web.controller;
 
 import com.kw.readwith.apiPayload.ApiResponse;
 import com.kw.readwith.dto.admin.AnalysisInputResponseDTO;
+import com.kw.readwith.dto.admin.BookAdminDetailDTO;
 import com.kw.readwith.dto.admin.UnsummarizedItemDTO;
 import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.dto.admin.CharacterDTO;
@@ -31,6 +32,13 @@ public class AdminController {
 
     private final AdminService adminService;
     private final AnalysisInputExportService analysisInputExportService;
+
+    @Operation(summary = "모든 도서 전체 정보 조회", description = "book 테이블의 모든 행들의 모든 칼럼값들을 조회합니다. (관리자용)")
+    @GetMapping("/books")
+    public ApiResponse<List<BookAdminDetailDTO>> getAllBooks() {
+        List<BookAdminDetailDTO> response = adminService.getAllBooks();
+        return ApiResponse.onSuccess(response);
+    }
 
     @Operation(
             summary = "인물 업로드",


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
관리자 페이지에서 전체 도서 목록 및 캐릭터 데이터를 모니터링하고 제어할 수 있도록 DTO 설계 및 데이터 조회 파이프라인을 구축

## 📋 변경 사항
1. 관리자 전용 전체 도서 조회 API 구현
- 엔드포인트: GET /api/admin/books
- BookAdminDetailDTO를 신규 생성하여 관리 목적에 최적화된 데이터 제공
- book 테이블의 19개 전체 컬럼을 포함하며, 계산된 필드 대신 createdAt, bookPrompt, uploadedBy 등 DB 원본 데이터 제공

2. 도서별 인물 목록 조회 API 구현
- 특정 도서에 매핑된 모든 캐릭터(인물) 데이터를 한눈에 파악할 수 있는 API를 추가
- 이를 통해 관리자 페이지 내에서 인물의 AI 이미지 생성 상태를 직관적으로 모니터링할 수 있는 기반을 마련

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
