### PR TITLE
Feat: 관리자 승인형 Reference Image QA Gate 이미지 생성 파이프라인

### DIFF
--- a/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/kw/readwith/apiPayload/code/status/ErrorStatus.java
@@ -55,6 +55,15 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_FILE_NAME_FORMAT(HttpStatus.BAD_REQUEST, "ADMIN4016", "잘못된 형식의 파일 이름입니다. 'chapter<숫자>_perspective_summaries.json' 형식을 따라야 합니다."),
     NODE_WEIGHT_ALREADY_EXISTS(HttpStatus.CONFLICT, "ADMIN4018", "해당 이벤트의 캐릭터 가중치 데이터가 이미 존재합니다."),
 
+    IMAGE_ASSET_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN4020", "해당 캐릭터 이미지 후보를 찾을 수 없습니다."),
+    IMAGE_ASSET_NOT_BELONG_TO_BOOK(HttpStatus.BAD_REQUEST, "ADMIN4021", "해당 이미지 후보가 요청한 책에 속하지 않습니다."),
+    IMAGE_ASSET_INVALID_STATUS(HttpStatus.BAD_REQUEST, "ADMIN4022", "현재 상태에서는 이미지 후보 작업을 수행할 수 없습니다."),
+    IMAGE_REFERENCE_NOT_APPROVED(HttpStatus.BAD_REQUEST, "ADMIN4023", "승인된 대표 이미지가 없어 fan-out 생성을 시작할 수 없습니다."),
+    INVALID_IMAGE_FANOUT_SCOPE(HttpStatus.BAD_REQUEST, "ADMIN4024", "잘못된 이미지 fan-out scope 값입니다. 허용값: MAIN_ONLY, GRAPH_VISIBLE, SELECTED, STALE_ONLY, FAILED_ONLY, ALL"),
+    INVALID_IMAGE_PUBLISH_POLICY(HttpStatus.BAD_REQUEST, "ADMIN4025", "잘못된 이미지 게시 정책입니다. 허용값: AUTO_AFTER_QA, MANUAL"),
+    IMAGE_REFERENCE_CHARACTER_REQUIRED(HttpStatus.BAD_REQUEST, "ADMIN4026", "대표 이미지 후보로 사용할 인물을 찾을 수 없습니다."),
+    IMAGE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ADMIN5020", "캐릭터 이미지 생성에 실패했습니다."),
+
     // Bookmark
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOKMARK4001", "해당 북마크를 찾을 수 없습니다."),
     BOOKMARK_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "BOOKMARK4002", "동일한 위치에 이미 북마크가 존재합니다."),

--- a/src/main/java/com/kw/readwith/config/CharacterImageProperties.java
+++ b/src/main/java/com/kw/readwith/config/CharacterImageProperties.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class CharacterImageProperties {
 
     private String model = "gpt-image-1";
+    private String editModel = "gpt-image-1";
     private String quality = "medium";
     private int width = 1024;
     private int height = 1024;

--- a/src/main/java/com/kw/readwith/domain/Book.java
+++ b/src/main/java/com/kw/readwith/domain/Book.java
@@ -45,7 +45,6 @@ public class Book extends BaseEntity {
     @Column(name = "summary_url", length = 255)
     private String summaryUrl;
 
-    @Lob
     @Column(name = "book_prompt", columnDefinition = "TEXT")
     private String bookPrompt;
 

--- a/src/main/java/com/kw/readwith/domain/BookCharacterImageProfile.java
+++ b/src/main/java/com/kw/readwith/domain/BookCharacterImageProfile.java
@@ -1,0 +1,106 @@
+package com.kw.readwith.domain;
+
+import com.kw.readwith.domain.common.BaseEntity;
+import com.kw.readwith.domain.enums.BookImageReferenceStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "book_character_image_profile")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class BookCharacterImageProfile extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "active_reference_asset_id")
+    private CharacterImageAsset activeReferenceAsset;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reference_character_id")
+    private Character referenceCharacter;
+
+    @Column(name = "reference_version", nullable = false)
+    @Builder.Default
+    private int referenceVersion = 0;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reference_status", length = 30, nullable = false)
+    @Builder.Default
+    private BookImageReferenceStatus referenceStatus = BookImageReferenceStatus.NONE;
+
+    @Column(length = 80)
+    private String model;
+
+    @Column(name = "base_style_prompt_hash", length = 64)
+    private String baseStylePromptHash;
+
+    @Column(name = "book_prompt_hash", length = 64)
+    private String bookPromptHash;
+
+    @Column(name = "approved_at")
+    private LocalDateTime approvedAt;
+
+    @Column(name = "approved_by", length = 120)
+    private String approvedBy;
+
+    public void markCandidateGenerating(Character referenceCharacter, String model,
+                                        String baseStylePromptHash, String bookPromptHash) {
+        this.referenceCharacter = referenceCharacter;
+        this.referenceStatus = BookImageReferenceStatus.CANDIDATE_GENERATING;
+        this.model = model;
+        this.baseStylePromptHash = baseStylePromptHash;
+        this.bookPromptHash = bookPromptHash;
+    }
+
+    public void markQaPassed(CharacterImageAsset candidate) {
+        this.activeReferenceAsset = candidate;
+        this.referenceCharacter = candidate.getCharacter();
+        this.referenceStatus = BookImageReferenceStatus.QA_PASSED;
+    }
+
+    public void markQaFailed(Character referenceCharacter) {
+        this.referenceCharacter = referenceCharacter;
+        this.referenceStatus = BookImageReferenceStatus.QA_FAILED;
+    }
+
+    public void approve(CharacterImageAsset candidate, String approvedBy) {
+        this.activeReferenceAsset = candidate;
+        this.referenceCharacter = candidate.getCharacter();
+        this.referenceVersion += 1;
+        this.referenceStatus = BookImageReferenceStatus.APPROVED;
+        this.model = candidate.getModel();
+        this.approvedAt = LocalDateTime.now();
+        this.approvedBy = approvedBy;
+    }
+
+    public void reject() {
+        this.referenceStatus = BookImageReferenceStatus.REJECTED;
+    }
+}

--- a/src/main/java/com/kw/readwith/domain/CharacterImageAsset.java
+++ b/src/main/java/com/kw/readwith/domain/CharacterImageAsset.java
@@ -1,0 +1,138 @@
+package com.kw.readwith.domain;
+
+import com.kw.readwith.domain.common.BaseEntity;
+import com.kw.readwith.domain.enums.CharacterImageAssetRole;
+import com.kw.readwith.domain.enums.CharacterImageAssetStatus;
+import com.kw.readwith.domain.enums.CharacterImageGenerationMode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "character_image_asset")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CharacterImageAsset extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "character_id", nullable = false)
+    private Character character;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "asset_role", length = 30, nullable = false)
+    private CharacterImageAssetRole assetRole;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "generation_mode", length = 30, nullable = false)
+    private CharacterImageGenerationMode generationMode;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_reference_asset_id")
+    private CharacterImageAsset sourceReferenceAsset;
+
+    @Column(name = "reference_version", nullable = false)
+    @Builder.Default
+    private int referenceVersion = 0;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30, nullable = false)
+    private CharacterImageAssetStatus status;
+
+    @Column(name = "s3_url", length = 1024)
+    private String s3Url;
+
+    @Column(length = 80)
+    private String model;
+
+    @Column(name = "prompt_hash", length = 64)
+    private String promptHash;
+
+    @Lob
+    @Column(name = "qa_result_json", columnDefinition = "TEXT")
+    private String qaResultJson;
+
+    @Column(name = "failure_code", length = 80)
+    private String failureCode;
+
+    @Column(name = "openai_request_id", length = 120)
+    private String openaiRequestId;
+
+    @Column(name = "attempt_no", nullable = false)
+    @Builder.Default
+    private int attemptNo = 1;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    public void generated(String s3Url, String model, String promptHash, String openaiRequestId) {
+        this.s3Url = s3Url;
+        this.model = model;
+        this.promptHash = promptHash;
+        this.openaiRequestId = openaiRequestId;
+        this.status = CharacterImageAssetStatus.QA_PENDING;
+    }
+
+    public void markQaPassed(String qaResultJson) {
+        this.qaResultJson = qaResultJson;
+        this.status = CharacterImageAssetStatus.QA_PASSED;
+        this.failureCode = null;
+    }
+
+    public void markQaFailed(String qaResultJson, String failureCode) {
+        this.qaResultJson = qaResultJson;
+        this.failureCode = failureCode;
+        this.status = CharacterImageAssetStatus.QA_FAILED;
+    }
+
+    public void approve() {
+        this.status = CharacterImageAssetStatus.APPROVED;
+    }
+
+    public void reject() {
+        this.status = CharacterImageAssetStatus.REJECTED;
+    }
+
+    public void publish() {
+        this.status = CharacterImageAssetStatus.PUBLISHED;
+        this.publishedAt = LocalDateTime.now();
+    }
+
+    public void fail(String failureCode) {
+        this.failureCode = failureCode;
+        this.status = CharacterImageAssetStatus.FAILED;
+    }
+
+    public void markStaleReference() {
+        this.status = CharacterImageAssetStatus.STALE_REFERENCE;
+    }
+
+    public void markSuperseded() {
+        this.status = CharacterImageAssetStatus.SUPERSEDED;
+    }
+}

--- a/src/main/java/com/kw/readwith/domain/enums/BookImageReferenceStatus.java
+++ b/src/main/java/com/kw/readwith/domain/enums/BookImageReferenceStatus.java
@@ -1,0 +1,11 @@
+package com.kw.readwith.domain.enums;
+
+public enum BookImageReferenceStatus {
+    NONE,
+    CANDIDATE_GENERATING,
+    QA_FAILED,
+    QA_PASSED,
+    APPROVED,
+    REJECTED,
+    SUPERSEDED
+}

--- a/src/main/java/com/kw/readwith/domain/enums/CharacterImageAssetRole.java
+++ b/src/main/java/com/kw/readwith/domain/enums/CharacterImageAssetRole.java
@@ -1,0 +1,7 @@
+package com.kw.readwith.domain.enums;
+
+public enum CharacterImageAssetRole {
+    REFERENCE_SEED,
+    DERIVED_CHARACTER,
+    STANDALONE_TEXT
+}

--- a/src/main/java/com/kw/readwith/domain/enums/CharacterImageAssetStatus.java
+++ b/src/main/java/com/kw/readwith/domain/enums/CharacterImageAssetStatus.java
@@ -1,0 +1,16 @@
+package com.kw.readwith.domain.enums;
+
+public enum CharacterImageAssetStatus {
+    GENERATING,
+    QA_PENDING,
+    QA_PASSED,
+    QA_FAILED,
+    REVIEW_REQUIRED,
+    APPROVED,
+    REJECTED,
+    PUBLISHED,
+    FAILED,
+    STALE_REFERENCE,
+    STALE_PROMPT,
+    SUPERSEDED
+}

--- a/src/main/java/com/kw/readwith/domain/enums/CharacterImageFanoutScope.java
+++ b/src/main/java/com/kw/readwith/domain/enums/CharacterImageFanoutScope.java
@@ -1,0 +1,10 @@
+package com.kw.readwith.domain.enums;
+
+public enum CharacterImageFanoutScope {
+    MAIN_ONLY,
+    GRAPH_VISIBLE,
+    SELECTED,
+    STALE_ONLY,
+    FAILED_ONLY,
+    ALL
+}

--- a/src/main/java/com/kw/readwith/domain/enums/CharacterImageGenerationMode.java
+++ b/src/main/java/com/kw/readwith/domain/enums/CharacterImageGenerationMode.java
@@ -1,0 +1,6 @@
+package com.kw.readwith.domain.enums;
+
+public enum CharacterImageGenerationMode {
+    TEXT_TO_IMAGE,
+    REFERENCE_EDIT
+}

--- a/src/main/java/com/kw/readwith/domain/enums/CharacterImagePublishPolicy.java
+++ b/src/main/java/com/kw/readwith/domain/enums/CharacterImagePublishPolicy.java
@@ -1,0 +1,6 @@
+package com.kw.readwith.domain.enums;
+
+public enum CharacterImagePublishPolicy {
+    AUTO_AFTER_QA,
+    MANUAL
+}

