### PR TITLE
Feat: 캐릭터 이미지 생성을 gpt-image-1 기반으로 전환

### DIFF
--- a/src/main/java/com/kw/readwith/config/CharacterImageProperties.java
+++ b/src/main/java/com/kw/readwith/config/CharacterImageProperties.java
@@ -14,13 +14,20 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "character-image")
 public class CharacterImageProperties {
 
+    private String model = "gpt-image-1";
+    private String quality = "medium";
+    private int width = 1024;
+    private int height = 1024;
+    private int count = 1;
+    private String responseFormat;
+
     /**
      * 이미지 생성 실패 시 사용할 기본 이미지 URL
      */
     private String fallbackUrl;
 
     /**
-     * DALL-E 프롬프트에 공통적으로 적용할 아트 스타일
+     * OpenAI 이미지 프롬프트에 공통적으로 적용할 아트 스타일
      */
     private String baseStylePrompt;
 

--- a/src/main/java/com/kw/readwith/domain/enums/ImageGenerationStatus.java
+++ b/src/main/java/com/kw/readwith/domain/enums/ImageGenerationStatus.java
@@ -10,7 +10,7 @@ public enum ImageGenerationStatus {
     PENDING,
     
     /**
-     * 이미지 생성 중 (DALL-E API 호출 중)
+     * 이미지 생성 중 (OpenAI 이미지 API 호출 중)
      */
     GENERATING,
     

--- a/src/main/java/com/kw/readwith/service/CharacterImageService.java
+++ b/src/main/java/com/kw/readwith/service/CharacterImageService.java
@@ -8,6 +8,7 @@ import com.kw.readwith.domain.enums.ImageGenerationStatus;
 import com.kw.readwith.repository.CharacterRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.image.Image;
 import org.springframework.ai.image.ImagePrompt;
 import org.springframework.ai.image.ImageResponse;
 import org.springframework.ai.openai.OpenAiImageModel;
@@ -142,24 +143,15 @@ public class CharacterImageService {
             Character character = getCharacterReadOnly(characterId);
             transactionService.updateStatus(characterId, ImageGenerationStatus.GENERATING);
 
-            String prompt = buildDallePrompt(character);
+            String prompt = buildImagePrompt(character);
             log.debug("Generated image prompt for characterId={}: {}", characterId, prompt);
 
             ImageResponse response = imageModel.call(
-                    new ImagePrompt(
-                            prompt,
-                            OpenAiImageOptions.builder()
-                                    .withModel("dall-e-3")
-                                    .withQuality("standard")
-                                    .withN(1)
-                                    .withHeight(1024)
-                                    .withWidth(1024)
-                                    .build()
-                    )
+                    new ImagePrompt(prompt, buildImageOptions())
             );
 
-            String dalleImageUrl = response.getResult().getOutput().getUrl();
-            byte[] imageData = downloadImageFromUrl(dalleImageUrl);
+            Image generatedImage = response.getResult().getOutput();
+            byte[] imageData = resolveGeneratedImageData(generatedImage);
             String base64Image = Base64.getEncoder().encodeToString(imageData);
 
             String s3KeyName = buildS3KeyName(character);
@@ -185,7 +177,37 @@ public class CharacterImageService {
         transactionService.updateImageAndStatus(characterId, s3Url, ImageGenerationStatus.COMPLETED);
     }
 
-    private String buildDallePrompt(Character character) {
+    private OpenAiImageOptions buildImageOptions() {
+        OpenAiImageOptions.Builder builder = OpenAiImageOptions.builder()
+                .withModel(resolveImageModel())
+                .withQuality(resolveImageQuality())
+                .withN(positiveOrDefault(imageProperties.getCount(), 1))
+                .withHeight(positiveOrDefault(imageProperties.getHeight(), 1024))
+                .withWidth(positiveOrDefault(imageProperties.getWidth(), 1024));
+
+        String responseFormat = normalizePromptSegment(imageProperties.getResponseFormat());
+        if (responseFormat != null) {
+            builder.withResponseFormat(responseFormat);
+        }
+
+        return builder.build();
+    }
+
+    private String resolveImageModel() {
+        String configured = normalizePromptSegment(imageProperties.getModel());
+        return configured != null ? configured : "gpt-image-1";
+    }
+
+    private String resolveImageQuality() {
+        String configured = normalizePromptSegment(imageProperties.getQuality());
+        return configured != null ? configured : "medium";
+    }
+
+    private int positiveOrDefault(int value, int defaultValue) {
+        return value > 0 ? value : defaultValue;
+    }
+
+    private String buildImagePrompt(Character character) {
         StringBuilder prompt = new StringBuilder();
 
         appendPromptSegment(prompt, resolveBaseStylePrompt());
@@ -262,6 +284,32 @@ public class CharacterImageService {
             prompt.append(", ");
         }
         prompt.append(segment);
+    }
+
+    private byte[] resolveGeneratedImageData(Image image) throws IOException {
+        if (image == null) {
+            throw new IOException("Generated image response is empty.");
+        }
+
+        String b64Json = normalizePromptSegment(image.getB64Json());
+        if (b64Json != null) {
+            try {
+                byte[] imageData = Base64.getDecoder().decode(b64Json.replaceAll("\\s+", ""));
+                if (imageData.length == 0) {
+                    throw new IOException("Generated image base64 payload is empty.");
+                }
+                return imageData;
+            } catch (IllegalArgumentException e) {
+                throw new IOException("Generated image base64 payload is invalid.", e);
+            }
+        }
+
+        String imageUrl = normalizePromptSegment(image.getUrl());
+        if (imageUrl != null) {
+            return downloadImageFromUrl(imageUrl);
+        }
+
+        throw new IOException("Generated image response has neither base64 data nor URL.");
     }
 
     private byte[] downloadImageFromUrl(String imageUrl) throws IOException {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,10 +63,10 @@ spring:
       api-key: ${OPENAI_API_KEY}
       image:
         options:
-          model: dall-e-3
-          size: 1024x1024
-          quality: standard
-          n: 1
+          model: ${CHARACTER_IMAGE_MODEL:gpt-image-1}
+          size: ${CHARACTER_IMAGE_SIZE:1024x1024}
+          quality: ${CHARACTER_IMAGE_QUALITY:medium}
+          n: ${CHARACTER_IMAGE_COUNT:1}
 
 epub:
   normalization:
@@ -118,6 +118,12 @@ cloud:
 # 캐릭터 이미지 생성 설정
 character-image:
   fallback-url: https://readwith-s3-bucket.s3.ap-northeast-2.amazonaws.com/character-images/default-character.jpg
+  model: ${CHARACTER_IMAGE_MODEL:gpt-image-1}
+  quality: ${CHARACTER_IMAGE_QUALITY:medium}
+  width: ${CHARACTER_IMAGE_WIDTH:1024}
+  height: ${CHARACTER_IMAGE_HEIGHT:1024}
+  count: ${CHARACTER_IMAGE_COUNT:1}
+  response-format: ${CHARACTER_IMAGE_RESPONSE_FORMAT:}
   base-style-prompt: ${CHARACTER_IMAGE_BASE_STYLE_PROMPT:A single centered chest-up character portrait in a mature editorial gouache illustration style, flat matte gouache rendering, clean silhouette, minimal linework, soft paper texture, plain muted background, low-saturation palette, restrained literary mood, natural facial proportions, not cartoonish, not anime, not painterly, not photorealistic}
 
   # 극강 통제 프롬프트 (얼굴만 나오도록)
@@ -196,7 +202,7 @@ character-image:
     ❌ 3D rendering appearance
     ❌ Busy or cluttered backgrounds
 
-    REMEMBER: This is a SIMPLE HEAD PORTRAIT ONLY. The person's face is THE ONLY element. Everything else must be plain beige paper. If DALL-E tries to add ANY decoration, pattern, symbol, or ornament - REJECT and keep background COMPLETELY PLAIN."
+    REMEMBER: This is a SIMPLE HEAD PORTRAIT ONLY. The person's face is THE ONLY element. Everything else must be plain beige paper. If the image model tries to add ANY decoration, pattern, symbol, or ornament - REJECT and keep background COMPLETELY PLAIN."
 
   s3-path: character-images
 

--- a/src/test/java/com/kw/readwith/service/CharacterImageServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/CharacterImageServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,12 +18,15 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.ai.image.Image;
 import org.springframework.ai.image.ImageGeneration;
+import org.springframework.ai.image.ImagePrompt;
 import org.springframework.ai.image.ImageResponse;
 import org.springframework.ai.openai.OpenAiImageModel;
+import org.springframework.ai.openai.OpenAiImageOptions;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 
@@ -81,6 +85,12 @@ class CharacterImageServiceTest {
                 .build();
 
         when(imageProperties.getFallbackUrl()).thenReturn("https://cdn.readwith.store/character/default.png");
+        when(imageProperties.getModel()).thenReturn("gpt-image-1");
+        when(imageProperties.getQuality()).thenReturn("medium");
+        when(imageProperties.getWidth()).thenReturn(1024);
+        when(imageProperties.getHeight()).thenReturn(1024);
+        when(imageProperties.getCount()).thenReturn(1);
+        when(imageProperties.getResponseFormat()).thenReturn("");
         when(imageProperties.getBaseStylePrompt()).thenReturn("Configured editorial gouache base style");
         when(imageProperties.getS3Path()).thenReturn("character-images");
         when(imageProperties.getBatchSize()).thenReturn(10);
@@ -88,9 +98,9 @@ class CharacterImageServiceTest {
     }
 
     @Test
-    @DisplayName("buildDallePrompt uses configured base style prompt and composes the remaining sections")
-    void buildDallePrompt_composesStructuredPrompt() {
-        String prompt = (String) ReflectionTestUtils.invokeMethod(characterImageService, "buildDallePrompt", testCharacter);
+    @DisplayName("buildImagePrompt uses configured base style prompt and composes the remaining sections")
+    void buildImagePrompt_composesStructuredPrompt() {
+        String prompt = (String) ReflectionTestUtils.invokeMethod(characterImageService, "buildImagePrompt", testCharacter);
 
         assertThat(prompt).contains("Configured editorial gouache base style");
         assertThat(prompt).contains("exactly one character, single centered chest-up bust portrait");
@@ -102,19 +112,19 @@ class CharacterImageServiceTest {
     }
 
     @Test
-    @DisplayName("buildDallePrompt falls back to default base style prompt when configuration is missing")
-    void buildDallePrompt_fallsBackToDefaultBaseStylePrompt() {
+    @DisplayName("buildImagePrompt falls back to default base style prompt when configuration is missing")
+    void buildImagePrompt_fallsBackToDefaultBaseStylePrompt() {
         when(imageProperties.getBaseStylePrompt()).thenReturn(null);
 
-        String prompt = (String) ReflectionTestUtils.invokeMethod(characterImageService, "buildDallePrompt", testCharacter);
+        String prompt = (String) ReflectionTestUtils.invokeMethod(characterImageService, "buildImagePrompt", testCharacter);
 
         assertThat(prompt).contains("A single centered chest-up character portrait in a mature editorial gouache illustration style");
         assertThat(prompt).contains("flat matte gouache rendering");
     }
 
     @Test
-    @DisplayName("buildDallePrompt removes multi-subject and scene-driving prompt segments")
-    void buildDallePrompt_sanitizesRiskyPromptSegments() {
+    @DisplayName("buildImagePrompt removes multi-subject and scene-driving prompt segments")
+    void buildImagePrompt_sanitizesRiskyPromptSegments() {
         Book riskyBook = Book.builder()
                 .id(2L)
                 .title("Risky Book")
@@ -133,7 +143,7 @@ class CharacterImageServiceTest {
                 .imageGenerationStatus(ImageGenerationStatus.PENDING)
                 .build();
 
-        String prompt = (String) ReflectionTestUtils.invokeMethod(characterImageService, "buildDallePrompt", riskyCharacter);
+        String prompt = (String) ReflectionTestUtils.invokeMethod(characterImageService, "buildImagePrompt", riskyCharacter);
 
         assertThat(prompt).contains("Victorian urban gothic");
         assertThat(prompt).contains("muted sepia palette");
@@ -165,7 +175,48 @@ class CharacterImageServiceTest {
         characterImageService.generateAndSaveImage(testCharacter.getId());
 
         verify(transactionService).updateStatus(testCharacter.getId(), ImageGenerationStatus.GENERATING);
+        ArgumentCaptor<ImagePrompt> imagePromptCaptor = ArgumentCaptor.forClass(ImagePrompt.class);
+        verify(imageModel).call(imagePromptCaptor.capture());
+        OpenAiImageOptions imageOptions = (OpenAiImageOptions) imagePromptCaptor.getValue().getOptions();
+        assertThat(imageOptions.getModel()).isEqualTo("gpt-image-1");
+        assertThat(imageOptions.getQuality()).isEqualTo("medium");
+        assertThat(imageOptions.getWidth()).isEqualTo(1024);
+        assertThat(imageOptions.getHeight()).isEqualTo(1024);
+        assertThat(imageOptions.getN()).isEqualTo(1);
         verify(s3Manager).uploadFileFromBase64(eq("character-images/1/10.png"), anyString(), eq("image/png"));
+        verify(transactionService).updateImageAndStatus(
+                testCharacter.getId(),
+                "https://cdn.readwith.store/character-images/1/10.png",
+                ImageGenerationStatus.COMPLETED
+        );
+    }
+
+    @Test
+    @DisplayName("generateAndSaveImage uploads gpt-image-1 base64 response")
+    void generateAndSaveImage_uploadsBase64JsonResponse() {
+        byte[] generatedImage = new byte[]{9, 8, 7, 6};
+
+        when(characterRepository.findByIdWithBook(testCharacter.getId())).thenReturn(Optional.of(testCharacter));
+        when(s3Manager.uploadFileFromBase64(anyString(), anyString(), eq("image/png")))
+                .thenReturn("https://cdn.readwith.store/character-images/1/10.png");
+
+        ImageResponse imageResponse = mock(ImageResponse.class);
+        ImageGeneration generation = mock(ImageGeneration.class);
+        Image image = mock(Image.class);
+        when(imageModel.call(any())).thenReturn(imageResponse);
+        when(imageResponse.getResult()).thenReturn(generation);
+        when(generation.getOutput()).thenReturn(image);
+        when(image.getB64Json()).thenReturn(Base64.getEncoder().encodeToString(generatedImage));
+
+        characterImageService.generateAndSaveImage(testCharacter.getId());
+
+        ArgumentCaptor<String> base64Captor = ArgumentCaptor.forClass(String.class);
+        verify(s3Manager).uploadFileFromBase64(
+                eq("character-images/1/10.png"),
+                base64Captor.capture(),
+                eq("image/png")
+        );
+        assertThat(Base64.getDecoder().decode(base64Captor.getValue())).containsExactly(generatedImage);
         verify(transactionService).updateImageAndStatus(
                 testCharacter.getId(),
                 "https://cdn.readwith.store/character-images/1/10.png",


### PR DESCRIPTION
## 📌 PR 작업 내역 요약
캐릭터 이미지 생성 기본 모델을 `gpt-image-1`로 전환했습니다.

기존 코드는 이미지 생성 옵션이 `dall-e-3`, `standard`, `1024x1024`, `n=1`로 하드코딩되어 있었고, 생성 결과도 URL 응답만 처리했습니다. 이번 PR에서는 모델/품질/크기/개수/응답 포맷을 설정값으로 분리하고, `gpt-image-1`에서 주로 내려오는 `b64_json` 응답과 기존 URL 응답을 모두 처리하도록 변경했습니다.

Closes #125

## ✨ 변경 사항
- 캐릭터 이미지 생성 기본 모델을 `gpt-image-1`로 변경
- `CHARACTER_IMAGE_MODEL`, `CHARACTER_IMAGE_QUALITY`, `CHARACTER_IMAGE_WIDTH`, `CHARACTER_IMAGE_HEIGHT`, `CHARACTER_IMAGE_COUNT`, `CHARACTER_IMAGE_RESPONSE_FORMAT` 설정 추가
- Spring AI 이미지 요청 옵션을 코드 고정값이 아니라 `CharacterImageProperties` 기반으로 생성하도록 변경
- OpenAI 이미지 응답 처리 시 `b64_json`이 있으면 base64 디코딩 후 S3 업로드하고, 없으면 기존 URL 다운로드 방식으로 fallback
- DALL-E 전용 네이밍/문구를 일반 이미지 생성 표현으로 정리
- 이미지 생성 단위 테스트에 요청 옵션 검증과 `gpt-image-1` base64 응답 처리 케이스 추가

## 🧑‍💻 Code Review
- Spring AI 의존성 버전은 이번 단기 수정 범위에서 올리지 않았습니다. 현재 사용 중인 래퍼가 이미지 모델명을 문자열로 전달할 수 있고 `b64_json`도 노출하고 있어, `gpt-image-1` 전환 자체는 버전업 없이 처리 가능했습니다.
- Spring AI/Spring Boot 버전업은 호환성 영향 범위가 커서 별도 이슈로 분리하는 것이 안전합니다.
- 전체 테스트는 기존 DB 스키마/기존 테스트 기대값 문제로 실패합니다. 이번 변경과 직접 관련된 `CharacterImageServiceTest`는 통과했습니다.

테스트 결과:
- [x] `$env:JAVA_HOME='C:\Program Files\Java\jdk-17'; .\gradlew.bat test --tests com.kw.readwith.service.CharacterImageServiceTest`
- [x] `$env:JAVA_HOME='C:\Program Files\Java\jdk-17'; .\gradlew.bat test`
  - 기존 context 테스트 실패: `book.book_prompt`는 `VARCHAR`, Hibernate 기대값은 `TEXT/CLOB`
  - 기존 `NormalizationJobServiceTest.getLatestNormalizationJobReturnsLatestJob` 실패: expected `src-v1`, actual `src-v2`

## 📸 ScreenShot
없음. 백엔드 이미지 생성 로직 및 설정 변경입니다.