### PR TITLE
Ops: nginx 요청 본문 크기 제한 상향

### DIFF
--- a/.platform/nginx/conf.d/client_max_body_size.conf
+++ b/.platform/nginx/conf.d/client_max_body_size.conf
@@ -1,0 +1,1 @@
+client_max_body_size 20M;


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약

`relationships` 업로드 시 nginx에서 `413 Request Entity Too Large`가 발생하는 문제를 해결하기 위해 Elastic Beanstalk nginx 설정에 요청 본문 크기 제한을 추가했습니다.

## 📋 변경 사항

- `.platform/nginx/conf.d/client_max_body_size.conf` 파일 추가
- nginx `client_max_body_size` 값을 `20M`으로 설정
- 대용량 `relationships` 업로드 요청이 nginx 단계에서 차단되지 않도록 조정

## 🔍 Code Review

- Elastic Beanstalk 배포 시 `.platform/nginx/conf.d/client_max_body_size.conf` 설정이 정상 반영되는지 확인
- `client_max_body_size 20M;` 값이 현재 업로드 payload 크기에 충분한지 확인
- 기존 `.platform/nginx.conf` 설정과 충돌 없이 동작하는지 확인

## 📸 ScreenShot

N/A