--- a/src/main/java/com/kw/readwith/dto/admin/CharacterImageAssetDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/CharacterImageAssetDTO.java
@@ -1,0 +1,105 @@
+package com.kw.readwith.dto.admin;
+
+import com.kw.readwith.domain.CharacterImageAsset;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "캐릭터 이미지 후보/게시 asset 응답")
+public class CharacterImageAssetDTO {
+
+    @Schema(description = "이미지 asset ID", example = "100")
+    private Long id;
+
+    @Schema(description = "도서 ID", example = "1")
+    private Long bookId;
+
+    @Schema(description = "인물 DB ID", example = "10")
+    private Long characterId;
+
+    @Schema(description = "인물 이름", example = "Elizabeth Bennet")
+    private String characterName;
+
+    @Schema(
+            description = "asset 역할",
+            allowableValues = {"REFERENCE_SEED", "DERIVED_CHARACTER", "STANDALONE_TEXT"}
+    )
+    private String assetRole;
+
+    @Schema(
+            description = "생성 방식",
+            allowableValues = {"TEXT_TO_IMAGE", "REFERENCE_EDIT"}
+    )
+    private String generationMode;
+
+    @Schema(
+            description = "asset 상태",
+            allowableValues = {
+                    "GENERATING",
+                    "QA_PENDING",
+                    "QA_PASSED",
+                    "QA_FAILED",
+                    "REVIEW_REQUIRED",
+                    "APPROVED",
+                    "REJECTED",
+                    "PUBLISHED",
+                    "FAILED",
+                    "STALE_REFERENCE",
+                    "STALE_PROMPT",
+                    "SUPERSEDED"
+            }
+    )
+    private String status;
+
+    @Schema(description = "S3 공개 URL", nullable = true)
+    private String s3Url;
+
+    @Schema(description = "사용 모델", nullable = true, example = "gpt-image-1")
+    private String model;
+
+    @Schema(description = "참조 asset ID", nullable = true)
+    private Long sourceReferenceAssetId;
+
+    @Schema(description = "참조 버전", example = "1")
+    private Integer referenceVersion;
+
+    @Schema(description = "시도 횟수", example = "1")
+    private Integer attemptNo;
+
+    @Schema(description = "실패 코드", nullable = true)
+    private String failureCode;
+
+    @Schema(description = "생성 시각")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "게시 시각", nullable = true)
+    private LocalDateTime publishedAt;
+
+    public static CharacterImageAssetDTO from(CharacterImageAsset asset) {
+        if (asset == null) {
+            return null;
+        }
+
+        return CharacterImageAssetDTO.builder()
+                .id(asset.getId())
+                .bookId(asset.getBook().getId())
+                .characterId(asset.getCharacter().getId())
+                .characterName(asset.getCharacter().getName())
+                .assetRole(asset.getAssetRole().name())
+                .generationMode(asset.getGenerationMode().name())
+                .status(asset.getStatus().name())
+                .s3Url(asset.getS3Url())
+                .model(asset.getModel())
+                .sourceReferenceAssetId(asset.getSourceReferenceAsset() != null ? asset.getSourceReferenceAsset().getId() : null)
+                .referenceVersion(asset.getReferenceVersion())
+                .attemptNo(asset.getAttemptNo())
+                .failureCode(asset.getFailureCode())
+                .createdAt(asset.getCreatedAt())
+                .publishedAt(asset.getPublishedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/kw/readwith/dto/admin/CharacterImageBookStatusResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/CharacterImageBookStatusResponseDTO.java
@@ -1,0 +1,37 @@
+package com.kw.readwith.dto.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "도서 단위 캐릭터 이미지 생성/승인 현황")
+public class CharacterImageBookStatusResponseDTO {
+
+    @Schema(description = "도서 ID", example = "1")
+    private Long bookId;
+
+    @Schema(
+            description = "대표 이미지 상태",
+            allowableValues = {"NONE", "CANDIDATE_GENERATING", "QA_FAILED", "QA_PASSED", "APPROVED", "REJECTED", "SUPERSEDED"}
+    )
+    private String referenceStatus;
+
+    @Schema(description = "활성 대표 이미지 asset ID", nullable = true)
+    private Long activeReferenceAssetId;
+
+    @Schema(description = "대표 캐릭터 DB ID", nullable = true)
+    private Long referenceCharacterId;
+
+    @Schema(description = "대표 이미지 버전", example = "1")
+    private Integer referenceVersion;
+
+    @Schema(description = "fan-out 생성 가능 여부")
+    private boolean canFanout;
+
+    @Schema(description = "캐릭터별 이미지 상태")
+    private List<CharacterImageCharacterStatusDTO> characters;
+}

--- a/src/main/java/com/kw/readwith/dto/admin/CharacterImageCandidateRequestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/CharacterImageCandidateRequestDTO.java
@@ -1,0 +1,27 @@
+package com.kw.readwith.dto.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "특정 캐릭터 이미지 후보 생성 요청")
+public class CharacterImageCandidateRequestDTO {
+
+    @Schema(description = "생성 직후 자동 QA를 실행할지 여부입니다.", example = "true", defaultValue = "true")
+    @Builder.Default
+    private Boolean autoQa = true;
+
+    @Schema(
+            description = "QA 통과 후 게시 정책. 허용값: AUTO_AFTER_QA, MANUAL",
+            example = "MANUAL",
+            allowableValues = {"AUTO_AFTER_QA", "MANUAL"}
+    )
+    @Builder.Default
+    private String publishPolicy = "MANUAL";
+}

--- a/src/main/java/com/kw/readwith/dto/admin/CharacterImageCharacterStatusDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/CharacterImageCharacterStatusDTO.java
@@ -1,0 +1,46 @@
+package com.kw.readwith.dto.admin;
+
+import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.CharacterImageAsset;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "캐릭터별 이미지 게시/후보 상태")
+public class CharacterImageCharacterStatusDTO {
+
+    @Schema(description = "인물 DB ID", example = "10")
+    private Long id;
+
+    @Schema(description = "책 내부 characterId", example = "1")
+    private Long bookCharacterId;
+
+    @Schema(description = "인물 이름", example = "Elizabeth Bennet")
+    private String name;
+
+    @Schema(description = "주요 인물 여부")
+    private boolean mainCharacter;
+
+    @Schema(description = "현재 게시 이미지 URL", nullable = true)
+    private String publishedImageUrl;
+
+    @Schema(description = "기존 이미지 생성 상태", nullable = true)
+    private String imageGenerationStatus;
+
+    @Schema(description = "최신 이미지 asset", nullable = true)
+    private CharacterImageAssetDTO latestAsset;
+
+    public static CharacterImageCharacterStatusDTO from(Character character, CharacterImageAsset latestAsset) {
+        return CharacterImageCharacterStatusDTO.builder()
+                .id(character.getId())
+                .bookCharacterId(character.getCharacterId())
+                .name(character.getName())
+                .mainCharacter(character.isMainCharacter())
+                .publishedImageUrl(character.getProfileImage())
+                .imageGenerationStatus(character.getImageGenerationStatus() != null ? character.getImageGenerationStatus().name() : null)
+                .latestAsset(CharacterImageAssetDTO.from(latestAsset))
+                .build();
+    }
+}

--- a/src/main/java/com/kw/readwith/dto/admin/CharacterImageFanoutRequestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/CharacterImageFanoutRequestDTO.java
@@ -1,0 +1,42 @@
+package com.kw.readwith.dto.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "승인된 대표 이미지를 기준으로 파생 캐릭터 이미지를 생성하는 요청")
+public class CharacterImageFanoutRequestDTO {
+
+    @Schema(
+            description = "생성 범위. 허용값: MAIN_ONLY, GRAPH_VISIBLE, SELECTED, STALE_ONLY, FAILED_ONLY, ALL",
+            example = "MAIN_ONLY",
+            allowableValues = {"MAIN_ONLY", "GRAPH_VISIBLE", "SELECTED", "STALE_ONLY", "FAILED_ONLY", "ALL"}
+    )
+    private String scope;
+
+    @Schema(description = "scope=SELECTED일 때 생성할 인물 DB ID 목록", example = "[10, 11, 12]", nullable = true)
+    private List<Long> characterIds;
+
+    @Schema(description = "이번 요청에서 최대 생성할 인물 수. 생략하면 제한하지 않습니다.", example = "10", nullable = true)
+    private Integer limit;
+
+    @Schema(description = "이미 게시 이미지가 있는 캐릭터도 후보를 새로 만들지 여부입니다.", example = "false", defaultValue = "false")
+    @Builder.Default
+    private Boolean overwritePublished = false;
+
+    @Schema(
+            description = "QA 통과 후 게시 정책. 허용값: AUTO_AFTER_QA, MANUAL",
+            example = "MANUAL",
+            allowableValues = {"AUTO_AFTER_QA", "MANUAL"}
+    )
+    @Builder.Default
+    private String publishPolicy = "MANUAL";
+}

--- a/src/main/java/com/kw/readwith/dto/admin/CharacterImageFanoutResponseDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/CharacterImageFanoutResponseDTO.java
@@ -1,0 +1,31 @@
+package com.kw.readwith.dto.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "fan-out 이미지 생성 결과")
+public class CharacterImageFanoutResponseDTO {
+
+    @Schema(description = "요청 scope")
+    private String scope;
+
+    @Schema(description = "생성 대상 수", example = "10")
+    private int targetCount;
+
+    @Schema(description = "생성 성공 수", example = "8")
+    private int successCount;
+
+    @Schema(description = "실패 수", example = "1")
+    private int failedCount;
+
+    @Schema(description = "스킵 수", example = "1")
+    private int skippedCount;
+
+    @Schema(description = "생성된 asset 목록")
+    private List<CharacterImageAssetDTO> assets;
+}

--- a/src/main/java/com/kw/readwith/dto/admin/CharacterImageReferenceCandidateRequestDTO.java
+++ b/src/main/java/com/kw/readwith/dto/admin/CharacterImageReferenceCandidateRequestDTO.java
@@ -1,0 +1,26 @@
+package com.kw.readwith.dto.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "책 단위 대표 이미지 후보 생성 요청")
+public class CharacterImageReferenceCandidateRequestDTO {
+
+    @Schema(
+            description = "대표 이미지 후보로 사용할 인물 DB ID입니다. 생략하면 주요 인물 정책에 따라 자동 선정합니다.",
+            example = "10",
+            nullable = true
+    )
+    private Long characterId;
+
+    @Schema(description = "생성 직후 자동 QA를 실행할지 여부입니다.", example = "true", defaultValue = "true")
+    @Builder.Default
+    private Boolean autoQa = true;
+}

--- a/src/main/java/com/kw/readwith/repository/BookCharacterImageProfileRepository.java
+++ b/src/main/java/com/kw/readwith/repository/BookCharacterImageProfileRepository.java
@@ -1,0 +1,14 @@
+package com.kw.readwith.repository;
+
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.BookCharacterImageProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BookCharacterImageProfileRepository extends JpaRepository<BookCharacterImageProfile, Long> {
+
+    Optional<BookCharacterImageProfile> findByBook(Book book);
+}

