### PR TITLE
feat: 실패한 정규화(Normalization) 작업 재시도 API 구현

### DIFF
--- a/src/main/java/com/kw/readwith/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/kw/readwith/apiPayload/exception/GeneralException.java
@@ -11,11 +11,13 @@ public class GeneralException extends RuntimeException {
     private final String overrideMessage;
 
     public GeneralException(BaseErrorCode code) {
+        super(code.getReason().getMessage());
         this.code = code;
         this.overrideMessage = null;
     }
 
     public GeneralException(BaseErrorCode code, String overrideMessage) {
+        super(overrideMessage);
         this.code = code;
         this.overrideMessage = overrideMessage;
     }

--- a/src/main/java/com/kw/readwith/service/normalization/NormalizationJobService.java
+++ b/src/main/java/com/kw/readwith/service/normalization/NormalizationJobService.java
@@ -99,6 +99,42 @@ public class NormalizationJobService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * 실패한 정규화 작업을 재시도하기 위해 새로운 작업을 생성하고 대기열(QUEUE)에 추가합니다.
+     *
+     * @param failedJobId 재시도할 원본(실패한) 작업의 ID
+     * @return 새로 생성되어 대기열에 추가된 작업의 정보
+     */
+    @Transactional
+    public NormalizationJobResponseDTO retryFailedJob(Long failedJobId) {
+        // 1. 요청받은 ID로 실패한 작업을 데이터베이스에서 조회합니다.
+        ProcessingJob failedJob = processingJobRepository.findById(failedJobId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._BAD_REQUEST, "Failed job not found."));
+
+        // 2. 해당 작업이 실제로 '실패(FAILED)' 상태인지 확인합니다. 실패하지 않은 작업은 재시도할 수 없습니다.
+        if (failedJob.getStatus() != ProcessingJobStatus.FAILED) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "Job did not fail. Cannot retry.");
+        }
+
+        // 3. 해당 작업이 '정규화(NORMALIZATION)' 파이프라인인지 확인합니다.
+        if (failedJob.getPipelineType() != ProcessingPipelineType.NORMALIZATION) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "Job is not a normalization job.");
+        }
+
+        // 4. 실패한 작업의 도서 정보와 소스 버전 정보를 가져옵니다.
+        Book book = failedJob.getBook();
+        String sourceVersion = failedJob.getSourceVersion();
+        
+        // 5. 실패한 기존 작업의 triggeredBy 값을 그대로 사용합니다.
+        String triggeredBy = failedJob.getTriggeredBy();
+
+        // 6. 이전 작업과 동일한 조건으로 새로운 작업을 생성하여 대기열에 넣습니다.
+        ProcessingJob newJob = createQueuedJob(book, sourceVersion, triggeredBy);
+
+        // 7. 새로 생성된 작업 정보를 DTO로 변환하여 반환합니다.
+        return mapToResponseDTO(newJob);
+    }
+
     private NormalizationJobResponseDTO mapToResponseDTO(ProcessingJob job) {
         return NormalizationJobResponseDTO.builder()
                 .id(job.getId())

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -12,6 +12,7 @@ import com.kw.readwith.dto.admin.NormalizationJobResponseDTO;
 import com.kw.readwith.dto.admin.ProcessingJobLogResponseDTO;
 import com.kw.readwith.service.AdminService;
 import com.kw.readwith.service.AnalysisInputExportService;
+import com.kw.readwith.service.normalization.NormalizationJobDispatcher;
 import com.kw.readwith.service.normalization.NormalizationJobService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -38,6 +39,7 @@ public class AdminController {
     private final AdminService adminService;
     private final AnalysisInputExportService analysisInputExportService;
     private final NormalizationJobService normalizationJobService;
+    private final NormalizationJobDispatcher normalizationJobDispatcher;
 
     @Operation(summary = "모든 도서 전체 정보 조회", description = "book 테이블의 모든 행들의 모든 칼럼값들을 조회합니다. (관리자용)")
     @GetMapping("/books")
@@ -50,6 +52,23 @@ public class AdminController {
     @GetMapping("/normalization/jobs/latest")
     public ApiResponse<List<NormalizationJobResponseDTO>> getRecentNormalizationJobs() {
         List<NormalizationJobResponseDTO> response = normalizationJobService.getRecentNormalizationJobs();
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(
+            summary = "실패한 정규화 Job 재시도",
+            description = "ID를 이용해 실패한 정규화 작업을 찾아, 동일한 설정으로 새로운 작업을 생성하여 재시도합니다."
+    )
+    @PostMapping("/normalization/jobs/{jobId}/retry")
+    public ApiResponse<NormalizationJobResponseDTO> retryNormalizationJob(
+            @Parameter(description = "재시도할 정규화 Job ID", required = true) @PathVariable Long jobId) {
+        
+        NormalizationJobResponseDTO response = normalizationJobService.retryFailedJob(jobId);
+        
+        // 새로운 작업이 생성되고 트랜잭션이 커밋된 후(Controller 레이어),
+        // 해당 작업을 처리할 Dispatcher를 호출하여 비동기로 실행되게 합니다.
+        normalizationJobDispatcher.dispatch(response.getId());
+
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/test/java/com/kw/readwith/service/normalization/NormalizationJobServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/normalization/NormalizationJobServiceTest.java
@@ -1,6 +1,7 @@
 package com.kw.readwith.service.normalization;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.config.EpubNormalizationProperties;
 import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Chapter;
@@ -15,6 +16,7 @@ import com.kw.readwith.repository.ProcessingJobLogRepository;
 import com.kw.readwith.repository.ProcessingJobRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -27,6 +29,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -81,6 +84,106 @@ public class NormalizationJobServiceTest {
                 transactionManager
         );
     }
+
+    @Nested
+    @DisplayName("retryFailedJob 메서드")
+    class RetryFailedJobTest {
+
+        private Book book;
+        private ProcessingJob failedJob;
+
+        @BeforeEach
+        void setup() {
+            book = Book.builder().title("Test Book").build();
+            ReflectionTestUtils.setField(book, "id", 1L);
+
+            failedJob = ProcessingJob.builder()
+                    .id(100L)
+                    .book(book)
+                    .pipelineType(ProcessingPipelineType.NORMALIZATION)
+                    .status(ProcessingJobStatus.FAILED)
+                    .sourceVersion("source-v1")
+                    .triggeredBy("UPLOAD")
+                    .build();
+        }
+
+        @Test
+        @DisplayName("실패한 정규화 작업을 재시도하면, 새로운 작업이 QUEUED 상태로 생성된다")
+        void retryFailedNormalizationJob_shouldCreateNewQueuedJob() {
+            // given
+            when(processingJobRepository.findById(100L)).thenReturn(Optional.of(failedJob));
+            when(normalizedArtifactStorageService.newNormalizationRunId()).thenReturn("new-run-id");
+            when(processingJobRepository.save(any(ProcessingJob.class))).thenAnswer(invocation -> {
+                ProcessingJob newJob = invocation.getArgument(0);
+                ReflectionTestUtils.setField(newJob, "id", 101L);
+                return newJob;
+            });
+
+            // when
+            var response = normalizationJobService.retryFailedJob(100L);
+
+            // then
+            assertThat(response.getId()).isEqualTo(101L);
+            assertThat(response.getStatus()).isEqualTo(ProcessingJobStatus.QUEUED);
+            assertThat(response.getSourceVersion()).isEqualTo("source-v1");
+            assertThat(response.getTriggeredBy()).isEqualTo("UPLOAD");
+            assertThat(response.getRunId()).isEqualTo("new-run-id");
+
+            ArgumentCaptor<ProcessingJob> jobCaptor = ArgumentCaptor.forClass(ProcessingJob.class);
+            verify(processingJobRepository).save(jobCaptor.capture());
+            ProcessingJob savedJob = jobCaptor.getValue();
+
+            assertThat(savedJob.getStatus()).isEqualTo(ProcessingJobStatus.QUEUED);
+            assertThat(savedJob.getTriggeredBy()).isEqualTo("UPLOAD");
+        }
+
+        @Test
+        @DisplayName("작업 상태가 FAILED가 아니면 예외를 발생시킨다")
+        void retryNonFailedJob_shouldThrowException() {
+            // given
+            failedJob.markReady("some-path", "completed"); // 상태를 FAILED가 아닌 것으로 변경
+            when(processingJobRepository.findById(100L)).thenReturn(Optional.of(failedJob));
+
+            // when & then
+            assertThatThrownBy(() -> normalizationJobService.retryFailedJob(100L))
+                    .isInstanceOf(GeneralException.class)
+                    .hasMessageContaining("Job did not fail. Cannot retry.");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 작업 ID이면 예외를 발생시킨다")
+        void retryNonExistentJob_shouldThrowException() {
+            // given
+            when(processingJobRepository.findById(999L)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> normalizationJobService.retryFailedJob(999L))
+                    .isInstanceOf(GeneralException.class)
+
+                    .hasMessageContaining("Failed job not found.");
+        }
+
+        @Test
+        @DisplayName("작업 타입이 NORMALIZATION이 아니면 예외를 발생시킨다")
+        void retryNonNormalizationJob_shouldThrowException() {
+            // given
+            failedJob = ProcessingJob.builder()
+                    .id(100L)
+                    .book(book)
+                    .pipelineType(ProcessingPipelineType.AI_ANALYSIS) // 다른 타입으로 설정
+                    .status(ProcessingJobStatus.FAILED)
+                    .sourceVersion("source-v1")
+                    .triggeredBy("UPLOAD")
+                    .build();
+            when(processingJobRepository.findById(100L)).thenReturn(Optional.of(failedJob));
+
+            // when & then
+            assertThatThrownBy(() -> normalizationJobService.retryFailedJob(100L))
+                    .isInstanceOf(GeneralException.class)
+                    .hasMessageContaining("Job is not a normalization job.");
+        }
+    }
+
 
     @Test
     @DisplayName("createQueuedJob uses the caller transaction for upload flow")
@@ -178,7 +281,7 @@ public class NormalizationJobServiceTest {
                 .book(book)
                 .pipelineType(ProcessingPipelineType.NORMALIZATION)
                 .runId("run-123")
-                .sourceVersion("src-v2")
+                .sourceVersion("src-v1")
                 .artifactPath("path/to/artifact")
                 .status(ProcessingJobStatus.READY)
                 .currentStep("completed")


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
기존의 실패 이력을 데이터베이스에 보존하여 추후 장애 분석에 활용하는 동시에, 동일한 조건으로 작업을 다시 큐(Queue)에 넣어 원활한 운영을 돕기 위해 재시도 API를 구현

## 📋 변경 사항
- 실패한 작업의 ID를 받아 재시도를 요청
- 실패한 작업의 상태를 검증하고, 기존 작업과 동일한 설정(소스 버전, triggeredBy 등)으로 새로운 작업을 생성하여 대기열에 추가
- 실패한 기존 작업 기록은 장애 분석을 위해 DB에 그대로 유지

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
