### PR TITLE
fix: 백엔드 CORS 도메인을 readwith.cloud로 교체

### DIFF
--- a/src/main/java/com/kw/readwith/config/SecurityConfig.java
+++ b/src/main/java/com/kw/readwith/config/SecurityConfig.java
@@ -87,7 +87,7 @@ public class SecurityConfig {
 
         configuration.setAllowedOriginPatterns(Arrays.asList(
                 "http://localhost:5173",
-                "https://dev.readwith.store",
+                "https://dev.readwith.cloud",
                 "https://readwith-frontend.vercel.app",
                 "https://readwith-frontend-*.vercel.app",
                 "https://*.vercel.app"

--- a/src/test/java/com/kw/readwith/config/V2ApiContractInterceptorTest.java
+++ b/src/test/java/com/kw/readwith/config/V2ApiContractInterceptorTest.java
@@ -57,13 +57,13 @@ public class V2ApiContractInterceptorTest {
     void allowsDevSwaggerUiOriginForUploadCors() {
         SecurityConfig securityConfig = new SecurityConfig(null, null, null);
         MockHttpServletRequest request = new MockHttpServletRequest("OPTIONS", "/api/v2/books");
-        request.addHeader("Origin", "https://dev.readwith.store");
+        request.addHeader("Origin", "https://dev.readwith.cloud");
 
         CorsConfiguration corsConfiguration = securityConfig.corsConfigurationSource().getCorsConfiguration(request);
 
         assertThat(corsConfiguration).isNotNull();
-        assertThat(corsConfiguration.checkOrigin("https://dev.readwith.store"))
-                .isEqualTo("https://dev.readwith.store");
+        assertThat(corsConfiguration.checkOrigin("https://dev.readwith.cloud"))
+                .isEqualTo("https://dev.readwith.cloud");
     }
 
     private void assertBlocked(String requestUri) {


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
만료된 백엔드 도메인 dev.readwith.store를 신규 도메인 dev.readwith.cloud로 교체했습니다.
AWS Elastic Beanstalk 백엔드에 새 도메인을 연결한 뒤, 브라우저 기반 요청이 정상 동작하도록 Spring Security CORS 허용 origin을 갱신했습니다.

## 📋 변경 사항

- SecurityConfig의 CORS 허용 origin 변경
    - 기존: https://dev.readwith.store
    - 변경: https://dev.readwith.cloud
- CORS 설정 검증 테스트의 기대 origin을 신규 도메인 기준으로 수정
- V2ApiContractInterceptorTest 실행으로 변경 사항 검증

## 🔍 Code Review
- https://dev.readwith.cloud가 CORS 허용 origin에 정상 포함되어 있는지 확인
- 기존 만료 도메인 https://dev.readwith.store 참조가 운영 CORS 설정에 남아 있지 않은지 확인
- allowCredentials(true) 설정이 유지되므로 wildcard origin이 아닌 명시적 origin을 사용하는지 확인
- Swagger UI 및 프론트엔드 요청이 신규 도메인 기준으로 정상 동작하는지 배포 후 확인 필요

## 📸 ScreenShot
https cloud dns로 스웨거 접속 성공
<img width="3376" height="1312" alt="image" src="https://github.com/user-attachments/assets/cb4f0e6b-7f1c-462d-a230-6ae6f172b207" />