--- a/src/main/java/com/kw/readwith/repository/CharacterImageAssetRepository.java
+++ b/src/main/java/com/kw/readwith/repository/CharacterImageAssetRepository.java
@@ -1,0 +1,49 @@
+package com.kw.readwith.repository;
+
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.CharacterImageAsset;
+import com.kw.readwith.domain.enums.CharacterImageAssetRole;
+import com.kw.readwith.domain.enums.CharacterImageAssetStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CharacterImageAssetRepository extends JpaRepository<CharacterImageAsset, Long> {
+
+    Optional<CharacterImageAsset> findByIdAndBook(Long id, Book book);
+
+    List<CharacterImageAsset> findByBookOrderByCreatedAtDesc(Book book);
+
+    List<CharacterImageAsset> findByCharacterOrderByCreatedAtDesc(Character character);
+
+    Optional<CharacterImageAsset> findFirstByCharacterOrderByCreatedAtDesc(Character character);
+
+    Optional<CharacterImageAsset> findFirstByCharacterAndStatusOrderByCreatedAtDesc(
+            Character character,
+            CharacterImageAssetStatus status
+    );
+
+    List<CharacterImageAsset> findByBookAndStatusIn(Book book, Collection<CharacterImageAssetStatus> statuses);
+
+    @Query("SELECT COALESCE(MAX(a.attemptNo), 0) FROM CharacterImageAsset a " +
+            "WHERE a.character = :character AND a.assetRole = :assetRole")
+    int findMaxAttemptNo(@Param("character") Character character,
+                         @Param("assetRole") CharacterImageAssetRole assetRole);
+
+    @Modifying
+    @Query("UPDATE CharacterImageAsset a SET a.status = com.kw.readwith.domain.enums.CharacterImageAssetStatus.STALE_REFERENCE " +
+            "WHERE a.book = :book " +
+            "AND a.sourceReferenceAsset = :sourceReferenceAsset " +
+            "AND a.status IN :statuses")
+    int markDerivedAssetsStale(@Param("book") Book book,
+                               @Param("sourceReferenceAsset") CharacterImageAsset sourceReferenceAsset,
+                               @Param("statuses") Collection<CharacterImageAssetStatus> statuses);
+}

--- a/src/main/java/com/kw/readwith/service/AdminService.java
+++ b/src/main/java/com/kw/readwith/service/AdminService.java
@@ -147,16 +147,6 @@ public class AdminService {
                 throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR, "Failed to save characters.");
             }
 
