### PR TITLE
feat: relationship delta 업로드 및 조회 API 추가

### DIFF
--- a/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
@@ -47,7 +47,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EVENT_DATA_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ADMIN4008", "해당 챕터의 이벤트 데이터가 이미 존재합니다."),
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN4009", "해당 이벤트를 찾을 수 없습니다."),
     RELATIONSHIP_DATA_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ADMIN4010", "해당 이벤트의 관계 데이터가 이미 존재합니다."),
-    RELATIONSHIP_LEGACY_API_DISABLED(HttpStatus.GONE, "ADMIN4019", "Legacy relationship upload API is disabled. Use /api/v2/admin/books/{bookId}/relationship-deltas."),
+    RELATIONSHIP_LEGACY_API_DISABLED(HttpStatus.GONE, "ADMIN4019", "기존 관계 업로드 API는 더 이상 사용할 수 없습니다. relationship-deltas 업로드 API를 사용해주세요."),
     NO_CHARACTERS_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4011", "삭제할 인물 데이터가 존재하지 않습니다."),
     NO_EVENTS_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4012", "삭제할 이벤트 데이터가 존재하지 않습니다."),
     NO_SUMMARY_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4013", "삭제할 POV 요약본이 존재하지 않습니다."),

--- a/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
@@ -47,6 +47,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EVENT_DATA_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ADMIN4008", "해당 챕터의 이벤트 데이터가 이미 존재합니다."),
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN4009", "해당 이벤트를 찾을 수 없습니다."),
     RELATIONSHIP_DATA_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "ADMIN4010", "해당 이벤트의 관계 데이터가 이미 존재합니다."),
+    RELATIONSHIP_LEGACY_API_DISABLED(HttpStatus.GONE, "ADMIN4019", "Legacy relationship upload API is disabled. Use /api/v2/admin/books/{bookId}/relationship-deltas."),
     NO_CHARACTERS_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4011", "삭제할 인물 데이터가 존재하지 않습니다."),
     NO_EVENTS_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4012", "삭제할 이벤트 데이터가 존재하지 않습니다."),
     NO_SUMMARY_TO_DELETE(HttpStatus.BAD_REQUEST, "ADMIN4013", "삭제할 POV 요약본이 존재하지 않습니다."),

--- a/src/main/java/com/kw/readwith/dto/admin/RelationshipDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/RelationshipDTO.java
@@ -30,4 +30,7 @@ public class RelationshipDTO {
     @JsonAlias("count")
     @Schema(description = "근거 개수 또는 상호작용 횟수", example = "3")
     private Integer evidenceCount;
+
+    @Schema(description = "현재 이벤트에서 관계 변화가 발생했다고 판단한 근거")
+    private String reason;
 }