-            List<Long> characterIds = savedCharacters.stream()
-                    .map(Character::getId)
-                    .collect(Collectors.toList());
-
-            try {
-                characterImageService.generateImagesAsync(characterIds);
-            } catch (Exception e) {
-                log.error("Failed to start character image generation.", e);
-            }
-
             bookAnalysisStatusService.refreshStatus(bookId);
             return savedCharacters.size();
         } catch (IOException e) {

--- a/src/main/java/com/kw/readwith/service/CharacterImageAdminService.java
+++ b/src/main/java/com/kw/readwith/service/CharacterImageAdminService.java
@@ -1,0 +1,591 @@
+package com.kw.readwith.service;
+
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.config.CharacterImageProperties;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.BookCharacterImageProfile;
+import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.CharacterImageAsset;
+import com.kw.readwith.domain.enums.BookImageReferenceStatus;
+import com.kw.readwith.domain.enums.CharacterImageAssetRole;
+import com.kw.readwith.domain.enums.CharacterImageAssetStatus;
+import com.kw.readwith.domain.enums.CharacterImageFanoutScope;
+import com.kw.readwith.domain.enums.CharacterImageGenerationMode;
+import com.kw.readwith.domain.enums.CharacterImagePublishPolicy;
+import com.kw.readwith.domain.enums.ImageGenerationStatus;
+import com.kw.readwith.dto.admin.CharacterImageAssetDTO;
+import com.kw.readwith.dto.admin.CharacterImageBookStatusResponseDTO;
+import com.kw.readwith.dto.admin.CharacterImageCandidateRequestDTO;
+import com.kw.readwith.dto.admin.CharacterImageCharacterStatusDTO;
+import com.kw.readwith.dto.admin.CharacterImageFanoutRequestDTO;
+import com.kw.readwith.dto.admin.CharacterImageFanoutResponseDTO;
+import com.kw.readwith.dto.admin.CharacterImageReferenceCandidateRequestDTO;
+import com.kw.readwith.repository.BookCharacterImageProfileRepository;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.CharacterImageAssetRepository;
+import com.kw.readwith.repository.CharacterRepository;
+import com.kw.readwith.service.image.CharacterImageQaService;
+import com.kw.readwith.service.image.GeneratedCharacterImage;
+import com.kw.readwith.service.image.OpenAiImageEditClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CharacterImageAdminService {
+
+    private static final Set<CharacterImageAssetStatus> REGENERATABLE_FAILURE_STATUSES = Set.of(
+            CharacterImageAssetStatus.FAILED,
+            CharacterImageAssetStatus.QA_FAILED,
+            CharacterImageAssetStatus.REVIEW_REQUIRED
+    );
+
+    private static final Set<CharacterImageAssetStatus> PUBLISHED_OR_APPROVED_STATUSES = Set.of(
+            CharacterImageAssetStatus.PUBLISHED,
+            CharacterImageAssetStatus.APPROVED,
+            CharacterImageAssetStatus.QA_PASSED
+    );
+
+    private final BookRepository bookRepository;
+    private final CharacterRepository characterRepository;
+    private final CharacterImageAssetRepository assetRepository;
+    private final BookCharacterImageProfileRepository profileRepository;
+    private final CharacterImageService characterImageService;
+    private final OpenAiImageEditClient imageEditClient;
+    private final CharacterImageQaService qaService;
+    private final CharacterImageProperties imageProperties;
+    private final RestTemplate restTemplate;
+
+    public CharacterImageBookStatusResponseDTO getBookStatus(Long bookId) {
+        Book book = getBook(bookId);
+        Optional<BookCharacterImageProfile> profile = profileRepository.findByBook(book);
+        List<Character> characters = characterRepository.findByBookOrderByIsMainCharacterDescNameAsc(book);
+
+        Map<Long, CharacterImageAsset> latestAssets = assetRepository.findByBookOrderByCreatedAtDesc(book).stream()
+                .collect(Collectors.toMap(
+                        asset -> asset.getCharacter().getId(),
+                        asset -> asset,
+                        (first, ignored) -> first,
+                        LinkedHashMap::new
+                ));
+
+        List<CharacterImageCharacterStatusDTO> characterStatuses = characters.stream()
+                .map(character -> CharacterImageCharacterStatusDTO.from(character, latestAssets.get(character.getId())))
+                .collect(Collectors.toList());
+
+        BookImageReferenceStatus referenceStatus = profile
+                .map(BookCharacterImageProfile::getReferenceStatus)
+                .orElse(BookImageReferenceStatus.NONE);
+
+        CharacterImageAsset activeReference = profile
+                .map(BookCharacterImageProfile::getActiveReferenceAsset)
+                .orElse(null);
+
+        Character referenceCharacter = profile
+                .map(BookCharacterImageProfile::getReferenceCharacter)
+                .orElse(null);
+
+        return CharacterImageBookStatusResponseDTO.builder()
+                .bookId(book.getId())
+                .referenceStatus(referenceStatus.name())
+                .activeReferenceAssetId(activeReference != null ? activeReference.getId() : null)
+                .referenceCharacterId(referenceCharacter != null ? referenceCharacter.getId() : null)
+                .referenceVersion(profile.map(BookCharacterImageProfile::getReferenceVersion).orElse(0))
+                .canFanout(referenceStatus == BookImageReferenceStatus.APPROVED && activeReference != null)
+                .characters(characterStatuses)
+                .build();
+    }
+
+    @Transactional
+    public CharacterImageAssetDTO createReferenceCandidate(Long bookId, CharacterImageReferenceCandidateRequestDTO request) {
+        Book book = getBook(bookId);
+        Character referenceCharacter = resolveReferenceCharacter(book, request != null ? request.getCharacterId() : null);
+        BookCharacterImageProfile profile = getOrCreateProfile(book);
+        profile.markCandidateGenerating(
+                referenceCharacter,
+                resolveTextImageModel(),
+                sha256(normalize(imageProperties.getBaseStylePrompt())),
+                sha256(normalize(book.getBookPrompt()))
+        );
+
+        CharacterImageAsset asset = createGeneratingAsset(
+                book,
+                referenceCharacter,
+                CharacterImageAssetRole.REFERENCE_SEED,
+                CharacterImageGenerationMode.TEXT_TO_IMAGE,
+                null,
+                0
+        );
+
+        try {
+            GeneratedCharacterImage generated = characterImageService.generateTextImage(referenceCharacter);
+            String s3Url = characterImageService.uploadGeneratedImage(
+                    referenceCharacter,
+                    generated.imageData(),
+                    characterImageService.buildReferenceCandidateS3KeyName(referenceCharacter, asset.getId())
+            );
+            asset.generated(s3Url, generated.model(), generated.promptHash(), generated.requestId());
+            runQa(asset, true, request == null || request.getAutoQa() == null || request.getAutoQa());
+
+            if (asset.getStatus() == CharacterImageAssetStatus.QA_PASSED) {
+                profile.markQaPassed(asset);
+            } else if (asset.getStatus() == CharacterImageAssetStatus.QA_FAILED) {
+                profile.markQaFailed(referenceCharacter);
+            }
+        } catch (Exception e) {
+            log.error("Reference image candidate generation failed. bookId={}, characterId={}",
+                    bookId, referenceCharacter.getId(), e);
+            asset.fail("REFERENCE_GENERATION_FAILED");
+            profile.markQaFailed(referenceCharacter);
+        }
+
+        return CharacterImageAssetDTO.from(asset);
+    }
+
+    @Transactional
+    public CharacterImageAssetDTO approveReferenceCandidate(Long bookId, Long assetId) {
+        Book book = getBook(bookId);
+        CharacterImageAsset asset = getAssetInBook(book, assetId);
+        ensureAssetRole(asset, CharacterImageAssetRole.REFERENCE_SEED);
+        ensurePublishable(asset);
+
+        BookCharacterImageProfile profile = getOrCreateProfile(book);
+        CharacterImageAsset previousReference = profile.getActiveReferenceAsset();
+        if (profile.getReferenceStatus() == BookImageReferenceStatus.APPROVED
+                && previousReference != null
+                && previousReference.getId().equals(asset.getId())) {
+            if (asset.getStatus() != CharacterImageAssetStatus.PUBLISHED) {
+                publishAsset(asset);
+            }
+            return CharacterImageAssetDTO.from(asset);
+        }
+
+        if (previousReference != null && !previousReference.getId().equals(asset.getId())) {
+            previousReference.markSuperseded();
+            assetRepository.markDerivedAssetsStale(book, previousReference, PUBLISHED_OR_APPROVED_STATUSES);
+        }
+
+        profile.approve(asset, "admin");
+        publishAsset(asset);
+        return CharacterImageAssetDTO.from(asset);
+    }
+
+    @Transactional
+    public CharacterImageAssetDTO rejectReferenceCandidate(Long bookId, Long assetId) {
+        Book book = getBook(bookId);
+        CharacterImageAsset asset = getAssetInBook(book, assetId);
+        ensureAssetRole(asset, CharacterImageAssetRole.REFERENCE_SEED);
+        asset.reject();
+
+        profileRepository.findByBook(book)
+                .filter(profile -> profile.getActiveReferenceAsset() != null)
+                .filter(profile -> profile.getActiveReferenceAsset().getId().equals(asset.getId()))
+                .ifPresent(BookCharacterImageProfile::reject);
+
+        return CharacterImageAssetDTO.from(asset);
+    }
+
+    @Transactional
+    public CharacterImageFanoutResponseDTO fanout(Long bookId, CharacterImageFanoutRequestDTO request) {
+        Book book = getBook(bookId);
+        CharacterImageFanoutScope scope = parseScope(request != null ? request.getScope() : null);
+        CharacterImagePublishPolicy publishPolicy = parsePublishPolicy(request != null ? request.getPublishPolicy() : null);
+        boolean overwritePublished = request != null && Boolean.TRUE.equals(request.getOverwritePublished());
+        Integer limit = request != null ? request.getLimit() : null;
+
+        BookCharacterImageProfile profile = profileRepository.findByBook(book)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.IMAGE_REFERENCE_NOT_APPROVED));
+        if (profile.getReferenceStatus() != BookImageReferenceStatus.APPROVED || profile.getActiveReferenceAsset() == null) {
+            throw new GeneralException(ErrorStatus.IMAGE_REFERENCE_NOT_APPROVED);
+        }
+
+        List<Character> targets = resolveFanoutTargets(book, scope, request != null ? request.getCharacterIds() : null);
+        Character referenceCharacter = profile.getReferenceCharacter();
+        if (referenceCharacter != null) {
+            targets = targets.stream()
+                    .filter(character -> !character.getId().equals(referenceCharacter.getId()))
+                    .collect(Collectors.toList());
+        }
+        if (limit != null && limit > 0 && targets.size() > limit) {
+            targets = targets.subList(0, limit);
+        }
+
+        List<CharacterImageAssetDTO> generatedAssets = new ArrayList<>();
+        int successCount = 0;
+        int failedCount = 0;
+        int skippedCount = 0;
+
+        for (Character character : targets) {
+            if (!overwritePublished && hasPublishedImage(character) && scope != CharacterImageFanoutScope.STALE_ONLY
+                    && scope != CharacterImageFanoutScope.FAILED_ONLY) {
+                skippedCount++;
+                continue;
+            }
+
+            CharacterImageAsset asset = createDerivedCandidate(character, profile, publishPolicy);
+            generatedAssets.add(CharacterImageAssetDTO.from(asset));
+            if (asset.getStatus() == CharacterImageAssetStatus.PUBLISHED
+                    || asset.getStatus() == CharacterImageAssetStatus.QA_PASSED) {
+                successCount++;
+            } else {
+                failedCount++;
+            }
+        }
+
+        return CharacterImageFanoutResponseDTO.builder()
+                .scope(scope.name())
+                .targetCount(targets.size())
+                .successCount(successCount)
+                .failedCount(failedCount)
+                .skippedCount(skippedCount)
+                .assets(generatedAssets)
+                .build();
+    }
+
+    @Transactional
+    public CharacterImageAssetDTO createCharacterCandidate(Long characterId, CharacterImageCandidateRequestDTO request) {
+        Character character = getCharacter(characterId);
+        Book book = character.getBook();
+        CharacterImagePublishPolicy publishPolicy = parsePublishPolicy(request != null ? request.getPublishPolicy() : null);
+
+        Optional<BookCharacterImageProfile> profile = profileRepository.findByBook(book);
+        if (profile.isPresent()
+                && profile.get().getReferenceStatus() == BookImageReferenceStatus.APPROVED
+                && profile.get().getActiveReferenceAsset() != null
+                && profile.get().getReferenceCharacter() != null
+                && !profile.get().getReferenceCharacter().getId().equals(character.getId())) {
+            return CharacterImageAssetDTO.from(createDerivedCandidate(character, profile.get(), publishPolicy));
+        }
+
+        CharacterImageAsset asset = createTextCandidate(character, request == null || request.getAutoQa() == null || request.getAutoQa());
+        if (publishPolicy == CharacterImagePublishPolicy.AUTO_AFTER_QA && asset.getStatus() == CharacterImageAssetStatus.QA_PASSED) {
+            publishAsset(asset);
+        }
+        return CharacterImageAssetDTO.from(asset);
+    }
+
+    @Transactional
+    public CharacterImageAssetDTO approveCharacterCandidate(Long characterId, Long assetId) {
+        Character character = getCharacter(characterId);
+        CharacterImageAsset asset = getAsset(assetId);
+        if (!asset.getCharacter().getId().equals(character.getId())) {
+            throw new GeneralException(ErrorStatus.IMAGE_ASSET_NOT_BELONG_TO_BOOK);
+        }
+        ensurePublishable(asset);
+        publishAsset(asset);
+        return CharacterImageAssetDTO.from(asset);
+    }
+
+    @Transactional
+    public CharacterImageAssetDTO rejectCharacterCandidate(Long characterId, Long assetId) {
+        Character character = getCharacter(characterId);
+        CharacterImageAsset asset = getAsset(assetId);
+        if (!asset.getCharacter().getId().equals(character.getId())) {
+            throw new GeneralException(ErrorStatus.IMAGE_ASSET_NOT_BELONG_TO_BOOK);
+        }
+        asset.reject();
+        return CharacterImageAssetDTO.from(asset);
+    }
+
+    private CharacterImageAsset createDerivedCandidate(Character character,
+                                                       BookCharacterImageProfile profile,
+                                                       CharacterImagePublishPolicy publishPolicy) {
+        CharacterImageAsset reference = profile.getActiveReferenceAsset();
+        CharacterImageAsset asset = createGeneratingAsset(
+                character.getBook(),
+                character,
+                CharacterImageAssetRole.DERIVED_CHARACTER,
+                CharacterImageGenerationMode.REFERENCE_EDIT,
+                reference,
+                profile.getReferenceVersion()
+        );
+
+        try {
+            byte[] referenceImage = restTemplate.getForObject(reference.getS3Url(), byte[].class);
+            String prompt = buildReferenceEditPrompt(character);
+            GeneratedCharacterImage generated = imageEditClient.generate(referenceImage, prompt);
+            String s3Url = characterImageService.uploadGeneratedImage(
+                    character,
+                    generated.imageData(),
+                    characterImageService.buildCandidateS3KeyName(character, asset.getId())
+            );
+            asset.generated(s3Url, generated.model(), generated.promptHash(), generated.requestId());
+            runQa(asset, false, true);
+
+            if (publishPolicy == CharacterImagePublishPolicy.AUTO_AFTER_QA
+                    && asset.getStatus() == CharacterImageAssetStatus.QA_PASSED) {
+                publishAsset(asset);
+            }
+        } catch (Exception e) {
+            log.error("Derived image generation failed. characterId={}, referenceAssetId={}",
+                    character.getId(), reference.getId(), e);
+            asset.fail("REFERENCE_EDIT_FAILED");
+        }
+
+        return asset;
+    }
+
+    private CharacterImageAsset createTextCandidate(Character character, boolean autoQa) {
+        CharacterImageAsset asset = createGeneratingAsset(
+                character.getBook(),
+                character,
+                CharacterImageAssetRole.STANDALONE_TEXT,
+                CharacterImageGenerationMode.TEXT_TO_IMAGE,
+                null,
+                0
+        );
+
+        try {
+            GeneratedCharacterImage generated = characterImageService.generateTextImage(character);
+            String s3Url = characterImageService.uploadGeneratedImage(
+                    character,
+                    generated.imageData(),
+                    characterImageService.buildCandidateS3KeyName(character, asset.getId())
+            );
+            asset.generated(s3Url, generated.model(), generated.promptHash(), generated.requestId());
+            runQa(asset, false, autoQa);
+        } catch (Exception e) {
+            log.error("Text image candidate generation failed. characterId={}", character.getId(), e);
+            asset.fail("TEXT_IMAGE_GENERATION_FAILED");
+        }
+
+        return asset;
+    }
+
+    private CharacterImageAsset createGeneratingAsset(Book book,
+                                                      Character character,
+                                                      CharacterImageAssetRole role,
+                                                      CharacterImageGenerationMode generationMode,
+                                                      CharacterImageAsset sourceReferenceAsset,
+                                                      int referenceVersion) {
+        int attemptNo = assetRepository.findMaxAttemptNo(character, role) + 1;
+        CharacterImageAsset asset = CharacterImageAsset.builder()
+                .book(book)
+                .character(character)
+                .assetRole(role)
+                .generationMode(generationMode)
+                .sourceReferenceAsset(sourceReferenceAsset)
+                .referenceVersion(referenceVersion)
+                .status(CharacterImageAssetStatus.GENERATING)
+                .attemptNo(attemptNo)
+                .build();
+        return assetRepository.save(asset);
+    }
+
+    private void runQa(CharacterImageAsset asset, boolean referenceSeed, boolean autoQa) {
+        if (!autoQa) {
+            return;
+        }
+
+        CharacterImageQaService.CharacterImageQaResult result = qaService.review(asset.getS3Url(), referenceSeed);
+        if (result.passed()) {
+            asset.markQaPassed(result.resultJson());
+        } else {
+            asset.markQaFailed(result.resultJson(), result.failureCode());
+        }
+    }
+
+    private void publishAsset(CharacterImageAsset asset) {
+        if (asset.getS3Url() == null || asset.getS3Url().isBlank()) {
+            throw new GeneralException(ErrorStatus.IMAGE_ASSET_INVALID_STATUS, "게시할 이미지 URL이 없습니다.");
+        }
+        asset.publish();
+        characterRepository.updateProfileImageAndStatus(
+                asset.getCharacter().getId(),
+                asset.getS3Url(),
+                ImageGenerationStatus.COMPLETED
+        );
+    }
+
+    private List<Character> resolveFanoutTargets(Book book, CharacterImageFanoutScope scope, List<Long> characterIds) {
+        List<Character> allCharacters = characterRepository.findByBookOrderByIsMainCharacterDescNameAsc(book);
+
+        return switch (scope) {
+            case MAIN_ONLY -> allCharacters.stream()
+                    .filter(Character::isMainCharacter)
+                    .collect(Collectors.toList());
+            case GRAPH_VISIBLE, ALL -> allCharacters;
+            case SELECTED -> resolveSelectedCharacters(book, characterIds);
+            case STALE_ONLY -> resolveCharactersByAssetStatuses(book, Set.of(
+                    CharacterImageAssetStatus.STALE_REFERENCE,
+                    CharacterImageAssetStatus.STALE_PROMPT
+            ));
+            case FAILED_ONLY -> resolveCharactersByAssetStatuses(book, REGENERATABLE_FAILURE_STATUSES);
+        };
+    }
+
+    private List<Character> resolveSelectedCharacters(Book book, List<Long> characterIds) {
+        if (characterIds == null || characterIds.isEmpty()) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "scope=SELECTED일 때 characterIds가 필요합니다.");
+        }
+
+        Set<Long> requestedIds = new LinkedHashSet<>(characterIds);
+        Map<Long, Character> charactersById = characterRepository.findAllById(requestedIds).stream()
+                .collect(Collectors.toMap(Character::getId, character -> character));
+
+        if (charactersById.size() != requestedIds.size()) {
+            throw new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND);
+        }
+
+        List<Character> result = new ArrayList<>();
+        for (Long id : requestedIds) {
+            Character character = charactersById.get(id);
+            if (character == null || !character.getBook().getId().equals(book.getId())) {
+                throw new GeneralException(ErrorStatus.BOOK_CHARACTER_NOT_FOUND);
+            }
+            result.add(character);
+        }
+        return result;
+    }
+
+    private List<Character> resolveCharactersByAssetStatuses(Book book, Set<CharacterImageAssetStatus> statuses) {
+        return assetRepository.findByBookAndStatusIn(book, statuses).stream()
+                .sorted(Comparator.comparing(CharacterImageAsset::getCreatedAt).reversed())
+                .map(CharacterImageAsset::getCharacter)
+                .filter(Objects::nonNull)
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toMap(Character::getId, character -> character, (first, ignored) -> first, LinkedHashMap::new),
+                        map -> new ArrayList<>(map.values())
+                ));
+    }
+
+    private Character resolveReferenceCharacter(Book book, Long requestedCharacterId) {
+        if (requestedCharacterId != null) {
+            Character character = getCharacter(requestedCharacterId);
+            if (!character.getBook().getId().equals(book.getId())) {
+                throw new GeneralException(ErrorStatus.BOOK_CHARACTER_NOT_FOUND);
+            }
+            return character;
+        }
+
+        return characterRepository.findByBookOrderByIsMainCharacterDescNameAsc(book).stream()
+                .findFirst()
+                .orElseThrow(() -> new GeneralException(ErrorStatus.IMAGE_REFERENCE_CHARACTER_REQUIRED));
+    }
+
+    private CharacterImageFanoutScope parseScope(String rawScope) {
+        String normalized = rawScope == null || rawScope.isBlank() ? "MAIN_ONLY" : rawScope.trim();
+        try {
+            return CharacterImageFanoutScope.valueOf(normalized);
+        } catch (IllegalArgumentException e) {
+            throw new GeneralException(ErrorStatus.INVALID_IMAGE_FANOUT_SCOPE);
+        }
+    }
+
+    private CharacterImagePublishPolicy parsePublishPolicy(String rawPolicy) {
+        String normalized = rawPolicy == null || rawPolicy.isBlank() ? "MANUAL" : rawPolicy.trim();
+        try {
+            return CharacterImagePublishPolicy.valueOf(normalized);
+        } catch (IllegalArgumentException e) {
+            throw new GeneralException(ErrorStatus.INVALID_IMAGE_PUBLISH_POLICY);
+        }
+    }
+
+    private void ensureAssetRole(CharacterImageAsset asset, CharacterImageAssetRole expectedRole) {
+        if (asset.getAssetRole() != expectedRole) {
+            throw new GeneralException(ErrorStatus.IMAGE_ASSET_INVALID_STATUS,
+                    "요청한 작업에 사용할 수 없는 이미지 asset role입니다.");
+        }
+    }
+
+    private void ensurePublishable(CharacterImageAsset asset) {
+        if (asset.getStatus() != CharacterImageAssetStatus.QA_PASSED
+                && asset.getStatus() != CharacterImageAssetStatus.APPROVED
+                && asset.getStatus() != CharacterImageAssetStatus.PUBLISHED) {
+            throw new GeneralException(ErrorStatus.IMAGE_ASSET_INVALID_STATUS,
+                    "QA를 통과한 이미지 후보만 승인/게시할 수 있습니다.");
+        }
+    }
+
+    private BookCharacterImageProfile getOrCreateProfile(Book book) {
+        return profileRepository.findByBook(book)
+                .orElseGet(() -> profileRepository.save(
+                        BookCharacterImageProfile.builder()
+                                .book(book)
+                                .referenceStatus(BookImageReferenceStatus.NONE)
+                                .build()
+                ));
+    }
+
+    private Book getBook(Long bookId) {
+        return bookRepository.findById(bookId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+    }
+
+    private Character getCharacter(Long characterId) {
+        return characterRepository.findByIdWithBook(characterId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHARACTER_NOT_FOUND));
+    }
+
+    private CharacterImageAsset getAsset(Long assetId) {
+        return assetRepository.findById(assetId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.IMAGE_ASSET_NOT_FOUND));
+    }
+
+    private CharacterImageAsset getAssetInBook(Book book, Long assetId) {
+        return assetRepository.findByIdAndBook(assetId, book)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.IMAGE_ASSET_NOT_BELONG_TO_BOOK));
+    }
+
+    private boolean hasPublishedImage(Character character) {
+        return character.getProfileImage() != null && !character.getProfileImage().isBlank();
+    }
+
+    private String buildReferenceEditPrompt(Character character) {
+        return "Use the input image as a style reference only. Keep the same illustration style, framing, " +
+                "background simplicity, color palette, and rendering quality. Create a distinct person matching " +
+                "the target character profile. Do not copy the reference person's facial identity, age, gender, " +
+                "ethnicity, clothing, or exact features unless explicitly specified. " +
+                characterImageService.buildImagePrompt(character);
+    }
+
+    private String resolveTextImageModel() {
+        String configured = normalize(imageProperties.getModel());
+        return configured != null ? configured : "gpt-image-1";
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private String sha256(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder builder = new StringBuilder();
+            for (byte b : hash) {
+                builder.append(String.format("%02x", b));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available.", e);
+        }
+    }
+}