--- a/src/main/java/com/kw/readwith/dto/admin/RelationshipUploadDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/RelationshipUploadDTO.java
@@ -13,6 +13,9 @@ import java.util.Map;
 @Schema(description = "관계 업로드 payload 루트")
 public class RelationshipUploadDTO {
 
+    @Schema(description = "relationship delta contract version", example = "relationship-delta-v1")
+    private String contractVersion;
+
     @Schema(description = "파일이 담당하는 챕터 인덱스(1-based)", example = "3")
     private Integer chapterIndex;
 

--- a/src/main/java/com/kw/readwith/dto/relationship/RelationshipDeltaEventDTO.java
+++ b/src/main/java/com/kw/readwith/dto/relationship/RelationshipDeltaEventDTO.java
@@ -1,0 +1,18 @@
+package com.kw.readwith.dto.relationship;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+public class RelationshipDeltaEventDTO {
+
+    private String contractVersion;
+    private Integer chapterIndex;
+    private String eventId;
+    private List<RelationshipDeltaItemDTO> items;
+    private Map<String, RelationshipNodeWeightDTO> nodeWeights;
+}

--- a/src/main/java/com/kw/readwith/dto/relationship/RelationshipDeltaItemDTO.java
+++ b/src/main/java/com/kw/readwith/dto/relationship/RelationshipDeltaItemDTO.java
@@ -1,0 +1,18 @@
+package com.kw.readwith.dto.relationship;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class RelationshipDeltaItemDTO {
+
+    private Long fromCharacterId;
+    private Long toCharacterId;
+    private List<String> labels;
+    private Double positivity;
+    private Integer evidenceCount;
+    private String reason;
+}

--- a/src/main/java/com/kw/readwith/dto/relationship/RelationshipDeltaListResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/relationship/RelationshipDeltaListResponseDTO.java
@@ -1,0 +1,14 @@
+package com.kw.readwith.dto.relationship;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class RelationshipDeltaListResponseDTO {
+
+    private Long bookId;
+    private List<RelationshipDeltaEventDTO> deltas;
+}

--- a/src/main/java/com/kw/readwith/dto/relationship/RelationshipGraphEdgeDTO.java
+++ b/src/main/java/com/kw/readwith/dto/relationship/RelationshipGraphEdgeDTO.java
@@ -1,0 +1,34 @@
+package com.kw.readwith.dto.relationship;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+public class RelationshipGraphEdgeDTO {
+
+    @JsonProperty("id1")
+    private Long from;
+
+    @JsonProperty("id2")
+    private Long to;
+
+    @JsonProperty("positivity")
+    private Double positivity;
+
+    @JsonProperty("count")
+    private Integer evidenceCount;
+
+    @JsonProperty("relation")
+    private List<String> labels;
+
+    private Map<String, Integer> labelScores;
+    private List<String> latestLabels;
+    private String latestReason;
+    private String latestEventId;
+    private Map<String, Integer> directionCounts;
+}

--- a/src/main/java/com/kw/readwith/dto/relationship/RelationshipGraphResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/relationship/RelationshipGraphResponseDTO.java
@@ -1,0 +1,24 @@
+package com.kw.readwith.dto.relationship;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kw.readwith.dto.graph.GraphNodeDTO;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class RelationshipGraphResponseDTO {
+
+    private Long bookId;
+    private String scope;
+    private Integer chapterIndex;
+    private String eventId;
+
+    @JsonProperty("characters")
+    private List<GraphNodeDTO> nodes;
+
+    @JsonProperty("relations")
+    private List<RelationshipGraphEdgeDTO> edges;
+}

--- a/src/main/java/com/kw/readwith/dto/relationship/RelationshipNodeWeightDTO.java
+++ b/src/main/java/com/kw/readwith/dto/relationship/RelationshipNodeWeightDTO.java
@@ -1,0 +1,11 @@
+package com.kw.readwith.dto.relationship;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RelationshipNodeWeightDTO {
+
+    private Double weight;
+}

--- a/src/main/java/com/kw/readwith/repository/EventCharacterStatRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventCharacterStatRepository.java
@@ -24,6 +24,12 @@ public interface EventCharacterStatRepository extends JpaRepository<EventCharact
 
     List<EventCharacterStat> findByEventIn(List<Event> events);
 
+    @Query("SELECT stat FROM EventCharacterStat stat " +
+           "JOIN stat.event event JOIN event.chapter chapter " +
+           "WHERE event IN :events " +
+           "ORDER BY chapter.idx ASC, event.idx ASC, stat.id ASC")
+    List<EventCharacterStat> findByEventsOrdered(@Param("events") List<Event> events);
+
     boolean existsByEvent(Event event);
 
     int deleteByEvent(Event event);

--- a/src/main/java/com/kw/readwith/repository/EventRelationshipEdgeRepository.java
+++ b/src/main/java/com/kw/readwith/repository/EventRelationshipEdgeRepository.java
@@ -31,4 +31,10 @@ public interface EventRelationshipEdgeRepository extends JpaRepository<EventRela
      */
     List<EventRelationshipEdge> findByEventIn(List<Event> events);
 
+    @Query("SELECT edge FROM EventRelationshipEdge edge " +
+           "JOIN edge.event event JOIN event.chapter chapter " +
+           "WHERE event IN :events " +
+           "ORDER BY chapter.idx ASC, event.idx ASC, edge.id ASC")
+    List<EventRelationshipEdge> findByEventsOrdered(@Param("events") List<Event> events);
+
 }

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -33,6 +33,7 @@ import jakarta.persistence.PersistenceContext;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +49,7 @@ import java.util.stream.Collectors;
 public class AdminService {
 
     private static final Logger log = LoggerFactory.getLogger(AdminService.class);
+    private static final String RELATIONSHIP_DELTA_CONTRACT_VERSION = "relationship-delta-v1";
 
     // 筌뤴뫀諭??온?귐딆쁽 疫꿸퀡????袁⑹뒄??Repository 獄?ObjectMapper ??뤵??雅뚯눘??
     private final BookRepository bookRepository;
@@ -390,27 +392,34 @@ public class AdminService {
      */
     @Transactional
     public int uploadRelationships(Long bookId, List<MultipartFile> files) {
+        return uploadRelationshipDeltas(bookId, files);
+    }
+
+    @Transactional
+    public int uploadRelationshipDeltas(Long bookId, List<MultipartFile> files) {
         if (files == null || files.isEmpty()) {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST, "No relationship files provided.");
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "No relationship delta files provided.");
         }
 
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
         try {
+            Map<String, RelationshipDeltaCandidate> candidatesByEventId = new LinkedHashMap<>();
             int totalProcessedCount = 0;
 
             for (MultipartFile file : files) {
                 if (file == null || file.isEmpty()) {
-                    log.warn("Skip empty relationship file.");
+                    log.warn("Skip empty relationship delta file.");
                     continue;
                 }
 
                 try {
                     RelationshipUploadDTO dto = objectMapper.readValue(file.getInputStream(), RelationshipUploadDTO.class);
                     if (dto == null || dto.getChapterIndex() == null) {
-                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "relationship payload chapterIndex is required.");
+                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "relationship delta payload chapterIndex is required.");
                     }
+                    validateRelationshipDeltaContract(dto);
 
                     String eventId = requireText(dto.getEventId(), "relationship.eventId");
                     int chapterIdx = dto.getChapterIndex();
@@ -422,11 +431,21 @@ public class AdminService {
                                     String.format("Event not found for book=%d chapter=%d event=%d", bookId, chapterIdx, eventIdx)
                             ));
 
-                    totalProcessedCount += processNodeWeights(event, book, dto.getNodeWeights());
-                    totalProcessedCount += processRelations(event, book, dto.getItems());
+                    String normalizedEventId = normalizeEventId(eventId, chapterIdx, eventIdx);
+                    if (candidatesByEventId.containsKey(normalizedEventId)) {
+                        throw new GeneralException(ErrorStatus._BAD_REQUEST, "Duplicate relationship delta eventId in request: " + normalizedEventId);
+                    }
+
+                    RelationshipDeltaCandidate candidate = buildRelationshipDeltaCandidate(event, book, dto);
+                    candidatesByEventId.put(normalizedEventId, candidate);
                 } catch (IOException e) {
-                    throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "Failed to parse relationship JSON: " + file.getOriginalFilename());
+                    throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR, "Failed to parse relationship delta JSON: " + file.getOriginalFilename());
                 }
+            }
+
+            for (RelationshipDeltaCandidate candidate : candidatesByEventId.values()) {
+                replaceRelationshipDelta(candidate.event());
+                totalProcessedCount += saveRelationshipDelta(candidate);
             }
 
             bookAnalysisStatusService.refreshStatus(bookId);
@@ -435,6 +454,138 @@ public class AdminService {
             markAnalysisRejectedIfNeeded(book, e);
             throw e;
         }
+    }
+
+    private void validateRelationshipDeltaContract(RelationshipUploadDTO dto) {
+        String contractVersion = requireText(dto.getContractVersion(), "relationship.contractVersion");
+        if (!RELATIONSHIP_DELTA_CONTRACT_VERSION.equals(contractVersion)) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "Unsupported relationship contractVersion: " + contractVersion);
+        }
+    }
+
+    private RelationshipDeltaCandidate buildRelationshipDeltaCandidate(Event event, Book book, RelationshipUploadDTO dto) {
+        List<EventCharacterStat> stats = buildRelationshipNodeWeights(event, book, dto.getNodeWeights());
+        List<EventRelationshipEdge> edges = buildRelationshipDeltaEdges(event, book, dto.getItems());
+        return new RelationshipDeltaCandidate(event, stats, edges);
+    }
+
+    private List<EventCharacterStat> buildRelationshipNodeWeights(Event event, Book book, Map<String, NodeWeightDTO> nodeWeightsMap) {
+        if (nodeWeightsMap == null || nodeWeightsMap.isEmpty()) {
+            return List.of();
+        }
+
+        List<EventCharacterStat> stats = new ArrayList<>();
+        for (Map.Entry<String, NodeWeightDTO> entry : nodeWeightsMap.entrySet()) {
+            Long characterBookId = parseCharacterId(entry.getKey(), "relationship.nodeWeights.characterId");
+            NodeWeightDTO weightDTO = entry.getValue();
+            if (weightDTO == null) {
+                throw new GeneralException(ErrorStatus._BAD_REQUEST, "relationship.nodeWeights value is required: " + characterBookId);
+            }
+
+            Character character = characterRepository.findByBookAndCharacterId(book, characterBookId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_CHARACTER_NOT_FOUND,
+                            "Character not found in book: " + characterBookId));
+
+            stats.add(EventCharacterStat.builder()
+                    .event(event)
+                    .character(character)
+                    .nodeWeight(weightDTO.getWeight())
+                    .build());
+        }
+        return stats;
+    }
+
+    private List<EventRelationshipEdge> buildRelationshipDeltaEdges(Event event, Book book, List<RelationshipDTO> relationDTOs) {
+        if (relationDTOs == null || relationDTOs.isEmpty()) {
+            return List.of();
+        }
+
+        Set<String> rawEdgeKeys = new LinkedHashSet<>();
+        List<EventRelationshipEdge> edges = new ArrayList<>();
+        for (RelationshipDTO dto : relationDTOs) {
+            Long fromCharacterId = parseCharacterId(dto.getFromCharacterId(), "relationship.fromCharacterId");
+            Long toCharacterId = parseCharacterId(dto.getToCharacterId(), "relationship.toCharacterId");
+            if (fromCharacterId.equals(toCharacterId)) {
+                throw new GeneralException(ErrorStatus._BAD_REQUEST, "relationship fromCharacterId and toCharacterId must differ.");
+            }
+
+            validateRelationshipDeltaItem(dto);
+
+            String rawEdgeKey = fromCharacterId + "->" + toCharacterId;
+            if (!rawEdgeKeys.add(rawEdgeKey)) {
+                throw new GeneralException(ErrorStatus._BAD_REQUEST, "Duplicate relationship delta edge in event: " + rawEdgeKey);
+            }
+
+            Character fromChar = characterRepository.findByBookAndCharacterId(book, fromCharacterId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_CHARACTER_NOT_FOUND,
+                            "Character not found in book: " + fromCharacterId));
+            Character toChar = characterRepository.findByBookAndCharacterId(book, toCharacterId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_CHARACTER_NOT_FOUND,
+                            "Character not found in book: " + toCharacterId));
+
+            try {
+                edges.add(EventRelationshipEdge.builder()
+                        .event(event)
+                        .fromCharacter(fromChar)
+                        .toCharacter(toChar)
+                        .explanation(dto.getReason())
+                        .sentimentScore(dto.getPositivity().floatValue())
+                        .interactionCount(dto.getEvidenceCount())
+                        .relationTags(objectMapper.writeValueAsString(dto.getLabels()))
+                        .build());
+            } catch (JsonProcessingException e) {
+                throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR,
+                        String.format("Failed to serialize relationship labels for %d -> %d", fromCharacterId, toCharacterId));
+            }
+        }
+        return edges;
+    }
+
+    private void validateRelationshipDeltaItem(RelationshipDTO dto) {
+        if (dto.getPositivity() == null) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "relationship positivity is required.");
+        }
+        if (dto.getPositivity() < -1.0 || dto.getPositivity() > 1.0) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "relationship positivity must be between -1.0 and 1.0.");
+        }
+        if (dto.getEvidenceCount() == null || dto.getEvidenceCount() <= 0) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "relationship evidenceCount must be positive.");
+        }
+        if (dto.getLabels() == null) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "relationship labels must not be null.");
+        }
+        for (String label : dto.getLabels()) {
+            requireText(label, "relationship.labels");
+        }
+    }
+
+    private void replaceRelationshipDelta(Event event) {
+        if (eventRelationshipEdgeRepository.existsByEvent(event)) {
+            eventRelationshipEdgeRepository.deleteByEvent(event);
+        }
+        if (statRepository.existsByEvent(event)) {
+            statRepository.deleteByEvent(event);
+        }
+    }
+
+    private int saveRelationshipDelta(RelationshipDeltaCandidate candidate) {
+        int savedCount = 0;
+        if (!candidate.stats().isEmpty()) {
+            statRepository.saveAll(candidate.stats());
+            savedCount += candidate.stats().size();
+        }
+        if (!candidate.edges().isEmpty()) {
+            eventRelationshipEdgeRepository.saveAll(candidate.edges());
+            savedCount += candidate.edges().size();
+        }
+        return savedCount;
+    }
+
+    private record RelationshipDeltaCandidate(
+            Event event,
+            List<EventCharacterStat> stats,
+            List<EventRelationshipEdge> edges
+    ) {
     }
 
     private SummaryItemDTO validateSummaryItem(SummaryItemDTO item) {

--- a/src/main/java/com/kw/readwith/service/RelationshipDeltaService.java
+++ b/src/main/java/com/kw/readwith/service/RelationshipDeltaService.java
@@ -1,0 +1,437 @@
+package com.kw.readwith.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Chapter;
+import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.Event;
+import com.kw.readwith.domain.mapping.EventCharacterStat;
+import com.kw.readwith.domain.mapping.EventRelationshipEdge;
+import com.kw.readwith.dto.common.LocatorDTO;
+import com.kw.readwith.dto.graph.GraphNodeDTO;
+import com.kw.readwith.dto.relationship.RelationshipDeltaEventDTO;
+import com.kw.readwith.dto.relationship.RelationshipDeltaItemDTO;
+import com.kw.readwith.dto.relationship.RelationshipDeltaListResponseDTO;
+import com.kw.readwith.dto.relationship.RelationshipGraphEdgeDTO;
+import com.kw.readwith.dto.relationship.RelationshipGraphResponseDTO;
+import com.kw.readwith.dto.relationship.RelationshipNodeWeightDTO;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import com.kw.readwith.repository.EventCharacterStatRepository;
+import com.kw.readwith.repository.EventRelationshipEdgeRepository;
+import com.kw.readwith.repository.EventRepository;
+import com.kw.readwith.util.LocatorSupport;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RelationshipDeltaService {
+
+    private static final String CONTRACT_VERSION = "relationship-delta-v1";
+
+    private final BookRepository bookRepository;
+    private final ChapterRepository chapterRepository;
+    private final EventRepository eventRepository;
+    private final EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
+    private final EventCharacterStatRepository eventCharacterStatRepository;
+    private final ObjectMapper objectMapper;
+    private final BookAccessPolicy bookAccessPolicy;
+    private final LocatorSupport locatorSupport;
+
+    public RelationshipDeltaListResponseDTO getRelationshipDeltas(
+            Long bookId,
+            Integer chapterIndex,
+            String eventId,
+            String fromEventId,
+            String toEventId,
+            Long userId
+    ) {
+        Book book = getReadableBook(bookId, userId);
+        List<Event> events = resolveRawDeltaEvents(book, chapterIndex, eventId, fromEventId, toEventId);
+        DeltaRows rows = loadDeltaRows(events);
+
+        List<RelationshipDeltaEventDTO> deltas = events.stream()
+                .map(event -> toDeltaEvent(event, rows))
+                .toList();
+
+        return RelationshipDeltaListResponseDTO.builder()
+                .bookId(bookId)
+                .deltas(deltas)
+                .build();
+    }
+
+    public RelationshipGraphResponseDTO getRelationshipGraph(
+            Long bookId,
+            String scope,
+            Integer chapterIndex,
+            String eventId,
+            Integer blockIndex,
+            Integer offset,
+            Long userId
+    ) {
+        Book book = getReadableBook(bookId, userId);
+        String resolvedScope = scope == null || scope.isBlank() ? "book" : scope.toLowerCase();
+        List<Event> events = resolveGraphEvents(book, resolvedScope, chapterIndex, eventId, blockIndex, offset);
+        DeltaRows rows = loadDeltaRows(events);
+        FoldResult foldResult = fold(events, rows);
+
+        return RelationshipGraphResponseDTO.builder()
+                .bookId(bookId)
+                .scope(resolvedScope)
+                .chapterIndex(chapterIndex)
+                .eventId(eventId)
+                .nodes(foldResult.nodes())
+                .edges(foldResult.edges())
+                .build();
+    }
+
+    private Book getReadableBook(Long bookId, Long userId) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+        bookAccessPolicy.ensureReadable(book, userId);
+        return book;
+    }
+
+    private List<Event> resolveRawDeltaEvents(Book book, Integer chapterIndex, String eventId, String fromEventId, String toEventId) {
+        List<Event> allEvents = eventRepository.findByBookOrderByChapterIdxAscIdxAsc(book);
+        if (eventId != null && !eventId.isBlank()) {
+            return List.of(findEventByEventId(allEvents, eventId));
+        }
+        if (fromEventId != null || toEventId != null) {
+            if (fromEventId == null || fromEventId.isBlank() || toEventId == null || toEventId.isBlank()) {
+                throw new GeneralException(ErrorStatus._BAD_REQUEST, "fromEventId and toEventId must be provided together.");
+            }
+            return sliceEvents(allEvents, fromEventId, toEventId);
+        }
+        if (chapterIndex != null) {
+            return allEvents.stream()
+                    .filter(event -> event.getChapter().getIdx() == chapterIndex)
+                    .toList();
+        }
+        return allEvents;
+    }
+
+    private List<Event> resolveGraphEvents(Book book, String scope, Integer chapterIndex, String eventId, Integer blockIndex, Integer offset) {
+        List<Event> allEvents = eventRepository.findByBookOrderByChapterIdxAscIdxAsc(book);
+        return switch (scope) {
+            case "book" -> allEvents;
+            case "chapter" -> {
+                if (chapterIndex == null) {
+                    throw new GeneralException(ErrorStatus._BAD_REQUEST, "chapterIndex is required for chapter scope.");
+                }
+                yield allEvents.stream()
+                        .filter(event -> event.getChapter().getIdx() <= chapterIndex)
+                        .toList();
+            }
+            case "event" -> {
+                String requiredEventId = requireText(eventId, "eventId");
+                Event target = findEventByEventId(allEvents, requiredEventId);
+                int targetIndex = allEvents.indexOf(target);
+                yield allEvents.subList(0, targetIndex + 1);
+            }
+            case "locator" -> {
+                if (chapterIndex == null || blockIndex == null || offset == null) {
+                    throw new GeneralException(ErrorStatus._BAD_REQUEST, "chapterIndex, blockIndex, offset are required for locator scope.");
+                }
+                Chapter chapter = chapterRepository.findByBookIdAndIdx(book.getId(), chapterIndex)
+                        .orElseThrow(() -> new GeneralException(ErrorStatus.CHAPTER_NOT_FOUND));
+                LocatorDTO locator = LocatorDTO.builder()
+                        .chapterIndex(chapterIndex)
+                        .blockIndex(blockIndex)
+                        .offset(offset)
+                        .build();
+                int txtOffset = locatorSupport.toTxtOffset(chapter, locator);
+                yield allEvents.stream()
+                        .filter(event -> event.getChapter().getIdx() < chapterIndex
+                                || (event.getChapter().getIdx() == chapterIndex && event.getStartTxtOffset() <= txtOffset))
+                        .toList();
+            }
+            default -> throw new GeneralException(ErrorStatus._BAD_REQUEST, "Unsupported relationship graph scope: " + scope);
+        };
+    }
+
+    private List<Event> sliceEvents(List<Event> allEvents, String fromEventId, String toEventId) {
+        Event fromEvent = findEventByEventId(allEvents, fromEventId);
+        Event toEvent = findEventByEventId(allEvents, toEventId);
+        int fromIndex = allEvents.indexOf(fromEvent);
+        int toIndex = allEvents.indexOf(toEvent);
+        if (fromIndex > toIndex) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "fromEventId must be before or equal to toEventId.");
+        }
+        return allEvents.subList(fromIndex, toIndex + 1);
+    }
+
+    private Event findEventByEventId(List<Event> events, String eventId) {
+        String normalizedEventId = normalizeEventId(eventId);
+        return events.stream()
+                .filter(event -> normalizedEventId.equals(event.getEventId()))
+                .findFirst()
+                .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND, "Event not found: " + eventId));
+    }
+
+    private String normalizeEventId(String eventId) {
+        String value = requireText(eventId, "eventId");
+        Matcher matcher = Pattern.compile("^ch(\\d+)-e(\\d+)$").matcher(value);
+        if (matcher.matches()) {
+            return value;
+        }
+        throw new GeneralException(ErrorStatus._BAD_REQUEST, "eventId must match ch{chapter}-e{event}: " + eventId);
+    }
+
+    private DeltaRows loadDeltaRows(List<Event> events) {
+        if (events.isEmpty()) {
+            return new DeltaRows(Map.of(), Map.of());
+        }
+
+        List<EventRelationshipEdge> edges = eventRelationshipEdgeRepository.findByEventsOrdered(events);
+        List<EventCharacterStat> stats = eventCharacterStatRepository.findByEventsOrdered(events);
+
+        Map<Long, List<EventRelationshipEdge>> edgesByEventId = edges.stream()
+                .collect(Collectors.groupingBy(edge -> edge.getEvent().getId(), LinkedHashMap::new, Collectors.toList()));
+        Map<Long, List<EventCharacterStat>> statsByEventId = stats.stream()
+                .collect(Collectors.groupingBy(stat -> stat.getEvent().getId(), LinkedHashMap::new, Collectors.toList()));
+        return new DeltaRows(edgesByEventId, statsByEventId);
+    }
+
+    private RelationshipDeltaEventDTO toDeltaEvent(Event event, DeltaRows rows) {
+        List<RelationshipDeltaItemDTO> items = rows.edgesByEventId()
+                .getOrDefault(event.getId(), List.of())
+                .stream()
+                .map(this::toDeltaItem)
+                .toList();
+
+        Map<String, RelationshipNodeWeightDTO> nodeWeights = new LinkedHashMap<>();
+        for (EventCharacterStat stat : rows.statsByEventId().getOrDefault(event.getId(), List.of())) {
+            nodeWeights.put(
+                    String.valueOf(stat.getCharacter().getCharacterId()),
+                    RelationshipNodeWeightDTO.builder()
+                            .weight(stat.getNodeWeight())
+                            .build()
+            );
+        }
+
+        return RelationshipDeltaEventDTO.builder()
+                .contractVersion(CONTRACT_VERSION)
+                .chapterIndex(event.getChapter().getIdx())
+                .eventId(event.getEventId())
+                .items(items)
+                .nodeWeights(nodeWeights)
+                .build();
+    }
+
+    private RelationshipDeltaItemDTO toDeltaItem(EventRelationshipEdge edge) {
+        return RelationshipDeltaItemDTO.builder()
+                .fromCharacterId(edge.getFromCharacter().getCharacterId())
+                .toCharacterId(edge.getToCharacter().getCharacterId())
+                .labels(readLabels(edge.getRelationTags()))
+                .positivity(edge.getSentimentScore() != null ? edge.getSentimentScore().doubleValue() : null)
+                .evidenceCount(edge.getInteractionCount())
+                .reason(edge.getExplanation())
+                .build();
+    }
+
+    private FoldResult fold(List<Event> events, DeltaRows rows) {
+        Map<Long, NodeAccumulator> nodeAccumulators = new LinkedHashMap<>();
+        Map<String, EdgeAccumulator> edgeAccumulators = new LinkedHashMap<>();
+
+        for (Event event : events) {
+            for (EventCharacterStat stat : rows.statsByEventId().getOrDefault(event.getId(), List.of())) {
+                nodeAccumulators
+                        .computeIfAbsent(stat.getCharacter().getId(), key -> new NodeAccumulator(stat.getCharacter()))
+                        .add(stat);
+            }
+
+            for (EventRelationshipEdge edge : rows.edgesByEventId().getOrDefault(event.getId(), List.of())) {
+                Character from = edge.getFromCharacter();
+                Character to = edge.getToCharacter();
+                nodeAccumulators.putIfAbsent(from.getId(), new NodeAccumulator(from));
+                nodeAccumulators.putIfAbsent(to.getId(), new NodeAccumulator(to));
+
+                String edgeKey = edgeKey(from.getCharacterId(), to.getCharacterId());
+                edgeAccumulators
+                        .computeIfAbsent(edgeKey, key -> new EdgeAccumulator(from, to))
+                        .add(edge);
+            }
+        }
+
+        List<GraphNodeDTO> nodes = nodeAccumulators.values().stream()
+                .map(NodeAccumulator::toDto)
+                .toList();
+        List<RelationshipGraphEdgeDTO> edges = edgeAccumulators.values().stream()
+                .map(EdgeAccumulator::toDto)
+                .toList();
+        return new FoldResult(nodes, edges);
+    }
+
+    private String edgeKey(Long leftCharacterId, Long rightCharacterId) {
+        long left = Math.min(leftCharacterId, rightCharacterId);
+        long right = Math.max(leftCharacterId, rightCharacterId);
+        return left + ":" + right;
+    }
+
+    private List<String> readLabels(String relationTags) {
+        if (relationTags == null || relationTags.isBlank()) {
+            return List.of();
+        }
+        try {
+            return objectMapper.readValue(
+                    relationTags,
+                    objectMapper.getTypeFactory().constructCollectionType(List.class, String.class)
+            );
+        } catch (Exception e) {
+            log.warn("Failed to parse relationTags: {}", relationTags, e);
+            return List.of();
+        }
+    }
+
+    private String requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, fieldName + " is required.");
+        }
+        return value;
+    }
+
+    private String truncateText(String text, int maxLength) {
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+        String cleanText = text.replaceAll("\\s+", " ").trim();
+        if (cleanText.length() <= maxLength) {
+            return cleanText;
+        }
+        return cleanText.substring(0, maxLength - 3) + "...";
+    }
+
+    private List<String> parseNames(String names, String fallbackName) {
+        if (names == null || names.trim().isEmpty()) {
+            return List.of(fallbackName);
+        }
+        List<String> nameList = Arrays.stream(names.split(","))
+                .map(String::trim)
+                .filter(name -> !name.isEmpty())
+                .toList();
+        return nameList.isEmpty() ? List.of(fallbackName) : nameList;
+    }
+
+    private record DeltaRows(
+            Map<Long, List<EventRelationshipEdge>> edgesByEventId,
+            Map<Long, List<EventCharacterStat>> statsByEventId
+    ) {
+    }
+
+    private record FoldResult(
+            List<GraphNodeDTO> nodes,
+            List<RelationshipGraphEdgeDTO> edges
+    ) {
+    }
+
+    private class NodeAccumulator {
+        private final Character character;
+        private double weightSum;
+        private int count;
+
+        private NodeAccumulator(Character character) {
+            this.character = character;
+        }
+
+        private void add(EventCharacterStat stat) {
+            this.weightSum += stat.getNodeWeight();
+            this.count++;
+        }
+
+        private GraphNodeDTO toDto() {
+            return GraphNodeDTO.builder()
+                    .id(character.getCharacterId())
+                    .label(character.getName())
+                    .isMainCharacter(character.isMainCharacter())
+                    .profileImage(character.getProfileImage())
+                    .description(truncateText(character.getPersonalityText(), 200))
+                    .portraitPrompt(character.getProfileText())
+                    .names(parseNames(character.getNames(), character.getName()))
+                    .weight(count > 0 ? (float) weightSum : null)
+                    .count(count > 0 ? count : null)
+                    .build();
+        }
+    }
+
+    private class EdgeAccumulator {
+        private final Character left;
+        private final Character right;
+        private final Map<String, Integer> labelScores = new LinkedHashMap<>();
+        private final Map<String, Integer> directionCounts = new LinkedHashMap<>();
+        private double positivityWeightedSum;
+        private int evidenceCount;
+        private List<String> latestLabels = List.of();
+        private String latestReason;
+        private String latestEventId;
+
+        private EdgeAccumulator(Character from, Character to) {
+            if (from.getCharacterId() <= to.getCharacterId()) {
+                this.left = from;
+                this.right = to;
+            } else {
+                this.left = to;
+                this.right = from;
+            }
+        }
+
+        private void add(EventRelationshipEdge edge) {
+            int deltaCount = edge.getInteractionCount() != null ? edge.getInteractionCount() : 0;
+            double positivity = edge.getSentimentScore() != null ? edge.getSentimentScore() : 0.0;
+            this.evidenceCount += deltaCount;
+            this.positivityWeightedSum += positivity * deltaCount;
+
+            List<String> labels = readLabels(edge.getRelationTags());
+            for (String label : labels) {
+                labelScores.merge(label, deltaCount, Integer::sum);
+            }
+
+            String directionKey = edge.getFromCharacter().getCharacterId() + "->" + edge.getToCharacter().getCharacterId();
+            directionCounts.merge(directionKey, deltaCount, Integer::sum);
+            latestLabels = labels;
+            latestReason = edge.getExplanation();
+            latestEventId = edge.getEvent().getEventId();
+        }
+
+        private RelationshipGraphEdgeDTO toDto() {
+            List<String> labels = labelScores.entrySet().stream()
+                    .sorted(Comparator
+                            .<Map.Entry<String, Integer>>comparingInt(Map.Entry::getValue)
+                            .reversed()
+                            .thenComparing(Map.Entry::getKey))
+                    .limit(3)
+                    .map(Map.Entry::getKey)
+                    .toList();
+
+            return RelationshipGraphEdgeDTO.builder()
+                    .from(left.getCharacterId())
+                    .to(right.getCharacterId())
+                    .positivity(evidenceCount > 0 ? positivityWeightedSum / evidenceCount : 0.0)
+                    .evidenceCount(evidenceCount)
+                    .labels(labels)
+                    .labelScores(labelScores)
+                    .latestLabels(latestLabels)
+                    .latestReason(latestReason)
+                    .latestEventId(latestEventId)
+                    .directionCounts(directionCounts)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -1,6 +1,8 @@
 package com.kw.readwith.web.controller;
 
 import com.kw.readwith.apiPayload.ApiResponse;
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.dto.admin.AnalysisInputResponseDTO;
 import com.kw.readwith.dto.admin.BookAdminDetailDTO;
 import com.kw.readwith.dto.admin.UnsummarizedItemDTO;
@@ -109,14 +111,25 @@ public class AdminController {
 
     @Operation(
             summary = "관계 업로드",
-            description = "`chapter_{n}_relationships_event_{m}.json` 파일들을 업로드합니다. payload 루트는 `chapterIndex`, `eventId`, `items`, `nodeWeights`를 사용합니다."
+            description = "비활성화된 legacy endpoint입니다. `/books/{bookId}/relationship-deltas`를 사용합니다."
     )
     @PostMapping(value = "/books/{bookId}/relationships", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadRelationships(
             @Parameter(description = "업로드 대상 도서 ID", required = true) @PathVariable Long bookId,
             @Parameter(description = "관계 JSON 파일 목록", required = true) @RequestParam("files") List<MultipartFile> files) {
-        adminService.uploadRelationships(bookId, files);
-        return ApiResponse.onSuccess("Relationships for the book have been successfully uploaded.");
+        throw new GeneralException(ErrorStatus.RELATIONSHIP_LEGACY_API_DISABLED);
+    }
+
+    @Operation(
+            summary = "관계 delta 업로드",
+            description = "`relationship-delta-v1` 파일들을 event 단위 replace 방식으로 업로드합니다."
+    )
+    @PostMapping(value = "/books/{bookId}/relationship-deltas", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<String> uploadRelationshipDeltas(
+            @Parameter(description = "업로드 대상 도서 ID", required = true) @PathVariable Long bookId,
+            @Parameter(description = "관계 delta JSON 파일 목록", required = true) @RequestParam("files") List<MultipartFile> files) {
+        adminService.uploadRelationshipDeltas(bookId, files);
+        return ApiResponse.onSuccess("Relationship deltas for the book have been successfully uploaded.");
     }
 
     @Operation(summary = "이벤트 관계 삭제", description = "특정 이벤트에 적재된 관계 edge와 node weight를 함께 삭제합니다.")

--- a/src/main/java/com/kw/readwith/web/controller/RelationshipDeltaController.java
+++ b/src/main/java/com/kw/readwith/web/controller/RelationshipDeltaController.java
@@ -1,0 +1,82 @@
+package com.kw.readwith.web.controller;
+
+import com.kw.readwith.apiPayload.ApiResponse;
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.dto.relationship.RelationshipDeltaListResponseDTO;
+import com.kw.readwith.dto.relationship.RelationshipGraphResponseDTO;
+import com.kw.readwith.service.RelationshipDeltaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/books")
+@Tag(name = "Relationship Delta", description = "relationship delta raw/fold 조회 API입니다.")
+public class RelationshipDeltaController {
+
+    private final RelationshipDeltaService relationshipDeltaService;
+
+    @GetMapping("/{bookId}/relationship-deltas")
+    @Operation(summary = "relationship delta 원본 조회")
+    public ApiResponse<RelationshipDeltaListResponseDTO> getRelationshipDeltas(
+            @Parameter(description = "조회 대상 도서 ID", required = true) @PathVariable Long bookId,
+            @RequestParam(required = false) Integer chapterIndex,
+            @RequestParam(required = false) String eventId,
+            @RequestParam(required = false) String fromEventId,
+            @RequestParam(required = false) String toEventId) {
+        RelationshipDeltaListResponseDTO response = relationshipDeltaService.getRelationshipDeltas(
+                bookId,
+                chapterIndex,
+                eventId,
+                fromEventId,
+                toEventId,
+                getCurrentUserIdOrNull()
+        );
+        return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping("/{bookId}/relationship-graph")
+    @Operation(summary = "relationship delta 누적 graph 조회")
+    public ApiResponse<RelationshipGraphResponseDTO> getRelationshipGraph(
+            @Parameter(description = "조회 대상 도서 ID", required = true) @PathVariable Long bookId,
+            @RequestParam(required = false, defaultValue = "book") String scope,
+            @RequestParam(required = false) Integer chapterIndex,
+            @RequestParam(required = false) String eventId,
+            @RequestParam(required = false) Integer blockIndex,
+            @RequestParam(required = false) Integer offset) {
+        RelationshipGraphResponseDTO response = relationshipDeltaService.getRelationshipGraph(
+                bookId,
+                scope,
+                chapterIndex,
+                eventId,
+                blockIndex,
+                offset,
+                getCurrentUserIdOrNull()
+        );
+        return ApiResponse.onSuccess(response);
+    }
+
+    private Long getCurrentUserIdOrNull() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getPrincipal() == null) {
+            return null;
+        }
+        if (authentication.getPrincipal() instanceof Long principal) {
+            return principal;
+        }
+        if ("anonymousUser".equals(authentication.getPrincipal())) {
+            return null;
+        }
+        throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+    }
+}

--- a/src/test/java/com/kw/readwith/service/AdminServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/AdminServiceTest.java
@@ -313,26 +313,28 @@ class AdminServiceTest {
     }
 
     @Test
-    @DisplayName("uploadRelationships saves node weights and edges from the current payload shape")
-    void uploadRelationships_withCorrectJsonStructure() throws IOException {
+    @DisplayName("uploadRelationshipDeltas saves node weights and edges from delta payload")
+    void uploadRelationshipDeltas_withCorrectJsonStructure() throws IOException {
         Long bookId = 1L;
         int chapterIdx = 1;
         int eventIdx = 1;
         String fileName = String.format("chapter%d_something_event_%d.json", chapterIdx, eventIdx);
         String jsonContent = """
                 {
+                  "contractVersion": "relationship-delta-v1",
                   "chapterIndex": 1,
                   "eventId": "ch1-e1",
-                  "relations": [
+                  "items": [
                     {
-                      "id1": "10",
-                      "id2": "20",
-                      "relation": ["friend"],
+                      "fromCharacterId": "10",
+                      "toCharacterId": "20",
+                      "labels": ["friend"],
                       "positivity": 0.9,
-                      "count": 5
+                      "evidenceCount": 5,
+                      "reason": "event reason"
                     }
                   ],
-                  "node_weights_accum": {
+                  "nodeWeights": {
                     "10": {
                       "weight": 15.5,
                       "count": 3
@@ -356,10 +358,8 @@ class AdminServiceTest {
         given(eventRepository.findByBookIdAndChapterIdxAndEventIdx(bookId, chapterIdx, eventIdx)).willReturn(Optional.of(event));
         given(characterRepository.findByBookAndCharacterId(book, 10L)).willReturn(Optional.of(fromChar));
         given(characterRepository.findByBookAndCharacterId(book, 20L)).willReturn(Optional.of(toChar));
-        given(statRepository.findByEventAndCharacter(any(), any())).willReturn(Optional.empty());
-        given(eventRelationshipEdgeRepository.existsByEventAndFromCharacterAndToCharacter(any(), any(), any())).willReturn(false);
 
-        adminService.uploadRelationships(bookId, List.of(file));
+        adminService.uploadRelationshipDeltas(bookId, List.of(file));
 
         ArgumentCaptor<List<EventCharacterStat>> statCaptor = ArgumentCaptor.forClass(List.class);
         verify(statRepository, times(1)).saveAll(statCaptor.capture());
@@ -376,26 +376,28 @@ class AdminServiceTest {
         assertThat(savedEdges.get(0).getToCharacter().getId()).isEqualTo(20L);
         assertThat(savedEdges.get(0).getSentimentScore()).isEqualTo(0.9f);
         assertThat(savedEdges.get(0).getInteractionCount()).isEqualTo(5);
+        assertThat(savedEdges.get(0).getExplanation()).isEqualTo("event reason");
     }
 
     @Test
-    @DisplayName("uploadRelationships rejects duplicate relationship data")
-    void uploadRelationships_throwsException_whenDataExists() throws IOException {
+    @DisplayName("uploadRelationshipDeltas replaces existing event relationship data")
+    void uploadRelationshipDeltas_replacesExistingEventData() throws IOException {
         Long bookId = 1L;
         int chapterIdx = 1;
         int eventIdx = 1;
         String fileName = String.format("chapter%d_something_event_%d.json", chapterIdx, eventIdx);
         String jsonContent = """
                 {
+                  "contractVersion": "relationship-delta-v1",
                   "chapterIndex": 1,
                   "eventId": "ch1-e1",
-                  "relations": [
+                  "items": [
                     {
-                      "id1": "10",
-                      "id2": "20",
-                      "relation": ["friend"],
+                      "fromCharacterId": "10",
+                      "toCharacterId": "20",
+                      "labels": ["friend"],
                       "positivity": 0.9,
-                      "count": 1
+                      "evidenceCount": 1
                     }
                   ]
                 }
@@ -416,11 +418,12 @@ class AdminServiceTest {
         given(eventRepository.findByBookIdAndChapterIdxAndEventIdx(bookId, chapterIdx, eventIdx)).willReturn(Optional.of(event));
         given(characterRepository.findByBookAndCharacterId(book, 10L)).willReturn(Optional.of(fromChar));
         given(characterRepository.findByBookAndCharacterId(book, 20L)).willReturn(Optional.of(toChar));
-        given(eventRelationshipEdgeRepository.existsByEventAndFromCharacterAndToCharacter(event, fromChar, toChar)).willReturn(true);
+        given(eventRelationshipEdgeRepository.existsByEvent(event)).willReturn(true);
 
-        GeneralException exception = assertThrows(GeneralException.class, () -> adminService.uploadRelationships(bookId, List.of(file)));
+        adminService.uploadRelationshipDeltas(bookId, List.of(file));
 
-        assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.RELATIONSHIP_DATA_ALREADY_EXISTS);
+        verify(eventRelationshipEdgeRepository, times(1)).deleteByEvent(event);
+        verify(eventRelationshipEdgeRepository, times(1)).saveAll(anyList());
     }
 
     @Test

--- a/src/test/java/com/kw/readwith/service/RelationshipDeltaServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/RelationshipDeltaServiceTest.java
@@ -1,0 +1,190 @@
+package com.kw.readwith.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Chapter;
+import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.Event;
+import com.kw.readwith.domain.enums.AnalysisStatus;
+import com.kw.readwith.domain.enums.NormalizationStatus;
+import com.kw.readwith.domain.mapping.EventCharacterStat;
+import com.kw.readwith.domain.mapping.EventRelationshipEdge;
+import com.kw.readwith.dto.relationship.RelationshipDeltaListResponseDTO;
+import com.kw.readwith.dto.relationship.RelationshipGraphResponseDTO;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.ChapterRepository;
+import com.kw.readwith.repository.EventCharacterStatRepository;
+import com.kw.readwith.repository.EventRelationshipEdgeRepository;
+import com.kw.readwith.repository.EventRepository;
+import com.kw.readwith.util.LocatorSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RelationshipDeltaServiceTest {
+
+    @Mock
+    private BookRepository bookRepository;
+    @Mock
+    private ChapterRepository chapterRepository;
+    @Mock
+    private EventRepository eventRepository;
+    @Mock
+    private EventRelationshipEdgeRepository eventRelationshipEdgeRepository;
+    @Mock
+    private EventCharacterStatRepository eventCharacterStatRepository;
+    @Mock
+    private BookAccessPolicy bookAccessPolicy;
+    @Mock
+    private LocatorSupport locatorSupport;
+
+    private RelationshipDeltaService relationshipDeltaService;
+
+    @BeforeEach
+    void setUp() {
+        relationshipDeltaService = new RelationshipDeltaService(
+                bookRepository,
+                chapterRepository,
+                eventRepository,
+                eventRelationshipEdgeRepository,
+                eventCharacterStatRepository,
+                new ObjectMapper(),
+                bookAccessPolicy,
+                locatorSupport
+        );
+    }
+
+    @Test
+    @DisplayName("raw delta query returns event delta payload shape")
+    void getRelationshipDeltasReturnsRawDeltaShape() {
+        Book book = sampleBook();
+        Chapter chapter = sampleChapter(book, 1);
+        Event event = sampleEvent(book, chapter, 1, "ch1-e1");
+        Character nick = sampleCharacter(book, 101L, 1L, "Nick");
+        Character gatsby = sampleCharacter(book, 102L, 2L, "Gatsby");
+        EventRelationshipEdge edge = sampleEdge(event, nick, gatsby, 0.8f, 2, "[\"trust\"]", "reason");
+        EventCharacterStat stat = sampleStat(event, nick, 0.5);
+
+        when(bookRepository.findById(10L)).thenReturn(Optional.of(book));
+        when(eventRepository.findByBookOrderByChapterIdxAscIdxAsc(book)).thenReturn(List.of(event));
+        when(eventRelationshipEdgeRepository.findByEventsOrdered(List.of(event))).thenReturn(List.of(edge));
+        when(eventCharacterStatRepository.findByEventsOrdered(List.of(event))).thenReturn(List.of(stat));
+
+        RelationshipDeltaListResponseDTO response = relationshipDeltaService.getRelationshipDeltas(
+                10L, null, "ch1-e1", null, null, 1L
+        );
+
+        assertThat(response.getDeltas()).hasSize(1);
+        assertThat(response.getDeltas().get(0).getContractVersion()).isEqualTo("relationship-delta-v1");
+        assertThat(response.getDeltas().get(0).getItems()).hasSize(1);
+        assertThat(response.getDeltas().get(0).getItems().get(0).getReason()).isEqualTo("reason");
+        assertThat(response.getDeltas().get(0).getNodeWeights()).containsKey("1");
+    }
+
+    @Test
+    @DisplayName("relationship graph folds deltas by event order")
+    void getRelationshipGraphFoldsDeltas() {
+        Book book = sampleBook();
+        Chapter chapter = sampleChapter(book, 1);
+        Event event1 = sampleEvent(book, chapter, 1, "ch1-e1");
+        Event event2 = sampleEvent(book, chapter, 2, "ch1-e2");
+        Character nick = sampleCharacter(book, 101L, 1L, "Nick");
+        Character gatsby = sampleCharacter(book, 102L, 2L, "Gatsby");
+        EventRelationshipEdge edge1 = sampleEdge(event1, nick, gatsby, 1.0f, 1, "[\"trust\"]", "first");
+        EventRelationshipEdge edge2 = sampleEdge(event2, gatsby, nick, -0.5f, 3, "[\"conflict\"]", "second");
+
+        when(bookRepository.findById(10L)).thenReturn(Optional.of(book));
+        when(eventRepository.findByBookOrderByChapterIdxAscIdxAsc(book)).thenReturn(List.of(event1, event2));
+        when(eventRelationshipEdgeRepository.findByEventsOrdered(List.of(event1, event2))).thenReturn(List.of(edge1, edge2));
+        when(eventCharacterStatRepository.findByEventsOrdered(List.of(event1, event2))).thenReturn(List.of());
+
+        RelationshipGraphResponseDTO response = relationshipDeltaService.getRelationshipGraph(
+                10L, "book", null, null, null, null, 1L
+        );
+
+        assertThat(response.getEdges()).hasSize(1);
+        assertThat(response.getEdges().get(0).getEvidenceCount()).isEqualTo(4);
+        assertThat(response.getEdges().get(0).getPositivity()).isEqualTo(-0.125);
+        assertThat(response.getEdges().get(0).getLatestReason()).isEqualTo("second");
+        assertThat(response.getEdges().get(0).getDirectionCounts()).containsEntry("1->2", 1);
+        assertThat(response.getEdges().get(0).getDirectionCounts()).containsEntry("2->1", 3);
+    }
+
+    private Book sampleBook() {
+        return Book.builder()
+                .id(10L)
+                .title("Book")
+                .normalizationStatus(NormalizationStatus.READY)
+                .analysisStatus(AnalysisStatus.READY)
+                .build();
+    }
+
+    private Chapter sampleChapter(Book book, int idx) {
+        return Chapter.builder()
+                .id((long) idx)
+                .book(book)
+                .idx(idx)
+                .build();
+    }
+
+    private Event sampleEvent(Book book, Chapter chapter, int idx, String eventId) {
+        return Event.builder()
+                .id((long) idx)
+                .book(book)
+                .chapter(chapter)
+                .idx(idx)
+                .eventId(eventId)
+                .startTxtOffset(idx * 10)
+                .endTxtOffset(idx * 10 + 5)
+                .rawText("event")
+                .build();
+    }
+
+    private Character sampleCharacter(Book book, Long id, Long characterId, String name) {
+        return Character.builder()
+                .id(id)
+                .characterId(characterId)
+                .book(book)
+                .name(name)
+                .isMainCharacter(true)
+                .build();
+    }
+
+    private EventRelationshipEdge sampleEdge(
+            Event event,
+            Character from,
+            Character to,
+            Float positivity,
+            Integer evidenceCount,
+            String labelsJson,
+            String reason
+    ) {
+        return EventRelationshipEdge.builder()
+                .event(event)
+                .fromCharacter(from)
+                .toCharacter(to)
+                .sentimentScore(positivity)
+                .interactionCount(evidenceCount)
+                .relationTags(labelsJson)
+                .explanation(reason)
+                .build();
+    }
+
+    private EventCharacterStat sampleStat(Event event, Character character, double weight) {
+        return EventCharacterStat.builder()
+                .event(event)
+                .character(character)
+                .nodeWeight(weight)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
relationship-delta-v1 계약에 맞춰 기존 관계 업로드 흐름을 delta 기반으로 전환하고, raw delta 조회 API와 fold graph 조회 API를 추가했습니다.

## 📋 변경 사항
- 기존 `/api/v2/admin/books/{bookId}/relationships` 업로드 API 비활성화
- 신규 `POST /api/v2/admin/books/{bookId}/relationship-deltas` 추가
- relationship delta 업로드 시 `contractVersion=relationship-delta-v1` 검증
- 동일 event에 기존 관계 데이터가 있으면 삭제 후 새 delta 저장, 없으면 신규 저장
- `reason`을 `EventRelationshipEdge.explanation`에 저장
- `nodeWeights.weight`만 저장하고 `nodeWeights.count`는 저장하지 않음
- `GET /api/v2/books/{bookId}/relationship-deltas` raw delta 조회 API 추가
- `GET /api/v2/books/{bookId}/relationship-graph` 누적 fold graph 조회 API 추가
- event order 기준으로 evidenceCount, positivity, labels, latestReason, directionCounts fold 처리
- 업로드 replace 정책 및 delta fold 테스트 추가

## 🔍 Code Review
- 기존 snapshot 전제의 `/relationships` 업로드가 더 이상 사용되지 않도록 비활성화 처리했습니다.
- graph 조회는 별도 `RelationshipDeltaService`에서 delta 원본을 읽어 서비스단에서 조립합니다.
- `nodeWeights.count`는 AI 디버깅용 값이라 저장하지 않는 정책을 반영했습니다.
- 확인한 테스트:
  - `./gradlew.bat test --tests com.kw.readwith.service.AdminServiceTest --tests com.kw.readwith.service.RelationshipDeltaServiceTest` 통과
- 전체 `./gradlew.bat test`는 기존 통합 테스트 DB schema validate 및 기존 NormalizationJobServiceTest 기대값 이슈로 실패했습니다.

## 📸 ScreenShot
없음