--- a/src/main/java/com/kw/readwith/service/CharacterImageService.java
+++ b/src/main/java/com/kw/readwith/service/CharacterImageService.java
@@ -6,6 +6,7 @@ import com.kw.readwith.domain.Book;
 import com.kw.readwith.domain.Character;
 import com.kw.readwith.domain.enums.ImageGenerationStatus;
 import com.kw.readwith.repository.CharacterRepository;
+import com.kw.readwith.service.image.GeneratedCharacterImage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.image.Image;
@@ -21,9 +22,13 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -143,19 +148,8 @@ public class CharacterImageService {
             Character character = getCharacterReadOnly(characterId);
             transactionService.updateStatus(characterId, ImageGenerationStatus.GENERATING);
 
-            String prompt = buildImagePrompt(character);
-            log.debug("Generated image prompt for characterId={}: {}", characterId, prompt);
-
-            ImageResponse response = imageModel.call(
-                    new ImagePrompt(prompt, buildImageOptions())
-            );
-
-            Image generatedImage = response.getResult().getOutput();
-            byte[] imageData = resolveGeneratedImageData(generatedImage);
-            String base64Image = Base64.getEncoder().encodeToString(imageData);
-
-            String s3KeyName = buildS3KeyName(character);
-            String s3Url = s3Manager.uploadFileFromBase64(s3KeyName, base64Image, "image/png");
+            GeneratedCharacterImage generatedImage = generateTextImage(character);
+            String s3Url = uploadGeneratedImage(character, generatedImage.imageData(), buildPublishedS3KeyName(character));
             updateImageUrlOnly(characterId, s3Url);
 
             log.info("Character image generation completed. characterId={}, s3Url={}", characterId, s3Url);
@@ -193,6 +187,46 @@ public class CharacterImageService {
         return builder.build();
     }
 
+    public GeneratedCharacterImage generateTextImage(Character character) throws IOException {
+        String prompt = buildImagePrompt(character);
+        log.debug("Generated image prompt for characterId={}: {}", character.getId(), prompt);
+
+        ImageResponse response = imageModel.call(
+                new ImagePrompt(prompt, buildImageOptions())
+        );
+
+        Image generatedImage = response.getResult().getOutput();
+        return new GeneratedCharacterImage(
+                resolveGeneratedImageData(generatedImage),
+                resolveImageModel(),
+                prompt,
+                sha256(prompt),
+                null
+        );
+    }
+
+    public String uploadGeneratedImage(Character character, byte[] imageData, String s3KeyName) {
+        String base64Image = Base64.getEncoder().encodeToString(imageData);
+        return s3Manager.uploadFileFromBase64(s3KeyName, base64Image, "image/png");
+    }
+
+    public String buildReferenceCandidateS3KeyName(Character character, Long assetId) {
+        return String.format("%s/%d/reference/%d-%s.png",
+                imageProperties.getS3Path(),
+                character.getBook().getId(),
+                assetId,
+                UUID.randomUUID());
+    }
+
+    public String buildCandidateS3KeyName(Character character, Long assetId) {
+        return String.format("%s/%d/%d/candidates/%d-%s.png",
+                imageProperties.getS3Path(),
+                character.getBook().getId(),
+                character.getId(),
+                assetId,
+                UUID.randomUUID());
+    }
+
     private String resolveImageModel() {
         String configured = normalizePromptSegment(imageProperties.getModel());
         return configured != null ? configured : "gpt-image-1";
@@ -207,7 +241,7 @@ public class CharacterImageService {
         return value > 0 ? value : defaultValue;
     }
 
-    private String buildImagePrompt(Character character) {
+    public String buildImagePrompt(Character character) {
         StringBuilder prompt = new StringBuilder();
 
         appendPromptSegment(prompt, resolveBaseStylePrompt());
@@ -330,11 +364,25 @@ public class CharacterImageService {
         }
     }
 
-    private String buildS3KeyName(Character character) {
+    private String buildPublishedS3KeyName(Character character) {
         return String.format("%s/%d/%d.png",
                 imageProperties.getS3Path(),
                 character.getBook().getId(),
                 character.getId());
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder builder = new StringBuilder();
+            for (byte b : hash) {
+                builder.append(String.format("%02x", b));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available.", e);
+        }
     }
 
     private void saveFallbackImage(Long characterId) {

--- a/src/main/java/com/kw/readwith/service/image/CharacterImageQaService.java
+++ b/src/main/java/com/kw/readwith/service/image/CharacterImageQaService.java
@@ -1,0 +1,27 @@
+package com.kw.readwith.service.image;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class CharacterImageQaService {
+
+    public CharacterImageQaResult review(String imageUrl, boolean referenceSeed) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            return CharacterImageQaResult.failed("{\"passed\":false,\"reason\":\"EMPTY_IMAGE_URL\"}", "EMPTY_IMAGE_URL");
+        }
+
+        String role = referenceSeed ? "REFERENCE_SEED" : "DERIVED_CHARACTER";
+        String resultJson = "{\"passed\":true,\"mode\":\"BASIC_URL_CHECK\",\"role\":\"" + role + "\"}";
+        return CharacterImageQaResult.passed(resultJson);
+    }
+
+    public record CharacterImageQaResult(boolean passed, String resultJson, String failureCode) {
+        public static CharacterImageQaResult passed(String resultJson) {
+            return new CharacterImageQaResult(true, resultJson, null);
+        }
+
+        public static CharacterImageQaResult failed(String resultJson, String failureCode) {
+            return new CharacterImageQaResult(false, resultJson, failureCode);
+        }
+    }
+}

--- a/src/main/java/com/kw/readwith/service/image/GeneratedCharacterImage.java
+++ b/src/main/java/com/kw/readwith/service/image/GeneratedCharacterImage.java
@@ -1,0 +1,10 @@
+package com.kw.readwith.service.image;
+
+public record GeneratedCharacterImage(
+        byte[] imageData,
+        String model,
+        String prompt,
+        String promptHash,
+        String requestId
+) {
+}

--- a/src/main/java/com/kw/readwith/service/image/OpenAiImageEditClient.java
+++ b/src/main/java/com/kw/readwith/service/image/OpenAiImageEditClient.java
@@ -1,0 +1,130 @@
+package com.kw.readwith.service.image;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kw.readwith.config.CharacterImageProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OpenAiImageEditClient {
+
+    private static final String IMAGE_EDIT_URL = "https://api.openai.com/v1/images/edits";
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final CharacterImageProperties imageProperties;
+
+    @Value("${spring.ai.openai.api-key:}")
+    private String apiKey;
+
+    public GeneratedCharacterImage generate(byte[] referenceImage, String prompt) {
+        if (referenceImage == null || referenceImage.length == 0) {
+            throw new IllegalArgumentException("Reference image is required.");
+        }
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new IllegalStateException("OpenAI API key is not configured.");
+        }
+
+        String model = resolveEditModel();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(apiKey);
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("model", model);
+        body.add("prompt", prompt);
+        body.add("image[]", new ByteArrayResource(referenceImage) {
+            @Override
+            public String getFilename() {
+                return "reference.png";
+            }
+        });
+
+        String size = imageProperties.getWidth() + "x" + imageProperties.getHeight();
+        body.add("size", size);
+
+        String quality = normalize(imageProperties.getQuality());
+        if (quality != null) {
+            body.add("quality", quality);
+        }
+
+        HttpEntity<MultiValueMap<String, Object>> entity = new HttpEntity<>(body, headers);
+        ResponseEntity<String> response = restTemplate.exchange(IMAGE_EDIT_URL, HttpMethod.POST, entity, String.class);
+
+        try {
+            JsonNode root = objectMapper.readTree(response.getBody());
+            JsonNode dataNode = root.path("data");
+            if (!dataNode.isArray() || dataNode.isEmpty()) {
+                throw new IllegalStateException("OpenAI image edit response has no data.");
+            }
+
+            String b64Json = dataNode.get(0).path("b64_json").asText(null);
+            if (b64Json == null || b64Json.isBlank()) {
+                throw new IllegalStateException("OpenAI image edit response has no b64_json.");
+            }
+
+            String requestId = response.getHeaders().getFirst("x-request-id");
+            return new GeneratedCharacterImage(
+                    Base64.getDecoder().decode(b64Json.replaceAll("\\s+", "")),
+                    model,
+                    prompt,
+                    sha256(prompt),
+                    requestId
+            );
+        } catch (Exception e) {
+            log.error("Failed to parse OpenAI image edit response.", e);
+            throw new IllegalStateException("Failed to parse OpenAI image edit response.", e);
+        }
+    }
+
+    private String resolveEditModel() {
+        String editModel = normalize(imageProperties.getEditModel());
+        if (editModel != null) {
+            return editModel;
+        }
+        String model = normalize(imageProperties.getModel());
+        return model != null ? model : "gpt-image-1";
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder builder = new StringBuilder();
+            for (byte b : hash) {
+                builder.append(String.format("%02x", b));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available.", e);
+        }
+    }
+}

--- a/src/main/java/com/kw/readwith/web/controller/AdminController.java
+++ b/src/main/java/com/kw/readwith/web/controller/AdminController.java
@@ -5,16 +5,26 @@ import com.kw.readwith.apiPayload.code.status.ErrorStatus;
 import com.kw.readwith.apiPayload.exception.GeneralException;
 import com.kw.readwith.dto.admin.AnalysisInputResponseDTO;
 import com.kw.readwith.dto.admin.BookAdminDetailDTO;
-import com.kw.readwith.dto.admin.UnsummarizedItemDTO;
-import com.kw.readwith.dto.book.BookSummaryDTO;
+import com.kw.readwith.dto.admin.CharacterImageAssetDTO;
+import com.kw.readwith.dto.admin.CharacterImageBookStatusResponseDTO;
+import com.kw.readwith.dto.admin.CharacterImageCandidateRequestDTO;
 import com.kw.readwith.dto.admin.CharacterDTO;
+import com.kw.readwith.dto.admin.CharacterImageFanoutRequestDTO;
+import com.kw.readwith.dto.admin.CharacterImageFanoutResponseDTO;
+import com.kw.readwith.dto.admin.CharacterImageReferenceCandidateRequestDTO;
 import com.kw.readwith.dto.admin.NormalizationJobResponseDTO;
 import com.kw.readwith.dto.admin.ProcessingJobLogResponseDTO;
+import com.kw.readwith.dto.admin.UnsummarizedItemDTO;
+import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.service.AdminService;
 import com.kw.readwith.service.AnalysisInputExportService;
+import com.kw.readwith.service.CharacterImageAdminService;
 import com.kw.readwith.service.normalization.NormalizationJobService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -22,6 +32,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -38,6 +49,7 @@ public class AdminController {
     private final AdminService adminService;
     private final AnalysisInputExportService analysisInputExportService;
     private final NormalizationJobService normalizationJobService;
+    private final CharacterImageAdminService characterImageAdminService;
 
     @Operation(summary = "모든 도서 전체 정보 조회", description = "book 테이블의 모든 행들의 모든 칼럼값들을 조회합니다. (관리자용)")
     @GetMapping("/books")
@@ -189,8 +201,255 @@ public class AdminController {
     }
 
     @Operation(
+            summary = "도서 캐릭터 이미지 QA Gate 상태 조회",
+            description = """
+                    도서 단위 대표 이미지와 캐릭터별 최신 이미지 후보 상태를 조회합니다.
+                    대표 이미지 상태: NONE, CANDIDATE_GENERATING, QA_FAILED, QA_PASSED, APPROVED, REJECTED, SUPERSEDED.
+                    이미지 asset 상태: GENERATING, QA_PENDING, QA_PASSED, QA_FAILED, REVIEW_REQUIRED, APPROVED, REJECTED, PUBLISHED, FAILED, STALE_REFERENCE, STALE_PROMPT, SUPERSEDED.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "이미지 QA Gate 상태 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CharacterImageBookStatusResponseDTO.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "PROGRESS4001: 해당 책을 찾을 수 없습니다."
+            )
+    })
+    @GetMapping("/books/{bookId}/character-images")
+    public ApiResponse<CharacterImageBookStatusResponseDTO> getCharacterImageStatus(
+            @Parameter(description = "조회 대상 도서 ID", required = true, example = "1") @PathVariable Long bookId) {
+        CharacterImageBookStatusResponseDTO response = characterImageAdminService.getBookStatus(bookId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(
+            summary = "대표 이미지 후보 생성",
+            description = """
+                    도서의 대표 스타일 기준이 될 이미지 후보를 생성합니다.
+                    요청에서 characterId를 생략하면 주요 인물 우선, 이름순으로 대표 인물을 자동 선택합니다.
+                    생성 직후 autoQa=true이면 QA를 실행하고, QA_PASSED가 되더라도 이 API는 게시하지 않습니다.
+                    대표 후보는 approve API를 통과해야 이후 fan-out 생성의 reference image가 됩니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "대표 이미지 후보 생성 요청 처리 성공. OpenAI/S3 실패는 asset.status=FAILED와 failureCode로 반환됩니다.",
+                    content = @Content(schema = @Schema(implementation = CharacterImageAssetDTO.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "ADMIN4006: 요청한 인물이 해당 책 소속이 아닙니다. ADMIN4026: 대표 후보로 사용할 인물을 찾을 수 없습니다."
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "PROGRESS4001: 해당 책을 찾을 수 없습니다. ADMIN4004: 해당 인물을 찾을 수 없습니다."
+            )
+    })
+    @PostMapping("/books/{bookId}/character-images/reference-candidates")
+    public ApiResponse<CharacterImageAssetDTO> createReferenceImageCandidate(
+            @Parameter(description = "대표 이미지 후보를 생성할 도서 ID", required = true, example = "1") @PathVariable Long bookId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "대표 이미지 후보 생성 옵션. 생략 가능하며, characterId를 생략하면 대표 인물을 자동 선택합니다.",
+                    required = false,
+                    content = @Content(schema = @Schema(implementation = CharacterImageReferenceCandidateRequestDTO.class))
+            )
+            @RequestBody(required = false) CharacterImageReferenceCandidateRequestDTO request) {
+        CharacterImageAssetDTO response = characterImageAdminService.createReferenceCandidate(bookId, request);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(
+            summary = "대표 이미지 후보 승인",
+            description = """
+                    QA_PASSED 상태의 대표 이미지 후보를 승인합니다.
+                    승인되면 해당 asset이 도서의 active reference image가 되고, 기존 reference로 생성된 게시/승인 후보는 STALE_REFERENCE 대상이 됩니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "대표 이미지 후보 승인 성공",
+                    content = @Content(schema = @Schema(implementation = CharacterImageAssetDTO.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "ADMIN4021: 요청한 책의 이미지 후보가 아닙니다. ADMIN4022: REFERENCE_SEED가 아니거나 QA_PASSED/APPROVED/PUBLISHED 상태가 아닙니다."
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "PROGRESS4001: 해당 책을 찾을 수 없습니다."
+            )
+    })
+    @PostMapping("/books/{bookId}/character-images/reference-candidates/{assetId}/approve")
+    public ApiResponse<CharacterImageAssetDTO> approveReferenceImageCandidate(
+            @Parameter(description = "도서 ID", required = true, example = "1") @PathVariable Long bookId,
+            @Parameter(description = "승인할 대표 이미지 asset ID", required = true, example = "100") @PathVariable Long assetId) {
+        CharacterImageAssetDTO response = characterImageAdminService.approveReferenceCandidate(bookId, assetId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(
+            summary = "대표 이미지 후보 거절",
+            description = "대표 이미지 후보를 REJECTED 상태로 변경합니다. 현재 active reference인 후보를 거절하면 도서 reference 상태도 REJECTED로 변경됩니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "대표 이미지 후보 거절 성공",
+                    content = @Content(schema = @Schema(implementation = CharacterImageAssetDTO.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "ADMIN4021: 요청한 책의 이미지 후보가 아닙니다. ADMIN4022: REFERENCE_SEED 역할이 아닙니다."
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "PROGRESS4001: 해당 책을 찾을 수 없습니다."
+            )
+    })
+    @PostMapping("/books/{bookId}/character-images/reference-candidates/{assetId}/reject")
+    public ApiResponse<CharacterImageAssetDTO> rejectReferenceImageCandidate(
+            @Parameter(description = "도서 ID", required = true, example = "1") @PathVariable Long bookId,
+            @Parameter(description = "거절할 대표 이미지 asset ID", required = true, example = "100") @PathVariable Long assetId) {
+        CharacterImageAssetDTO response = characterImageAdminService.rejectReferenceCandidate(bookId, assetId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(
+            summary = "대표 이미지 기반 캐릭터 이미지 fan-out 생성",
+            description = """
+                    승인된 대표 이미지(reference image)를 입력 이미지로 사용해 대상 캐릭터들의 이미지 후보를 생성합니다.
+                    scope 허용값: MAIN_ONLY, GRAPH_VISIBLE, SELECTED, STALE_ONLY, FAILED_ONLY, ALL.
+                    publishPolicy 허용값: AUTO_AFTER_QA, MANUAL.
+                    MANUAL은 후보만 만들고, AUTO_AFTER_QA는 QA_PASSED 후보를 즉시 게시합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "fan-out 생성 처리 성공. 개별 실패는 asset.status=FAILED와 failureCode로 반환됩니다.",
+                    content = @Content(schema = @Schema(implementation = CharacterImageFanoutResponseDTO.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "ADMIN4023: 승인된 대표 이미지가 없습니다. ADMIN4024: 잘못된 scope 값입니다. ADMIN4025: 잘못된 publishPolicy 값입니다. ADMIN4006: 선택 인물이 책 소속이 아닙니다."
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "PROGRESS4001: 해당 책을 찾을 수 없습니다. ADMIN4004: 선택 인물을 찾을 수 없습니다."
+            )
+    })
+    @PostMapping(value = "/books/{bookId}/character-images/fanout", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<CharacterImageFanoutResponseDTO> fanoutCharacterImages(
+            @Parameter(description = "fan-out을 실행할 도서 ID", required = true, example = "1") @PathVariable Long bookId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "fan-out 생성 범위와 게시 정책",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = CharacterImageFanoutRequestDTO.class))
+            )
+            @RequestBody CharacterImageFanoutRequestDTO request) {
+        CharacterImageFanoutResponseDTO response = characterImageAdminService.fanout(bookId, request);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(
+            summary = "캐릭터 이미지 후보 생성",
+            description = """
+                    특정 캐릭터의 이미지 후보를 생성합니다.
+                    도서에 승인된 대표 이미지가 있으면 reference edit 방식으로 생성하고, 없거나 대표 캐릭터 본인이면 text-to-image 방식으로 생성합니다.
+                    기본 publishPolicy는 MANUAL이라 QA 통과 후에도 바로 게시하지 않습니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "캐릭터 이미지 후보 생성 처리 성공. OpenAI/S3 실패는 asset.status=FAILED와 failureCode로 반환됩니다.",
+                    content = @Content(schema = @Schema(implementation = CharacterImageAssetDTO.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "ADMIN4025: 잘못된 publishPolicy 값입니다."
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "ADMIN4004: 해당 인물을 찾을 수 없습니다."
+            )
+    })
+    @PostMapping("/characters/{characterId}/image-candidates")
+    public ApiResponse<CharacterImageAssetDTO> createCharacterImageCandidate(
+            @Parameter(description = "이미지 후보를 생성할 캐릭터 DB ID", required = true, example = "10") @PathVariable Long characterId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "캐릭터 이미지 후보 생성 옵션. 생략 가능하며 기본값은 autoQa=true, publishPolicy=MANUAL입니다.",
+                    required = false,
+                    content = @Content(schema = @Schema(implementation = CharacterImageCandidateRequestDTO.class))
+            )
+            @RequestBody(required = false) CharacterImageCandidateRequestDTO request) {
+        CharacterImageAssetDTO response = characterImageAdminService.createCharacterCandidate(characterId, request);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(
+            summary = "캐릭터 이미지 후보 승인/게시",
+            description = "QA_PASSED, APPROVED, PUBLISHED 상태의 캐릭터 이미지 후보를 게시 이미지로 반영합니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "캐릭터 이미지 후보 승인/게시 성공",
+                    content = @Content(schema = @Schema(implementation = CharacterImageAssetDTO.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "ADMIN4021: 요청한 캐릭터의 이미지 후보가 아닙니다. ADMIN4022: 게시 가능한 상태가 아닙니다."
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "ADMIN4004: 해당 인물을 찾을 수 없습니다. ADMIN4020: 해당 이미지 후보를 찾을 수 없습니다."
+            )
+    })
+    @PostMapping("/characters/{characterId}/image-candidates/{assetId}/approve")
+    public ApiResponse<CharacterImageAssetDTO> approveCharacterImageCandidate(
+            @Parameter(description = "캐릭터 DB ID", required = true, example = "10") @PathVariable Long characterId,
+            @Parameter(description = "승인/게시할 이미지 asset ID", required = true, example = "120") @PathVariable Long assetId) {
+        CharacterImageAssetDTO response = characterImageAdminService.approveCharacterCandidate(characterId, assetId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(
+            summary = "캐릭터 이미지 후보 거절",
+            description = "캐릭터 이미지 후보를 REJECTED 상태로 변경합니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "캐릭터 이미지 후보 거절 성공",
+                    content = @Content(schema = @Schema(implementation = CharacterImageAssetDTO.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "ADMIN4021: 요청한 캐릭터의 이미지 후보가 아닙니다."
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "ADMIN4004: 해당 인물을 찾을 수 없습니다. ADMIN4020: 해당 이미지 후보를 찾을 수 없습니다."
+            )
+    })
+    @PostMapping("/characters/{characterId}/image-candidates/{assetId}/reject")
+    public ApiResponse<CharacterImageAssetDTO> rejectCharacterImageCandidate(
+            @Parameter(description = "캐릭터 DB ID", required = true, example = "10") @PathVariable Long characterId,
+            @Parameter(description = "거절할 이미지 asset ID", required = true, example = "120") @PathVariable Long assetId) {
+        CharacterImageAssetDTO response = characterImageAdminService.rejectCharacterCandidate(characterId, assetId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(
             summary = "캐릭터 이미지 재생성",
-            description = "특정 캐릭터의 프로필 이미지를 다시 생성합니다. 기존 이미지가 없거나 생성이 실패했을 때 사용합니다.",
+            description = "호환용 legacy endpoint입니다. 이제 이미지를 바로 게시하지 않고 `/characters/{characterId}/image-candidates`와 같은 후보 생성 흐름으로 처리합니다.",
             security = {}
     )
     @PostMapping(
@@ -199,7 +458,13 @@ public class AdminController {
     )
     public ApiResponse<String> regenerateCharacterImage(
             @Parameter(description = "이미지를 다시 생성할 캐릭터 DB ID", required = true) @PathVariable Long characterId) {
-        adminService.regenerateCharacterImage(characterId);
-        return ApiResponse.onSuccess("Character image regeneration has been started.");
+        characterImageAdminService.createCharacterCandidate(
+                characterId,
+                CharacterImageCandidateRequestDTO.builder()
+                        .autoQa(true)
+                        .publishPolicy("MANUAL")
+                        .build()
+        );
+        return ApiResponse.onSuccess("Character image candidate generation has been started.");
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -119,6 +119,7 @@ cloud:
 character-image:
   fallback-url: https://readwith-s3-bucket.s3.ap-northeast-2.amazonaws.com/character-images/default-character.jpg
   model: ${CHARACTER_IMAGE_MODEL:gpt-image-1}
+  edit-model: ${CHARACTER_IMAGE_EDIT_MODEL:${CHARACTER_IMAGE_MODEL:gpt-image-1}}
   quality: ${CHARACTER_IMAGE_QUALITY:medium}
   width: ${CHARACTER_IMAGE_WIDTH:1024}
   height: ${CHARACTER_IMAGE_HEIGHT:1024}

--- a/src/main/resources/db/migration/V6__character_image_approval_pipeline.sql
+++ b/src/main/resources/db/migration/V6__character_image_approval_pipeline.sql
@@ -1,0 +1,57 @@
+CREATE TABLE character_image_asset (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    book_id BIGINT NOT NULL,
+    character_id BIGINT NOT NULL,
+    asset_role VARCHAR(30) NOT NULL,
+    generation_mode VARCHAR(30) NOT NULL,
+    source_reference_asset_id BIGINT,
+    reference_version INTEGER NOT NULL DEFAULT 0,
+    status VARCHAR(30) NOT NULL,
+    s3_url VARCHAR(1024),
+    model VARCHAR(80),
+    prompt_hash VARCHAR(64),
+    qa_result_json TEXT,
+    failure_code VARCHAR(80),
+    openai_request_id VARCHAR(120),
+    attempt_no INTEGER NOT NULL DEFAULT 1,
+    published_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_character_image_asset_book
+        FOREIGN KEY (book_id) REFERENCES book (id),
+    CONSTRAINT fk_character_image_asset_character
+        FOREIGN KEY (character_id) REFERENCES book_character (id),
+    CONSTRAINT fk_character_image_asset_reference
+        FOREIGN KEY (source_reference_asset_id) REFERENCES character_image_asset (id)
+);
+
+CREATE INDEX idx_character_image_asset_book_status
+    ON character_image_asset (book_id, status);
+
+CREATE INDEX idx_character_image_asset_character_created
+    ON character_image_asset (character_id, created_at);
+
+CREATE TABLE book_character_image_profile (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    book_id BIGINT NOT NULL,
+    active_reference_asset_id BIGINT,
+    reference_character_id BIGINT,
+    reference_version INTEGER NOT NULL DEFAULT 0,
+    reference_status VARCHAR(30) NOT NULL DEFAULT 'NONE',
+    model VARCHAR(80),
+    base_style_prompt_hash VARCHAR(64),
+    book_prompt_hash VARCHAR(64),
+    approved_at DATETIME(6),
+    approved_by VARCHAR(120),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_book_character_image_profile_book UNIQUE (book_id),
+    CONSTRAINT fk_book_character_image_profile_book
+        FOREIGN KEY (book_id) REFERENCES book (id),
+    CONSTRAINT fk_book_character_image_profile_reference_asset
+        FOREIGN KEY (active_reference_asset_id) REFERENCES character_image_asset (id),
+    CONSTRAINT fk_book_character_image_profile_reference_character
+        FOREIGN KEY (reference_character_id) REFERENCES book_character (id)
+);

--- a/src/test/java/com/kw/readwith/ReadwithApplicationTests.java
+++ b/src/test/java/com/kw/readwith/ReadwithApplicationTests.java
@@ -2,8 +2,10 @@ package com.kw.readwith;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class ReadwithApplicationTests {
 
 	@Test

--- a/src/test/java/com/kw/readwith/controller/BookControllerTest.java
+++ b/src/test/java/com/kw/readwith/controller/BookControllerTest.java
@@ -1,6 +1,7 @@
 package com.kw.readwith.controller;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kw.readwith.dto.book.BookDetailDTO;
 import com.kw.readwith.dto.book.BookSummaryDTO;
@@ -52,7 +53,10 @@ class BookControllerTest {
                 .andReturn();
 
         String responseJson = result.getResponse().getContentAsString();
-        List<BookSummaryDTO> list = objectMapper.readValue(responseJson, new TypeReference<>() {});
+        List<BookSummaryDTO> list = objectMapper.readValue(
+                readResult(responseJson).traverse(),
+                new TypeReference<>() {}
+        );
         assertThat(list).isNotEmpty();
     }
 
@@ -65,8 +69,14 @@ class BookControllerTest {
                 .andReturn();
 
         String responseJson = result.getResponse().getContentAsString();
-        BookDetailDTO dto = objectMapper.readValue(responseJson, BookDetailDTO.class);
+        BookDetailDTO dto = objectMapper.treeToValue(readResult(responseJson), BookDetailDTO.class);
         assertThat(dto.getId()).isEqualTo(existingBookId);
         assertThat(dto.getTitle()).isNotBlank();
     }
-} 
+
+    private JsonNode readResult(String responseJson) throws Exception {
+        JsonNode root = objectMapper.readTree(responseJson);
+        assertThat(root.path("isSuccess").asBoolean()).isTrue();
+        return root.path("result");
+    }
+}

--- a/src/test/java/com/kw/readwith/controller/FavoriteControllerTest.java
+++ b/src/test/java/com/kw/readwith/controller/FavoriteControllerTest.java
@@ -1,9 +1,13 @@
 package com.kw.readwith.controller;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kw.readwith.domain.User;
 import com.kw.readwith.dto.book.BookSummaryDTO;
 import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.UserRepository;
+import com.kw.readwith.util.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,38 +39,65 @@ class FavoriteControllerTest {
     @Autowired
     private BookRepository bookRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
     private Long existingBookId;
+    private String accessToken;
 
     @BeforeEach
     void setUp() {
         existingBookId = bookRepository.findAll().get(0).getId();
+        User user = userRepository.findAll().stream()
+                .findFirst()
+                .orElseThrow();
+        accessToken = jwtUtil.generateAccessToken(user.getId(), user.getEmail());
     }
 
     @Test
     @DisplayName("즐겨찾기 추가/조회/삭제 플로우가 정상 동작한다")
     void favorite_flow() throws Exception {
         // 1. 즐겨찾기 추가
-        mockMvc.perform(post("/api/favorites/" + existingBookId))
+        mockMvc.perform(post("/api/favorites/" + existingBookId)
+                        .header("Authorization", "Bearer " + accessToken))
                 .andExpect(status().isOk());
 
         // 2. 즐겨찾기 목록 조회 – 추가된 책 포함
         MvcResult listResult = mockMvc.perform(get("/api/favorites")
+                        .header("Authorization", "Bearer " + accessToken)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andReturn();
-        List<BookSummaryDTO> list = objectMapper.readValue(listResult.getResponse().getContentAsString(), new TypeReference<>() {});
+        List<BookSummaryDTO> list = objectMapper.readValue(
+                readResult(listResult).traverse(),
+                new TypeReference<>() {}
+        );
         assertThat(list).extracting(BookSummaryDTO::getId).contains(existingBookId);
 
         // 3. 즐겨찾기 삭제
-        mockMvc.perform(delete("/api/favorites/" + existingBookId))
-                .andExpect(status().isNoContent());
+        mockMvc.perform(delete("/api/favorites/" + existingBookId)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk());
 
         // 4. 목록 조회 시 비어 있음
         MvcResult listResult2 = mockMvc.perform(get("/api/favorites")
+                        .header("Authorization", "Bearer " + accessToken)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andReturn();
-        List<BookSummaryDTO> list2 = objectMapper.readValue(listResult2.getResponse().getContentAsString(), new TypeReference<>() {});
+        List<BookSummaryDTO> list2 = objectMapper.readValue(
+                readResult(listResult2).traverse(),
+                new TypeReference<>() {}
+        );
         assertThat(list2).extracting(BookSummaryDTO::getId).doesNotContain(existingBookId);
     }
-} 
+
+    private JsonNode readResult(MvcResult result) throws Exception {
+        JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(root.path("isSuccess").asBoolean()).isTrue();
+        return root.path("result");
+    }
+}

--- a/src/test/java/com/kw/readwith/service/AdminServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/AdminServiceTest.java
@@ -44,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -149,6 +150,7 @@ class AdminServiceTest {
         assertThat(savedCharacters.get(0).getName()).isEqualTo("Harry Potter");
         assertThat(savedCharacters.get(0).isMainCharacter()).isTrue();
         assertThat(book.getBookPrompt()).isEqualTo("Victorian urban gothic, muted sepia and deep green palette");
+        verify(characterImageService, never()).generateImagesAsync(anyList());
     }
 
     @Test

--- a/src/test/java/com/kw/readwith/service/CharacterImageAdminServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/CharacterImageAdminServiceTest.java
@@ -1,0 +1,178 @@
+package com.kw.readwith.service;
+
+import com.kw.readwith.apiPayload.code.status.ErrorStatus;
+import com.kw.readwith.apiPayload.exception.GeneralException;
+import com.kw.readwith.config.CharacterImageProperties;
+import com.kw.readwith.domain.Book;
+import com.kw.readwith.domain.BookCharacterImageProfile;
+import com.kw.readwith.domain.Character;
+import com.kw.readwith.domain.CharacterImageAsset;
+import com.kw.readwith.domain.enums.BookImageReferenceStatus;
+import com.kw.readwith.domain.enums.CharacterImageAssetRole;
+import com.kw.readwith.domain.enums.CharacterImageAssetStatus;
+import com.kw.readwith.domain.enums.CharacterImageGenerationMode;
+import com.kw.readwith.dto.admin.CharacterImageFanoutRequestDTO;
+import com.kw.readwith.repository.BookCharacterImageProfileRepository;
+import com.kw.readwith.repository.BookRepository;
+import com.kw.readwith.repository.CharacterImageAssetRepository;
+import com.kw.readwith.repository.CharacterRepository;
+import com.kw.readwith.service.image.CharacterImageQaService;
+import com.kw.readwith.service.image.OpenAiImageEditClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CharacterImageAdminServiceTest {
+
+    @InjectMocks
+    private CharacterImageAdminService characterImageAdminService;
+
+    @Mock
+    private BookRepository bookRepository;
+    @Mock
+    private CharacterRepository characterRepository;
+    @Mock
+    private CharacterImageAssetRepository assetRepository;
+    @Mock
+    private BookCharacterImageProfileRepository profileRepository;
+    @Mock
+    private CharacterImageService characterImageService;
+    @Mock
+    private OpenAiImageEditClient imageEditClient;
+    @Mock
+    private CharacterImageQaService qaService;
+    @Mock
+    private CharacterImageProperties imageProperties;
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Test
+    @DisplayName("fanout rejects invalid scope enum value")
+    void fanout_rejectsInvalidScope() {
+        Book book = Book.builder().id(1L).build();
+        CharacterImageFanoutRequestDTO request = CharacterImageFanoutRequestDTO.builder()
+                .scope("WRONG_SCOPE")
+                .build();
+
+        given(bookRepository.findById(1L)).willReturn(Optional.of(book));
+
+        GeneralException exception = assertThrows(
+                GeneralException.class,
+                () -> characterImageAdminService.fanout(1L, request)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.INVALID_IMAGE_FANOUT_SCOPE);
+    }
+
+    @Test
+    @DisplayName("fanout rejects invalid publishPolicy enum value")
+    void fanout_rejectsInvalidPublishPolicy() {
+        Book book = Book.builder().id(1L).build();
+        CharacterImageFanoutRequestDTO request = CharacterImageFanoutRequestDTO.builder()
+                .scope("MAIN_ONLY")
+                .publishPolicy("WRONG_POLICY")
+                .build();
+
+        given(bookRepository.findById(1L)).willReturn(Optional.of(book));
+
+        GeneralException exception = assertThrows(
+                GeneralException.class,
+                () -> characterImageAdminService.fanout(1L, request)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.INVALID_IMAGE_PUBLISH_POLICY);
+    }
+
+    @Test
+    @DisplayName("fanout requires an approved reference image")
+    void fanout_requiresApprovedReferenceImage() {
+        Book book = Book.builder().id(1L).build();
+        CharacterImageFanoutRequestDTO request = CharacterImageFanoutRequestDTO.builder()
+                .scope("MAIN_ONLY")
+                .publishPolicy("MANUAL")
+                .build();
+
+        given(bookRepository.findById(1L)).willReturn(Optional.of(book));
+        given(profileRepository.findByBook(book)).willReturn(Optional.empty());
+
+        GeneralException exception = assertThrows(
+                GeneralException.class,
+                () -> characterImageAdminService.fanout(1L, request)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.IMAGE_REFERENCE_NOT_APPROVED);
+    }
+
+    @Test
+    @DisplayName("approveReferenceCandidate rejects assets that did not pass QA")
+    void approveReferenceCandidate_rejectsNonPublishableStatus() {
+        Book book = Book.builder().id(1L).build();
+        Character character = Character.builder().id(10L).book(book).name("Alice").build();
+        CharacterImageAsset asset = CharacterImageAsset.builder()
+                .id(100L)
+                .book(book)
+                .character(character)
+                .assetRole(CharacterImageAssetRole.REFERENCE_SEED)
+                .generationMode(CharacterImageGenerationMode.TEXT_TO_IMAGE)
+                .status(CharacterImageAssetStatus.QA_FAILED)
+                .attemptNo(1)
+                .build();
+
+        given(bookRepository.findById(1L)).willReturn(Optional.of(book));
+        given(assetRepository.findByIdAndBook(100L, book)).willReturn(Optional.of(asset));
+
+        GeneralException exception = assertThrows(
+                GeneralException.class,
+                () -> characterImageAdminService.approveReferenceCandidate(1L, 100L)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.IMAGE_ASSET_INVALID_STATUS);
+    }
+
+    @Test
+    @DisplayName("fanout rejects a profile that has not reached APPROVED")
+    void fanout_rejectsUnapprovedProfile() {
+        Book book = Book.builder().id(1L).build();
+        Character character = Character.builder().id(10L).book(book).name("Alice").build();
+        CharacterImageAsset reference = CharacterImageAsset.builder()
+                .id(100L)
+                .book(book)
+                .character(character)
+                .assetRole(CharacterImageAssetRole.REFERENCE_SEED)
+                .generationMode(CharacterImageGenerationMode.TEXT_TO_IMAGE)
+                .status(CharacterImageAssetStatus.QA_PASSED)
+                .attemptNo(1)
+                .build();
+        BookCharacterImageProfile profile = BookCharacterImageProfile.builder()
+                .book(book)
+                .activeReferenceAsset(reference)
+                .referenceCharacter(character)
+                .referenceStatus(BookImageReferenceStatus.QA_PASSED)
+                .build();
+        CharacterImageFanoutRequestDTO request = CharacterImageFanoutRequestDTO.builder()
+                .scope("MAIN_ONLY")
+                .publishPolicy("MANUAL")
+                .build();
+
+        given(bookRepository.findById(1L)).willReturn(Optional.of(book));
+        given(profileRepository.findByBook(book)).willReturn(Optional.of(profile));
+
+        GeneralException exception = assertThrows(
+                GeneralException.class,
+                () -> characterImageAdminService.fanout(1L, request)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.IMAGE_REFERENCE_NOT_APPROVED);
+    }
+}

--- a/src/test/java/com/kw/readwith/service/CharacterImageServiceIntegrationTest.java
+++ b/src/test/java/com/kw/readwith/service/CharacterImageServiceIntegrationTest.java
@@ -7,6 +7,7 @@ import com.kw.readwith.domain.enums.ImageGenerationStatus;
 import com.kw.readwith.repository.BookRepository;
 import com.kw.readwith.repository.CharacterRepository;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -35,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @ActiveProfiles("test")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DisplayName("캐릭터 이미지 생성 완전 통합 테스트 (실제 API 호출)")
+@EnabledIfEnvironmentVariable(named = "RUN_REAL_IMAGE_INTEGRATION_TESTS", matches = "true")
 class CharacterImageServiceIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/kw/readwith/service/normalization/NormalizationJobServiceTest.java
+++ b/src/test/java/com/kw/readwith/service/normalization/NormalizationJobServiceTest.java
@@ -198,7 +198,7 @@ public class NormalizationJobServiceTest {
         assertThat(response.getBookId()).isEqualTo(bookId);
         assertThat(response.getBookTitle()).isEqualTo("Book Title");
         assertThat(response.getPipelineType()).isEqualTo(ProcessingPipelineType.NORMALIZATION);
-        assertThat(response.getSourceVersion()).isEqualTo("src-v1");
+        assertThat(response.getSourceVersion()).isEqualTo("src-v2");
         assertThat(response.getArtifactPath()).isEqualTo("path/to/artifact");
         assertThat(response.getStatus()).isEqualTo(ProcessingJobStatus.READY);
         assertThat(response.getCurrentStep()).isEqualTo("completed");

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -12,6 +12,32 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+        hbm2ddl:
+          auto: update
   sql:
     init:
-      mode: never 
+      mode: never
+  ai:
+    openai:
+      api-key: test
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test
+            client-secret: test
+cloud:
+  aws:
+    s3:
+      bucket: test-bucket
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    credentials:
+      accessKey: test
+      secretKey: test
+    path:
+      original: original
+      metadata: metadata


### PR DESCRIPTION
﻿## 🧑🏻‍💻 PR 작업 내역 요약
관리자 승인형 Reference Image QA Gate 기반 캐릭터 이미지 생성 파이프라인을 추가했습니다.

기존에는 인물 업로드 직후 모든 캐릭터 이미지를 자동 생성해 비용 낭비와 스타일 편차가 발생할 수 있었습니다. 이제는 대표 이미지 후보를 먼저 생성하고 QA/관리자 승인을 통과한 뒤, 승인된 reference image 기반으로 나머지 캐릭터 후보를 fan-out 생성하는 흐름으로 변경했습니다.

Closes #127

## 📋 변경 사항
- 인물 업로드 직후 전체 이미지 자동 생성 제거
- 도서 단위 대표 이미지 프로필과 캐릭터 이미지 asset 저장 테이블 추가
- 대표 이미지 후보 생성, 승인, 거절 API 추가
- 승인된 대표 이미지 기반 fan-out 생성 API 추가
- 캐릭터별 이미지 후보 생성, 승인/게시, 거절 API 추가
- 기존 `regenerate-image`는 즉시 게시가 아니라 `MANUAL` 후보 생성 흐름으로 변경
- OpenAI `/v1/images/edits` 직접 클라이언트 추가
  - Spring AI text-to-image는 기존대로 사용
  - reference 기반 변형은 같은 `spring.ai.openai.api-key`로 직접 호출
- Swagger에 관리자 API 설명, enum 허용값, 주요 에러 코드 명시
- 실제 OpenAI/S3 호출 통합 테스트는 기본 테스트에서 제외하고 `RUN_REAL_IMAGE_INTEGRATION_TESTS=true`일 때만 실행되도록 변경

관리자 페이지 구현 가이드:
1. 도서 상세/캐릭터 관리 화면 진입 시 `GET /api/admin/books/{bookId}/character-images`로 상태를 조회합니다.
2. `canFanout=false`이고 `referenceStatus`가 `NONE`, `QA_FAILED`, `REJECTED`이면 대표 이미지 후보 생성 버튼을 노출합니다.
3. `POST /api/admin/books/{bookId}/character-images/reference-candidates`로 대표 후보를 생성합니다.
   - `characterId`를 지정하면 해당 캐릭터 기준
   - 생략하면 서버가 주요 인물 우선으로 자동 선택
4. 후보가 `QA_PASSED`면 관리자에게 이미지 미리보기와 승인/거절 버튼을 보여줍니다.
5. 승인 시 `POST /api/admin/books/{bookId}/character-images/reference-candidates/{assetId}/approve`를 호출합니다.
6. 대표 이미지 승인 후 `POST /api/admin/books/{bookId}/character-images/fanout`으로 나머지 캐릭터 후보를 생성합니다.
   - 초기 운영은 `scope=MAIN_ONLY`, `publishPolicy=MANUAL` 권장
   - 전체 생성 전에는 `limit`으로 소량 검증 가능
7. 각 캐릭터 row/card에는 `latestAsset.status`, `s3Url`, `failureCode`를 표시합니다.
8. 캐릭터별 후보가 `QA_PASSED`면 `POST /api/admin/characters/{characterId}/image-candidates/{assetId}/approve`로 게시합니다.
9. 마음에 들지 않으면 reject 후 `POST /api/admin/characters/{characterId}/image-candidates`로 개별 재생성합니다.

관리자 UI 상태 매핑 권장:
- `NONE`: 대표 이미지 후보 없음
- `CANDIDATE_GENERATING`: 대표 후보 생성 중 또는 직후 처리 중
- `QA_PASSED`: 대표 후보 승인 대기
- `APPROVED`: fan-out 가능
- `QA_FAILED`, `FAILED`: 재생성 필요
- `REJECTED`: 거절됨
- `STALE_REFERENCE`: 대표 이미지가 바뀌어 재생성 권장
- `PUBLISHED`: 현재 서비스 노출 이미지

## 🔍 Code Review
- `AdminService.uploadCharacters`에서 이미지 자동 생성 호출이 제거되어 업로드만으로 OpenAI 비용이 발생하지 않는지 확인해주세요.
- `CharacterImageAdminService`의 상태 전이 흐름을 확인해주세요.
  - reference 후보 생성 → QA_PASSED → approve → fanout
  - candidate QA_PASSED → approve/publish
- `OpenAiImageEditClient`는 Spring AI 미지원 영역을 직접 호출합니다. multipart 필드 `image[]`, 모델 설정, API key 주입 방식을 확인해주세요.
- 관리자 Swagger 설명에 enum 값과 에러 코드가 충분히 드러나는지 확인해주세요.
- V6 마이그레이션이 운영 DB의 `book`, `book_character` 테이블명과 FK를 정확히 참조하는지 확인해주세요.

검증:
- `./gradlew.bat test` 통과
- `git diff --check` 통과

## 📸 ScreenShot
없음. Swagger/API 및 백엔드 파이프라인 변경입니다.
